### PR TITLE
AI-308: Handle litellm errors

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,7 +56,7 @@ dependencies = [
     "duckduckgo_search~=6.3.7",
     "markitdown~=0.0.1a3",
     "pyperclip~=1.9.0",
-    "solace-ai-connector @ git+https://github.com/SolaceDev/solace-ai-connector.git@hugo/ai-308/litellm-error-handling",
+    "solace-ai-connector~=1.0.1",
     "solace-ai-connector-web~=0.1.0",
     "solace-ai-connector-rest~=0.0.1",
     "solace-ai-connector-slack~=0.0.1",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,7 +56,7 @@ dependencies = [
     "duckduckgo_search~=6.3.7",
     "markitdown~=0.0.1a3",
     "pyperclip~=1.9.0",
-    "solace-ai-connector~=1.0.1",
+    "solace-ai-connector @ git+https://github.com/SolaceDev/solace-ai-connector.git@hugo/ai-308/litellm-error-handling",
     "solace-ai-connector-web~=0.1.0",
     "solace-ai-connector-rest~=0.0.1",
     "solace-ai-connector-slack~=0.0.1",

--- a/src/services/llm_service/components/llm_request_component.py
+++ b/src/services/llm_service/components/llm_request_component.py
@@ -207,9 +207,9 @@ class LLMRequestComponent(ComponentBase):
             current_batch += content
 
             if payload.get("handle_error", False):
-                    log.error("Error invoking LLM service: %s", payload.get("content", ""), exc_info=True)
-                    aggregate_result = payload.get("content", None)
-                    last_message = True
+                log.error("Error invoking LLM service: %s", payload.get("content", ""), exc_info=True)
+                aggregate_result = payload.get("content", None)
+                last_message = True
 
             if len(current_batch.split()) >= self.stream_batch_size or last_message:
                 self._send_streaming_chunk(

--- a/src/services/llm_service/components/llm_request_component.py
+++ b/src/services/llm_service/components/llm_request_component.py
@@ -206,6 +206,11 @@ class LLMRequestComponent(ComponentBase):
             aggregate_result += content
             current_batch += content
 
+            if payload.get("handle_error", False):
+                    log.error("Error invoking LLM service: %s", payload.get("content", ""), exc_info=True)
+                    aggregate_result = payload.get("content", None)
+                    last_message = True
+
             if len(current_batch.split()) >= self.stream_batch_size or last_message:
                 self._send_streaming_chunk(
                     input_message,


### PR DESCRIPTION
### What is the purpose of this change?
Handling Litellm errors

### How is this accomplished?
Any messages having `handle_error` key set to True will return their payload's content to the orchestrator.

### Anything reviews should focus on/be aware of?
This is a multi-repository change. The change itself does not affect anything yet since message payloads do not include the `handle_error` key.