### PR TITLE
AI-548: Fix orchestrator asking for email bug

### DIFF
--- a/src/orchestrator/components/orchestrator_stimulus_processor_component.py
+++ b/src/orchestrator/components/orchestrator_stimulus_processor_component.py
@@ -184,7 +184,7 @@ class OrchestratorStimulusProcessorComponent(LLMRequestComponent):
             message.set_user_properties(user_properties)
 
         input_data = self.get_user_input(chat_text)
-        user_info = payload.get("user_info", {"email": "unknown"})
+        user_info = message.get_user_properties()
 
         agent_state_yaml, examples = self.get_agents_yaml(user_properties)
         full_input = {

--- a/src/services/middleware_service/middleware_service.py
+++ b/src/services/middleware_service/middleware_service.py
@@ -6,14 +6,12 @@ class MiddlewareService(metaclass=SingletonMeta):
         self._register_defaults()
     
     def _register_defaults(self):
-        print("Registering default middleware in middleware_service.py")
         # Default middleware that just returns actions unchanged
         self.register("filter_action", lambda user_properties, actions: actions)
         # Default middleware that allows all actions
         self.register("base_agent_filter", lambda user_properties, action: True)
         # Default middleware that allows all action requests
         self.register("validate_action_request", lambda user_properties, action_details: True)
-        print("Done Registering default middleware in middleware_service.py")
     
     def register(self, name: str, middleware_fn):
         self._middleware[name] = middleware_fn

--- a/src/services/middleware_service/middleware_service.py
+++ b/src/services/middleware_service/middleware_service.py
@@ -6,12 +6,14 @@ class MiddlewareService(metaclass=SingletonMeta):
         self._register_defaults()
     
     def _register_defaults(self):
+        print("Registering default middleware in middleware_service.py")
         # Default middleware that just returns actions unchanged
         self.register("filter_action", lambda user_properties, actions: actions)
         # Default middleware that allows all actions
         self.register("base_agent_filter", lambda user_properties, action: True)
         # Default middleware that allows all action requests
         self.register("validate_action_request", lambda user_properties, action_details: True)
+        print("Done Registering default middleware in middleware_service.py")
     
     def register(self, name: str, middleware_fn):
         self._middleware[name] = middleware_fn


### PR DESCRIPTION
### What is the purpose of this change?
Fix the issue with user information being "unknown" after opening an agent. This will fix the issues with SAM asking for the users email for tasks such as looking up jira issues etc

### How is this accomplished?
Instead of getting user properties from the data object we get it from the message object which always has it

### Anything reviews should focus on/be aware of?
