### PR TITLE
AI-436: Prevent orchestrator from processing action responses not initiated by orchestrator

### DIFF
--- a/configs/monitor_stim_and_errors_to_slack.yaml
+++ b/configs/monitor_stim_and_errors_to_slack.yaml
@@ -100,8 +100,8 @@ flows:
             source_value: '0'
             dest_expression: user_data.output:payload.action_idx
           - type: copy
-            source_value: 'non-orchestrator-agent-invocation'
-            dest_expression: user_data.output:payload.action_list_id
+            source_value: 'stim_and_error_monitor'
+            dest_expression: user_data.output:payload.originator
           - type: copy
             source_expression: template:${SOLACE_AGENT_MESH_NAMESPACE}solace-agent-mesh/v1/actionRequest/monitor/x/slack/post_message/{{text://input.payload:correlation_id}}
             dest_expression: user_data.output:topic

--- a/configs/monitor_stim_and_errors_to_slack.yaml
+++ b/configs/monitor_stim_and_errors_to_slack.yaml
@@ -100,6 +100,9 @@ flows:
             source_value: '0'
             dest_expression: user_data.output:payload.action_idx
           - type: copy
+            source_value: 'non-orchestrator-agent-invocation'
+            dest_expression: user_data.output:payload.action_list_id
+          - type: copy
             source_expression: template:${SOLACE_AGENT_MESH_NAMESPACE}solace-agent-mesh/v1/actionRequest/monitor/x/slack/post_message/{{text://input.payload:correlation_id}}
             dest_expression: user_data.output:topic
         input_selection:

--- a/src/agents/base_agent_component.py
+++ b/src/agents/base_agent_component.py
@@ -12,6 +12,7 @@ from solace_ai_connector.common.utils import ensure_slash_on_end
 from ..services.llm_service.components.llm_service_component_base import LLMServiceComponentBase
 from ..common.action_list import ActionList
 from ..common.action_response import ActionResponse, ErrorInfo
+from ..common.constants import ORCHESTRATOR_COMPONENT_NAME
 from ..services.file_service import FileService
 from ..services.file_service.file_utils import recursive_file_resolver
 from ..services.middleware_service.middleware_service import MiddlewareService
@@ -185,6 +186,7 @@ class BaseAgentComponent(LLMServiceComponentBase, ABC):
         action_response.action_idx = data.get("action_idx")
         action_response.action_name = action_name
         action_response.action_params = data.get("action_params", {})
+        action_response.originator = data.get("originator", ORCHESTRATOR_COMPONENT_NAME)
         try:
             action_response_dict = action_response.to_dict()
         except Exception as e:

--- a/src/common/action_response.py
+++ b/src/common/action_response.py
@@ -212,6 +212,8 @@ class ActionResponse:
         self._is_async: bool = is_async
         # async_response_id - unique identifier for correlating async responses
         self._async_response_id: str = async_response_id
+        # originator - the component that originated the action request
+        self._originator: str = None
 
     @property
     def message(self) -> any:
@@ -269,6 +271,10 @@ class ActionResponse:
     def action_params(self) -> dict:
         return self._action_params
 
+    @property
+    def originator(self) -> dict:
+        return self._originator
+
     @action_list_id.setter
     def action_list_id(self, action_list_id: str):
         self._action_list_id = action_list_id
@@ -284,6 +290,10 @@ class ActionResponse:
     @action_params.setter
     def action_params(self, action_params: dict):
         self._action_params = action_params
+
+    @originator.setter
+    def originator(self, originator: str):
+        self._originator = originator
 
     @property
     def is_async(self) -> bool:
@@ -324,4 +334,5 @@ class ActionResponse:
         response["action_idx"] = self._action_idx
         response["action_name"] = self._action_name
         response["action_params"] = self._action_params
+        response["originator"] = self._originator
         return response

--- a/src/common/action_response.py
+++ b/src/common/action_response.py
@@ -1,5 +1,7 @@
 """This is the definition of responses for the actions of the system."""
 
+from typing import Optional
+
 
 class RagMatch:
 
@@ -213,7 +215,7 @@ class ActionResponse:
         # async_response_id - unique identifier for correlating async responses
         self._async_response_id: str = async_response_id
         # originator - the component that originated the action request
-        self._originator: str = None
+        self._originator: Optional[str] = None
 
     @property
     def message(self) -> any:

--- a/src/common/constants.py
+++ b/src/common/constants.py
@@ -1,3 +1,5 @@
 SOLACE_AGENT_MESH_SYSTEM_SESSION_ID = "solace_agent_mesh_system_session_id"
 
 DEFAULT_IDENTITY_KEY_FIELD = "identity"
+
+ORCHESTRATOR_COMPONENT_NAME = "orchestrator"

--- a/src/orchestrator/action_manager.py
+++ b/src/orchestrator/action_manager.py
@@ -79,11 +79,10 @@ class ActionManager:
     def add_action_response(self, action_response_obj, response_text_and_files):
         """Add an action response to the list"""
 
-        originator = action_response_obj.get(ORCHESTRATOR_COMPONENT_NAME)
-        
-        # Ignore action responses that were not originated by the orchestrator
-        if originator != "orchestrator":
-            log.debug("Ignoring action response not originated by the orchestrator")
+        originator = action_response_obj.get("originator")
+        # Ignore responses for actions that are not originated by the orchestrator
+        if originator != ORCHESTRATOR_COMPONENT_NAME:
+            log.debug("Ignoring response for action not originated by the orchestrator")
             return None
             
         action_list_id = action_response_obj.get("action_list_id")

--- a/src/orchestrator/action_manager.py
+++ b/src/orchestrator/action_manager.py
@@ -78,6 +78,12 @@ class ActionManager:
     def add_action_response(self, action_response_obj, response_text_and_files):
         """Add an action response to the list"""
         action_list_id = action_response_obj.get("action_list_id")
+        
+        # Ignore action responses with action_list_id "non-orchestrator-agent-invocation"
+        if action_list_id == "non-orchestrator-agent-invocation":
+            log.debug("Ignoring non-orchestrator initiated action response with action_list_id 'non-orchestrator-agent-invocation'")
+            return None
+            
         with self.lock:
             action_list = self.action_requests.get(action_list_id)
             if action_list is None:

--- a/src/orchestrator/action_manager.py
+++ b/src/orchestrator/action_manager.py
@@ -78,15 +78,18 @@ class ActionManager:
 
     def add_action_response(self, action_response_obj, response_text_and_files):
         """Add an action response to the list"""
-
-        originator = action_response_obj.get("originator")
-        # Ignore responses for actions that are not originated by the orchestrator
-        if originator != ORCHESTRATOR_COMPONENT_NAME:
-            log.debug("Ignoring response for action not originated by the orchestrator")
-            return None
-            
         action_list_id = action_response_obj.get("action_list_id")
 
+        originator = action_response_obj.get("originator", "unknown")
+        # Ignore responses for actions that are not originated by the orchestrator
+        if originator != ORCHESTRATOR_COMPONENT_NAME:
+            log.debug(
+                "Ignoring response for action not originated by the orchestrator. "
+                "originator: %s   action_list_id: %s", 
+                originator, action_list_id
+            )
+            return None
+            
         with self.lock:
             action_list = self.action_requests.get(action_list_id)
             if action_list is None:

--- a/src/orchestrator/components/orchestrator_stimulus_processor_component.py
+++ b/src/orchestrator/components/orchestrator_stimulus_processor_component.py
@@ -14,6 +14,7 @@ import yaml
 from solace_ai_connector.common.log import log
 from solace_ai_connector.common.message import Message
 
+from ...common.constants import ORCHESTRATOR_COMPONENT_NAME
 from ...services.llm_service.components.llm_request_component import LLMRequestComponent, info as base_info
 from ...services.middleware_service.middleware_service import MiddlewareService
 from ...services.file_service import FileService
@@ -458,6 +459,7 @@ class OrchestratorStimulusProcessorComponent(LLMRequestComponent):
                             "action_name": action_name,
                             "action_params": action_params,
                             "action_idx": action_idx,
+                            "originator": ORCHESTRATOR_COMPONENT_NAME,
                         },
                         "topic": f"{os.getenv('SOLACE_AGENT_MESH_NAMESPACE')}solace-agent-mesh/v1/actionRequest/orchestrator/agent/{agent_name}/{action_name}",
                     }


### PR DESCRIPTION
## What is the purpose of this change?

To prevent the orchestrator from processing action responses that were not initiated by the orchestrator itself, by introducing a way to identify and ignore these external responses.

## How is this accomplished?

By adding a special identifier ('non-orchestrator-agent-invocation') to the action_list_id field for actions initiated outside the orchestrator, and modifying the action_manager to check for and ignore responses with this identifier. This was implemented in both the configuration file and the action manager's response handling logic.

## Anything reviews should focus on/be aware of?

Reviewers should verify that legitimate orchestrator-initiated actions continue to work normally while external actions are properly ignored. This change affects action response routing, so it's important to confirm there are no unintended side effects on the overall messaging flow.