### PR TITLE
AI-566: Add a tutorial for adding an SQL plugin (with sample data)

### DIFF
--- a/docs/docs/documentation/tutorials/sql-database.md
+++ b/docs/docs/documentation/tutorials/sql-database.md
@@ -1,0 +1,6 @@
+---
+title: SQL Database Integration - sqlite3, MySQL, PostgreSQL
+sidebar_position: 20
+---
+
+# SQL Database Integration

--- a/docs/docs/documentation/tutorials/sql-database.md
+++ b/docs/docs/documentation/tutorials/sql-database.md
@@ -35,10 +35,11 @@ This command will create a new configuration file at `configs/agents/abc_coffee_
 
 For this tutorial, we'll use a sample SQLite database for a fictional coffee company called ABC Coffee Co. Follow these steps to download the example data:
 
-1. Visit [this link](https://download-directory.github.io/?url=https%3A%2F%2Fgithub.com%2FSolaceLabs%2Fsolace-agent-mesh-core-plugins%2Ftree%2Fmain%2Fsam-sql-database%2Fexample-data%2Fabc_coffee_co) to download the example data
+1. Visit [this link](https://download-directory.github.io/?url=https%3A%2F%2Fgithub.com%2FSolaceLabs%2Fsolace-agent-mesh-core-plugins%2Ftree%2Fmain%2Fsam-sql-database%2Fexample-data) to download the example data
 2. The link will open a page allowing you to download a ZIP file containing the example data
 3. Save the ZIP file to your computer
 4. Unzip the file to a directory of your choice (preferably in the same directory where you'll run the agent)
+5. This should create an abc_coffee_co directory with many CSV files inside
 
 ## Configuring the Agent
 
@@ -50,18 +51,12 @@ Now you need to update the agent configuration to use the SQLite database and im
 Here's what you need to modify in the configuration file:
 
 ```yaml
-# Find the component_config section and update these values:
-component_config:
-  llm_service_topic: ${SOLACE_AGENT_MESH_NAMESPACE}solace-agent-mesh/v1/llm-service/request/general-good/
-  embedding_service_topic: ${SOLACE_AGENT_MESH_NAMESPACE}solace-agent-mesh/v1/embedding-service/request/text/
-  agent_name: abc_coffee_info
-  db_type: sqlite
-  database: /path/to/your/unzipped/data/abc_coffee.db
-  query_timeout: 30
-  database_purpose: "ABC Coffee Co. sales and operations database"
-  data_description: "Contains information about ABC Coffee Co. products, sales, customers, employees, and store locations."
-  csv_directories:
-    - /path/to/your/unzipped/data
+      # Find the component_config section for the action_request_processor and update these values:
+      - component_name: action_request_processor
+        component_config: 
+            # Other configuration options (mostly specified via env vars)...
+            csv_directories:
+                - /path/to/your/unzipped/data
 ```
 
 Make sure to replace `/path/to/your/unzipped/data` with the actual path where you unzipped the example data.
@@ -71,19 +66,12 @@ Make sure to replace `/path/to/your/unzipped/data` with the actual path where yo
 The SQL Database agent requires several environment variables. Create or update your `.env` file with the following:
 
 ```
-SOLACE_BROKER_URL=tcp://localhost:55555
-SOLACE_BROKER_USERNAME=default
-SOLACE_BROKER_PASSWORD=default
-SOLACE_BROKER_VPN=default
-SOLACE_AGENT_MESH_NAMESPACE=
-
 ABC_COFFEE_INFO_DB_TYPE=sqlite
-ABC_COFFEE_INFO_DB_NAME=/path/to/your/unzipped/data/abc_coffee.db
+ABC_COFFEE_INFO_DB_NAME=abc_coffee.db
 ABC_COFFEE_INFO_DB_PURPOSE="ABC Coffee Co. sales and operations database"
 ABC_COFFEE_INFO_DB_DESCRIPTION="Contains information about ABC Coffee Co. products, sales, customers, employees, and store locations."
+# You can leave other environment variables as unset or empty
 ```
-
-Again, replace `/path/to/your/unzipped/data` with the actual path to your unzipped data.
 
 ## Running the Agent
 
@@ -93,7 +81,7 @@ Now you can start Solace Agent Mesh with your new SQL database agent:
 sam run -eb
 ```
 
-The `-e` flag loads environment variables from the `.env` file, and the `-b` flag opens a browser window to the SAM web interface.
+The `-e` flag loads environment variables from the `.env` file, and the `-b` flag will rebuild the sam config files
 
 ## Interacting with the Database
 
@@ -113,7 +101,20 @@ The SQL Database agent will convert your natural language questions into SQL que
 
 The ABC Coffee Co. database contains the following tables:
 
-[Table names and descriptions to be filled in]
+    customers
+    employees
+    inventory
+    order_history
+    order_items
+    orders
+    product_categories
+    product_specifications
+    products
+    sales_call_logs
+    support_ticket_comments
+    support_tickets
+
+The schemas for them all will be learned by the agent when it starts up.
 
 ## Conclusion
 

--- a/docs/docs/documentation/tutorials/sql-database.md
+++ b/docs/docs/documentation/tutorials/sql-database.md
@@ -4,3 +4,16 @@ sidebar_position: 20
 ---
 
 # SQL Database Integration
+
+<inst>
+Fill in this tutorial using the following as guides:
+1. All the other tutorials in this docs directory
+2. Using the sam_sql_database plugin code and its README.md
+3. Command to download example data
+https://download-directory.github.io/?url=https%3A%2F%2Fgithub.com%2FSolaceLabs%2Fsolace-agent-mesh-core-plugins%2Ftree%2Fmain%2Fsam-sql-database%2Fexample-data%2Fabc_coffee_co
+
+The tutorial will show the user how to download and install the plugin, using the plugin add and then the add agent commands with the copy-from option. 
+The agent will have the name abc_coffee_info and it will use an sqlite3 database. 
+That database will be populated with the example data that can be downloaded from the link above. That link will open a page allowing the user to download a zip file with the example data. That data will have to be unzipped somewhere (probably in the same directory where the agent will be started from) and the .yaml config file will need to be updated to point to the directory where the data was unzipped so that it can be imported.
+Finally, the agent mesh can be started with `sam run -eb` and then the user can interact with the agent using a browser (localhost:5001) and can ask questions about ABC Coffee, its sales, its customers, employees, etc.
+</inst>

--- a/docs/docs/documentation/tutorials/sql-database.md
+++ b/docs/docs/documentation/tutorials/sql-database.md
@@ -5,15 +5,118 @@ sidebar_position: 20
 
 # SQL Database Integration
 
-<inst>
-Fill in this tutorial using the following as guides:
-1. All the other tutorials in this docs directory
-2. Using the sam_sql_database plugin code and its README.md
-3. Command to download example data
-https://download-directory.github.io/?url=https%3A%2F%2Fgithub.com%2FSolaceLabs%2Fsolace-agent-mesh-core-plugins%2Ftree%2Fmain%2Fsam-sql-database%2Fexample-data%2Fabc_coffee_co
+This tutorial will guide you through setting up a SQL database agent in Solace Agent Mesh (SAM) that can answer natural language queries about a sample coffee company database.
 
-The tutorial will show the user how to download and install the plugin, using the plugin add and then the add agent commands with the copy-from option. 
-The agent will have the name abc_coffee_info and it will use an sqlite3 database. 
-That database will be populated with the example data that can be downloaded from the link above. That link will open a page allowing the user to download a zip file with the example data. That data will have to be unzipped somewhere (probably in the same directory where the agent will be started from) and the .yaml config file will need to be updated to point to the directory where the data was unzipped so that it can be imported.
-Finally, the agent mesh can be started with `sam run -eb` and then the user can interact with the agent using a browser (localhost:5001) and can ask questions about ABC Coffee, its sales, its customers, employees, etc.
-</inst>
+## Prerequisites
+
+Before starting this tutorial, make sure you have:
+- [Installed Solace Agent Mesh and the SAM CLI](../getting-started/installation.md)
+- [Created a new Solace Agent Mesh project](../getting-started/quick-start.md)
+
+## Installing the SQL Database Plugin
+
+First, add the SQL Database plugin to your SAM project:
+
+```sh
+solace-agent-mesh plugin add sam_sql_database --pip -u git+https://github.com/SolaceLabs/solace-agent-mesh-core-plugins#subdirectory=sam-sql-database
+```
+
+## Creating a SQL Database Agent
+
+Next, create a new agent instance based on the SQL database template:
+
+```sh
+solace-agent-mesh add agent abc_coffee_info --copy-from sam_sql_database:sql_database
+```
+
+This command will create a new configuration file at `configs/agents/abc_coffee_info.yaml`.
+
+## Downloading Example Data
+
+For this tutorial, we'll use a sample SQLite database for a fictional coffee company called ABC Coffee Co. Follow these steps to download the example data:
+
+1. Visit [this link](https://download-directory.github.io/?url=https%3A%2F%2Fgithub.com%2FSolaceLabs%2Fsolace-agent-mesh-core-plugins%2Ftree%2Fmain%2Fsam-sql-database%2Fexample-data%2Fabc_coffee_co) to download the example data
+2. The link will open a page allowing you to download a ZIP file containing the example data
+3. Save the ZIP file to your computer
+4. Unzip the file to a directory of your choice (preferably in the same directory where you'll run the agent)
+
+## Configuring the Agent
+
+Now you need to update the agent configuration to use the SQLite database and import the CSV files. Open the `configs/agents/abc_coffee_info.yaml` file and make the following changes:
+
+1. Set the database type to SQLite
+2. Point to the directory where you unzipped the example data
+
+Here's what you need to modify in the configuration file:
+
+```yaml
+# Find the component_config section and update these values:
+component_config:
+  llm_service_topic: ${SOLACE_AGENT_MESH_NAMESPACE}solace-agent-mesh/v1/llm-service/request/general-good/
+  embedding_service_topic: ${SOLACE_AGENT_MESH_NAMESPACE}solace-agent-mesh/v1/embedding-service/request/text/
+  agent_name: abc_coffee_info
+  db_type: sqlite
+  database: /path/to/your/unzipped/data/abc_coffee.db
+  query_timeout: 30
+  database_purpose: "ABC Coffee Co. sales and operations database"
+  data_description: "Contains information about ABC Coffee Co. products, sales, customers, employees, and store locations."
+  csv_directories:
+    - /path/to/your/unzipped/data
+```
+
+Make sure to replace `/path/to/your/unzipped/data` with the actual path where you unzipped the example data.
+
+## Setting Environment Variables
+
+The SQL Database agent requires several environment variables. Create or update your `.env` file with the following:
+
+```
+SOLACE_BROKER_URL=tcp://localhost:55555
+SOLACE_BROKER_USERNAME=default
+SOLACE_BROKER_PASSWORD=default
+SOLACE_BROKER_VPN=default
+SOLACE_AGENT_MESH_NAMESPACE=
+
+ABC_COFFEE_INFO_DB_TYPE=sqlite
+ABC_COFFEE_INFO_DB_NAME=/path/to/your/unzipped/data/abc_coffee.db
+ABC_COFFEE_INFO_DB_PURPOSE="ABC Coffee Co. sales and operations database"
+ABC_COFFEE_INFO_DB_DESCRIPTION="Contains information about ABC Coffee Co. products, sales, customers, employees, and store locations."
+```
+
+Again, replace `/path/to/your/unzipped/data` with the actual path to your unzipped data.
+
+## Running the Agent
+
+Now you can start Solace Agent Mesh with your new SQL database agent:
+
+```sh
+sam run -eb
+```
+
+The `-e` flag loads environment variables from the `.env` file, and the `-b` flag opens a browser window to the SAM web interface.
+
+## Interacting with the Database
+
+Once SAM is running, you can interact with the ABC Coffee database through the web interface at http://localhost:5001.
+
+You can ask natural language questions about the ABC Coffee Co. database, such as:
+
+- "How many customers does ABC Coffee have?"
+- "What are the top-selling products?"
+- "Show me the sales by region"
+- "Which employees have the highest sales?"
+- "What's the average order value?"
+
+The SQL Database agent will convert your natural language questions into SQL queries, execute them against the database, and return the results.
+
+## Database Schema
+
+The ABC Coffee Co. database contains the following tables:
+
+[Table names and descriptions to be filled in]
+
+## Conclusion
+
+You've successfully set up a SQL Database agent in Solace Agent Mesh that can answer natural language queries about the ABC Coffee Co. database. This same approach can be used to connect to other database types like MySQL and PostgreSQL by adjusting the configuration and environment variables accordingly.
+
+For more information about the SQL Database plugin, see the [plugin README](https://github.com/SolaceLabs/solace-agent-mesh-core-plugins/blob/main/sam-sql-database/README.md).

--- a/docs/docs/documentation/tutorials/sql-database.md
+++ b/docs/docs/documentation/tutorials/sql-database.md
@@ -5,7 +5,7 @@ sidebar_position: 20
 
 # SQL Database Integration
 
-This tutorial will guide you through setting up a SQL database agent in Solace Agent Mesh (SAM) that can answer natural language queries about a sample coffee company database.
+This tutorial will guide you through setting up a SQL database agent in Solace Agent Mesh (SAM) that can answer natural language queries about a sample coffee company database. It provides some example data to setup a SQLite database, but you can use the same approach to connect to other database types like MySQL and PostgreSQL.
 
 ## Prerequisites
 
@@ -21,12 +21,14 @@ First, add the SQL Database plugin to your SAM project:
 solace-agent-mesh plugin add sam_sql_database --pip -u git+https://github.com/SolaceLabs/solace-agent-mesh-core-plugins#subdirectory=sam-sql-database
 ```
 
+Note that you can replace the Solace Agent Mesh CLI command with `sam` as a shortcut.
+
 ## Creating a SQL Database Agent
 
 Next, create a new agent instance based on the SQL database template:
 
 ```sh
-solace-agent-mesh add agent abc_coffee_info --copy-from sam_sql_database:sql_database
+sam add agent abc_coffee_info --copy-from sam_sql_database:sql_database
 ```
 
 This command will create a new configuration file at `configs/agents/abc_coffee_info.yaml`.
@@ -59,7 +61,7 @@ Here's what you need to modify in the configuration file:
                 - /path/to/your/unzipped/data
 ```
 
-Make sure to replace `/path/to/your/unzipped/data` with the actual path where you unzipped the example data.
+Make sure to replace `/path/to/your/unzipped/data` with the actual path where you unzipped the example data. In this example, if you put the zip file in the same directory as the agent, you can use `abc_coffee_co`.
 
 ## Setting Environment Variables
 
@@ -72,6 +74,8 @@ ABC_COFFEE_INFO_DB_PURPOSE="ABC Coffee Co. sales and operations database"
 ABC_COFFEE_INFO_DB_DESCRIPTION="Contains information about ABC Coffee Co. products, sales, customers, employees, and store locations."
 # You can leave other environment variables as unset or empty
 ```
+
+For SQLite, it just uses a local file with no username or password. If you're using MySQL or PostgreSQL, you'll need to provide the appropriate environment variables for your database.
 
 ## Running the Agent
 
@@ -92,8 +96,10 @@ You can ask natural language questions about the ABC Coffee Co. database, such a
 - "How many customers does ABC Coffee have?"
 - "What are the top-selling products?"
 - "Show me the sales by region"
-- "Which employees have the highest sales?"
-- "What's the average order value?"
+
+Try creating reports by asking questions like:
+
+- "Create a report of our sales in 2024"
 
 The SQL Database agent will convert your natural language questions into SQL queries, execute them against the database, and return the results.
 


### PR DESCRIPTION
### What is the purpose of this change?

Add an easy tutorial to add some data into the system so that you can do interesting things with Agent Mesh

### How is this accomplished?

Tutorial has been added here and sample data has been added to the sam-sql-database agent plugin

