### PR TITLE
DOCS: Update URLs for Solace Agent Mesh Core Plugins

### DIFF
--- a/docs/docs/documentation/concepts/gateways.md
+++ b/docs/docs/documentation/concepts/gateways.md
@@ -70,9 +70,9 @@ Solace Agent Mesh comes with two built-in gateway interfaces called `REST Endpoi
 Fore more information about plugins and how to configure them, see [Plugins](./plugins/index.md).
 
 Some of the official core plugins gateways interfaces include:
-- [Slack Gateway](https://github.com/SolaceDev/solace-agent-mesh-core-plugins/tree/main/cm-slack): Allows integration with Slack workspaces and channels.
-- [MS Teams Gateway](https://github.com/SolaceDev/solace-agent-mesh-core-plugins/tree/main/cm-ms-teams): Provides integration with Microsoft Teams for chat-based interactions.
-- [Solace Event Mesh Gateway](https://github.com/SolaceDev/solace-agent-mesh-core-plugins/tree/main/solace-event-mesh): Enables communication with the PubSub+ event broker directly as an input interface. 
+- [Slack Gateway](https://github.com/SolaceLabs/solace-agent-mesh-core-plugins/tree/main/cm-slack): Allows integration with Slack workspaces and channels.
+- [MS Teams Gateway](https://github.com/SolaceLabs/solace-agent-mesh-core-plugins/tree/main/cm-ms-teams): Provides integration with Microsoft Teams for chat-based interactions.
+- [Solace Event Mesh Gateway](https://github.com/SolaceLabs/solace-agent-mesh-core-plugins/tree/main/solace-event-mesh): Enables communication with the PubSub+ event broker directly as an input interface. 
 
 :::note
 Each gateway type has its own configuration options and specific features. See the individual gateway documentation pages for detailed information on setup and usage.

--- a/docs/docs/documentation/concepts/plugins/index.md
+++ b/docs/docs/documentation/concepts/plugins/index.md
@@ -23,7 +23,7 @@ Run `solace-agent-mesh plugin --help` to see the list of available commands for 
 
 ## Official Core Plugins
 
-Solace Agent Mesh comes with a set of official core plugins that can be used to extend the functionality of the system. You can find repository of the official core plugins [here 🔗](https://github.com/SolaceDev/solace-agent-mesh-core-plugins).
+Solace Agent Mesh comes with a set of official core plugins that can be used to extend the functionality of the system. You can find repository of the official core plugins [here 🔗](https://github.com/SolaceLabs/solace-agent-mesh-core-plugins).
 
 Fore more information about how to use the official core plugins, see [Use Plugins](./use-plugins.md).
 

--- a/docs/docusaurus.config.ts
+++ b/docs/docusaurus.config.ts
@@ -84,7 +84,7 @@ const config: Config = {
             },
             {
               label: "Official Plugins",
-              href: "https://github.com/SolaceDev/solace-agent-mesh-core-plugins/",
+              href: "https://github.com/SolaceLabs/solace-agent-mesh-core-plugins/",
             }
           ],
         },


### PR DESCRIPTION
## What is the purpose of this change?

The purpose of this change is to update the URLs for the official core plugins of the Solace Agent Mesh documentation to reflect the new repository location. This ensures users are directed to the correct resources for accessing and utilizing the plugins.

## How is this accomplished?

- Updated urls for solace-agent-mesh-core-plugins

## Anything reviews should focus on/be aware of?

Reviewers should ensure that all instances of the outdated URLs have been correctly updated to the new SolaceLabs repository URLs.