### PR TITLE
AI-559: Extend request expiry and lower activity timeout

### DIFF
--- a/configs/orchestrator.yaml
+++ b/configs/orchestrator.yaml
@@ -85,7 +85,8 @@ flows:
         broker_request_response:
           enabled: true
           broker_config: *broker_connection
-          request_expiry_ms: 120000
+          request_expiry_ms: 300000
+          activity_timeout_s: 30
           payload_encoding: utf-8
           payload_format: json
           response_topic_prefix: ${SOLACE_AGENT_MESH_NAMESPACE}solace-agent-mesh/v1/llm-service/response


### PR DESCRIPTION
### What is the purpose of this change?
Permit a longer duration for streaming messages back to the orchestrator.
Raising Timeout Error if nothing is streamed back within a configurable limit (activity_timeout_s)

### How is this accomplished?
New config added in AI-559 (see solace-ai-connector repo) - catch orchestrator timeouts faster
Extended `request_expiry_ms` value to 5 min, will allow generation of larger files

### Anything reviews should focus on/be aware of?
DO NOT MERGE before the AI-559 branch is merged on solace-ai-connector
