### PR TITLE
AI-558: Improve the configurability of the response_format_prompt

### DIFF
--- a/cli/commands/build.py
+++ b/cli/commands/build.py
@@ -160,7 +160,8 @@ def ensure_config_aliases(content, config_aliases):
     updated_content = content
     
     for alias, default_config in config_aliases.items():
-        if f"- {alias}:" in content or f"- {alias} :" in content:
+        # Check for the alias pattern &alias_name in the content
+        if f"&{alias}" in content:
             found_aliases.add(alias)
         else:
             # Add default config at the end of the file

--- a/cli/commands/build.py
+++ b/cli/commands/build.py
@@ -190,7 +190,7 @@ def build_specific_gateway(
                 
             # Define config aliases to check for so that if they are missing we can add defaults
             config_aliases = {
-                "response_format_config": "- response_format_config: &response_format_config \"\""
+                "response_format_prompt": "- response_format_prompt: &response_format_prompt \"\""
             }
             
             # Check which aliases are already in the gateway config
@@ -252,15 +252,6 @@ def build_specific_gateway(
                     complete_interface_gateway += "\n# Default configurations\nshared_config_defaults:\n"
                     for alias in missing_aliases:
                         complete_interface_gateway += f"{config_aliases[alias]}\n"
-
-                # One special case for backwards compatibility for response_format_config:
-                if re.search(r"response_format_prompt:\s*&response_format_prompt\s*>", complete_interface_gateway):
-                    # Use regex to replace with proper indentation preserved
-                    complete_interface_gateway = re.sub(
-                        r"response_format_prompt:\s*&response_format_prompt\s*>",
-                        r"- response_format_config: &response_format_config >",
-                        complete_interface_gateway
-                    )                    
 
                 # Write interface specific flows
                 complete_interface_gateway += "\nflows:\n"

--- a/cli/commands/build.py
+++ b/cli/commands/build.py
@@ -190,7 +190,7 @@ def build_specific_gateway(
                 
             # Define config aliases to check for so that if they are missing we can add defaults
             config_aliases = {
-                "response_format_config": "- response_format_config: &response_format_config\n    response_format_prompt: \"\""
+                "response_format_config": "- response_format_config: &response_format_config \"\""
             }
             
             # Check which aliases are already in the gateway config
@@ -253,12 +253,12 @@ def build_specific_gateway(
                     for alias in missing_aliases:
                         complete_interface_gateway += f"{config_aliases[alias]}\n"
 
-                # One special case for backwards compatibility for resopnse_format_config:
+                # One special case for backwards compatibility for response_format_config:
                 if re.search(r"response_format_prompt:\s*&response_format_prompt\s*>", complete_interface_gateway):
                     # Use regex to replace with proper indentation preserved
                     complete_interface_gateway = re.sub(
                         r"response_format_prompt:\s*&response_format_prompt\s*>",
-                        r"- response_format_config: &response_format_config\n    response_format_prompt: >",
+                        r"- response_format_config: &response_format_config >",
                         complete_interface_gateway
                     )                    
 

--- a/src/gateway/components/gateway_input.py
+++ b/src/gateway/components/gateway_input.py
@@ -38,6 +38,12 @@ info = {
             },
             "description": "Gateway configuration including originators and their configurations.",
         },
+        {
+            "name": "response_format_prompt",
+            "type": "string",
+            "description": "Format instructions for the response that will be passed to the model",
+            "default": ""
+        }
     ],
     "input_schema": {
         "type": "object",
@@ -129,6 +135,7 @@ class GatewayInput(GatewayBase):
             "interaction_type", DEFAULT_INTERACTION_TYPE
         )
         self.identity_component = self._initialize_identity_component()
+        self.response_format_prompt = self.get_config("response_format_prompt", "")
 
     def _authenticate_user(self, _user_properties: Dict[str, Any]) -> bool:
         # Implement actual authentication logic here
@@ -164,7 +171,6 @@ class GatewayInput(GatewayBase):
             top_level_user_properties = {
                 "input_type",
                 "session_id",
-                "response_format_prompt",
             }
             self.demote_interface_properties(user_properties, top_level_user_properties)
 
@@ -221,6 +227,10 @@ class GatewayInput(GatewayBase):
             errors.append(str(e))
 
         stimulus_uuid = self.gateway_id + str(uuid4())
+
+        # Add response format prompt from config if available
+        if self.response_format_prompt:
+            user_properties["response_format_prompt"] = self.response_format_prompt
 
         user_properties.update(
             {

--- a/src/orchestrator/orchestrator_prompt.py
+++ b/src/orchestrator/orchestrator_prompt.py
@@ -214,6 +214,11 @@ The assistant's behavior aligns with the system purpose specified below:
     3. After opening agents, the assistant will be reinvoked with an updated list of open agents and their actions.
     4. When opening an agent, provide only a brief status update without detailed explanations.
     5. Do not perform any other actions besides opening the required agents in this step.
+  - Report generation:
+    1. If a report is requested and no format is specified, create the report in an HTML file.
+    2. Generate each section of the report independently and store it in the file service with create_file action. When finishing the report, combine the sections using amfs urls with the resolve=true query parameter to insert the sections into the main document. When generating HTML, create the header first with all the necessary CSS and JS links so that it is clear what css the rest of the document will use.
+    3. Images are always very useful in reports, so the assistant will add them when appropriate. If images are embedded in html, they must be resolved and converted to datauri format or they won't render in the final document. This can be done by using the encoding=datauri&resolve=true in the amfs link. For example, <img src="amfs://xxxxxx.png?encoding=datauri&resolve=true". The assistant will take care of the rest. Images can be created in parallel
+    4. During report generation in interactive sessions, the assistant will send lots of status messages to indicate what is happening. 
   - Handling stimuli with open agents:
     1. Use agents' actions to break down the stimulus into smaller, manageable tasks.
     2. Prioritize using available actions to fulfill the stimulus whenever possible.

--- a/templates/gateway-config-template.yaml
+++ b/templates/gateway-config-template.yaml
@@ -2,5 +2,4 @@
     key: "value" # Add your configuration here
 
 - response_format_prompt: &response_format_prompt >
-    Format the response using Markdown text formatting such as
-    **bold**, _italic_, and `code` where necessary.
+    Return all responses in markdown format and if the response contains a file or image, return it with the <file> tags and not as a link.

--- a/templates/gateway-config-template.yaml
+++ b/templates/gateway-config-template.yaml
@@ -1,4 +1,4 @@
 - {{SNAKE_CASE_NAME}}_config: &gateway_interface_config
     key: "value" # Add your configuration here
 
-- response_format_config: &response_format_config ""
+- response_format_prompt: &response_format_prompt ""

--- a/templates/gateway-config-template.yaml
+++ b/templates/gateway-config-template.yaml
@@ -1,4 +1,6 @@
 - {{SNAKE_CASE_NAME}}_config: &gateway_interface_config
     key: "value" # Add your configuration here
 
-- response_format_prompt: &response_format_prompt ""
+- response_format_prompt: &response_format_prompt >
+    Format the response using Markdown text formatting such as
+    **bold**, _italic_, and `code` where necessary.

--- a/templates/gateway-config-template.yaml
+++ b/templates/gateway-config-template.yaml
@@ -1,6 +1,5 @@
 - {{SNAKE_CASE_NAME}}_config: &gateway_interface_config
     key: "value" # Add your configuration here
 
-- response_format_prompt: &response_format_prompt >
-    Format the response using Markdown text formatting such as
-    **bold**, _italic_, and `code` where necessary.
+- response_format_config: &response_format_config
+    response_format_prompt: ""

--- a/templates/gateway-config-template.yaml
+++ b/templates/gateway-config-template.yaml
@@ -1,5 +1,4 @@
 - {{SNAKE_CASE_NAME}}_config: &gateway_interface_config
     key: "value" # Add your configuration here
 
-- response_format_config: &response_format_config
-    response_format_prompt: ""
+- response_format_config: &response_format_config ""

--- a/templates/gateway-default-config.yaml
+++ b/templates/gateway-default-config.yaml
@@ -16,8 +16,8 @@
 - gateway_config: &gateway_config
     gateway_id: {{GATEWAY_ID}}
     system_purpose: >
-      The system is an AI Chatbot, that is providing information reasoning and general assistance for writing 
-      and coding to the users in this system.
+      The system is an AI Chatbot with agentic capabilities. It will use the agents available to provide information, reasoning and general assistance for the users in this system.      
+        
     interaction_type: "interactive"
 
     identity:

--- a/templates/gateway-flows.yaml
+++ b/templates/gateway-flows.yaml
@@ -13,12 +13,9 @@
         component_config:
           identity_key_field: identity
           <<: *gateway_config
+          <<: *response_format_config
         component_input:
           source_expression: previous
-        input_transforms:
-          - type: copy
-            source_value: *response_format_prompt
-            dest_expression: input.user_properties:response_format_prompt
       - component_name: broker_output
         component_module: broker_output
         component_config:

--- a/templates/gateway-flows.yaml
+++ b/templates/gateway-flows.yaml
@@ -13,7 +13,7 @@
         component_config:
           identity_key_field: identity
           <<: *gateway_config
-          response_format_prompt: *response_format_config
+          response_format_prompt: *response_format_prompt
         component_input:
           source_expression: previous
       - component_name: broker_output

--- a/templates/gateway-flows.yaml
+++ b/templates/gateway-flows.yaml
@@ -13,7 +13,7 @@
         component_config:
           identity_key_field: identity
           <<: *gateway_config
-          <<: *response_format_config
+          response_format_prompt: *response_format_config
         component_input:
           source_expression: previous
       - component_name: broker_output

--- a/templates/rest-api-default-config.yaml
+++ b/templates/rest-api-default-config.yaml
@@ -21,3 +21,13 @@
     frontend_collect_feedback: ${WEBUI_FRONTEND_COLLECT_FEEDBACK}
     frontend_url: ${WEBUI_FRONTEND_URL}
     local_dev : ${WEBUI_LOCAL_DEV}
+
+- response_format_prompt: &response_format_prompt >
+    The system is an AI Chatbot, that is providing information reasoning and general assistance for writing 
+    and coding to the users in this system. When returning images, return them with the <file> tags and not as a link.
+
+    If a report or document is being created, try to create document section independently. These can be stored in the file service with the create_file action and then combined later using amfs links with resolve=true. Doing this will generate higher quality reports since the assistant can focus on one section at a time. Before you start, though, create the header of the document with all the css and links to stylesheets and scripts. This will allow the assistant to create the document in pieces and then combine them later. HTML docs must be modern, well formatted and responsive.
+
+    Images are always very useful in reports, so the assistant will add them when appropriate. If images are embedded in html, they must be resolved and converted to datauri format or they won't render in the final document. This can be done by using the encoding=datauri&resolve=true in the amfs link. For example, <img src="amfs://xxxxxx.png?encoding=datauri&resolve=true". The assistant will take care of the rest. Images can be created in parallel
+
+    During report generation in interactive sessions, the assistant will send lots of status messages to indicate what is happening. This will help understand the process and know that the system is working.

--- a/templates/rest-api-default-config.yaml
+++ b/templates/rest-api-default-config.yaml
@@ -23,11 +23,5 @@
     local_dev : ${WEBUI_LOCAL_DEV}
 
 - response_format_prompt: &response_format_prompt >
-    The system is an AI Chatbot, that is providing information reasoning and general assistance for writing 
-    and coding to the users in this system. When returning images, return them with the <file> tags and not as a link.
-
-    If a report or document is being created, try to create document section independently. These can be stored in the file service with the create_file action and then combined later using amfs links with resolve=true. Doing this will generate higher quality reports since the assistant can focus on one section at a time. Before you start, though, create the header of the document with all the css and links to stylesheets and scripts. This will allow the assistant to create the document in pieces and then combine them later. HTML docs must be modern, well formatted and responsive.
-
-    Images are always very useful in reports, so the assistant will add them when appropriate. If images are embedded in html, they must be resolved and converted to datauri format or they won't render in the final document. This can be done by using the encoding=datauri&resolve=true in the amfs link. For example, <img src="amfs://xxxxxx.png?encoding=datauri&resolve=true". The assistant will take care of the rest. Images can be created in parallel
-
-    During report generation in interactive sessions, the assistant will send lots of status messages to indicate what is happening. This will help understand the process and know that the system is working.
+    Return all responses in markdown format and if the response contains a file or image, return it with the <file> tags and not as a link.
+    

--- a/templates/rest-api-flows.yaml
+++ b/templates/rest-api-flows.yaml
@@ -21,6 +21,7 @@
         component_config:
           identity_key_field: user_email
           <<: *gateway_config
+          <<: *response_format_config
         component_input:
           source_expression: previous
       - component_name: broker_output

--- a/templates/rest-api-flows.yaml
+++ b/templates/rest-api-flows.yaml
@@ -21,7 +21,7 @@
         component_config:
           identity_key_field: user_email
           <<: *gateway_config
-          <<: *response_format_config
+          response_format_prompt: *response_format_config
         component_input:
           source_expression: previous
       - component_name: broker_output

--- a/templates/rest-api-flows.yaml
+++ b/templates/rest-api-flows.yaml
@@ -21,7 +21,7 @@
         component_config:
           identity_key_field: user_email
           <<: *gateway_config
-          response_format_prompt: *response_format_config
+          response_format_prompt: *response_format_prompt
         component_input:
           source_expression: previous
       - component_name: broker_output

--- a/templates/slack-default-config.yaml
+++ b/templates/slack-default-config.yaml
@@ -7,3 +7,11 @@
     acknowledgement_message: "Chatbot is thinking... :hourglass_flowing_sand:"
     max_total_file_size: 2000 # 2GB
     max_file_size: 500 # 500MB
+
+- response_format_prompt: &response_format_prompt >
+    - Format the response as a Slack message, using appropriate 
+    formatting such as *bold*, _italic_, and `code` where necessary.
+
+    - Use bullet points or numbered lists for multiple items.
+
+    - If including links, use the format <url|text>.

--- a/templates/slack-default-config.yaml
+++ b/templates/slack-default-config.yaml
@@ -11,7 +11,6 @@
 - response_format_prompt: &response_format_prompt >
     - Format the response as a Slack message, using appropriate 
     formatting such as *bold*, _italic_, and `code` where necessary.
-
     - Use bullet points or numbered lists for multiple items.
-
-    - If including links, use the format <url|text>.
+    - If the response contains a file or image, return it with the <file> tags and not as a link.
+    - If including hyperlinks, use the format <url|text>.

--- a/templates/slack-flows.yaml
+++ b/templates/slack-flows.yaml
@@ -13,7 +13,7 @@
         component_config:
           identity_key_field: user_email
           <<: *gateway_config
-          <<: *response_format_config
+          response_format_prompt: *response_format_config
         component_input:
           source_expression: previous
         input_transforms:

--- a/templates/slack-flows.yaml
+++ b/templates/slack-flows.yaml
@@ -13,7 +13,7 @@
         component_config:
           identity_key_field: user_email
           <<: *gateway_config
-          response_format_prompt: *response_format_config
+          response_format_prompt: *response_format_prompt
         component_input:
           source_expression: previous
         input_transforms:

--- a/templates/slack-flows.yaml
+++ b/templates/slack-flows.yaml
@@ -13,21 +13,13 @@
         component_config:
           identity_key_field: user_email
           <<: *gateway_config
+          <<: *response_format_config
         component_input:
           source_expression: previous
         input_transforms:
           - type: copy
             source_expression: input.payload:thread_id
             dest_expression: input.user_properties:session_id
-          - type: copy
-            source_value: >
-              - Format the response as a Slack message, using appropriate 
-              formatting such as *bold*, _italic_, and `code` where necessary.
-
-              - Use bullet points or numbered lists for multiple items.
-
-              - If including links, use the format <url|text>.
-            dest_expression: input.user_properties:response_format_prompt
       - component_name: broker_output
         component_module: broker_output
         component_config:
@@ -87,4 +79,3 @@
             dest_expression: user_data.component_input:content
         component_input:
           source_expression: user_data.component_input
-

--- a/templates/web-default-config.yaml
+++ b/templates/web-default-config.yaml
@@ -3,3 +3,5 @@
     max_total_file_size: 0.5
     max_file_size: 2000 # 2GB
 
+- response_format_prompt: &response_format_prompt >
+    - Format the response as markdown.

--- a/templates/web-default-config.yaml
+++ b/templates/web-default-config.yaml
@@ -4,4 +4,4 @@
     max_file_size: 2000 # 2GB
 
 - response_format_prompt: &response_format_prompt >
-    - Format the response as markdown.
+    Return all responses in markdown format and if the response contains a file or image, return it with the <file> tags and not as a link.

--- a/templates/web-flows.yaml
+++ b/templates/web-flows.yaml
@@ -14,7 +14,7 @@
         component_config:
           identity_key_field: user_email
           <<: *gateway_config
-          response_format_prompt: *response_format_config
+          response_format_prompt: *response_format_prompt
         component_input:
           source_expression: previous
       - component_name: broker_output

--- a/templates/web-flows.yaml
+++ b/templates/web-flows.yaml
@@ -14,7 +14,7 @@
         component_config:
           identity_key_field: user_email
           <<: *gateway_config
-          <<: *response_format_config
+          response_format_prompt: *response_format_config
         component_input:
           source_expression: previous
       - component_name: broker_output

--- a/templates/web-flows.yaml
+++ b/templates/web-flows.yaml
@@ -1,10 +1,4 @@
-  # Start the Web application
-  - name: start_web_app
-    trace_level: ERROR
-    components:
-      - component_name: start_web_app
-        component_package: solace_ai_connector_web
-        component_module: solace_ai_connector_web.components.start_web_app
+
   # Web to Gateway to Solace
   - name: web_gateway_input_flow
     trace_level: ERROR
@@ -20,13 +14,9 @@
         component_config:
           identity_key_field: user_email
           <<: *gateway_config
+          <<: *response_format_config
         component_input:
           source_expression: previous
-        input_transforms:
-          - type: copy
-            source_value: >
-              - Format the response as markdown.
-            dest_expression: input.user_properties:response_format_prompt
       - component_name: broker_output
         component_module: broker_output
         component_config:


### PR DESCRIPTION
### What is the purpose of this change?

1. Allow a user to put the response_format_prompt in either the gateway or interface configuration and if it isn't there, then insert a default value.
2. Add a bit more information into the orchestrator prompt to indicate how to handle report requests

### Anything reviews should focus on/be aware of?

This should be backwards compatible