### PR TITLE
AI-615: Fix rare CORS issue due to using localhost 

### DIFF
--- a/cli/commands/init/init.py
+++ b/cli/commands/init/init.py
@@ -45,7 +45,7 @@ default_options = {
     "rest_api_gateway_name": "rest-api",
     "webui_enabled": True,
     "webui_listen_port": "5001",
-    "webui_host": "localhost"
+    "webui_host": "127.0.0.1"
 }
 """
 Default options for the init command.


### PR DESCRIPTION
### What is the purpose of this change?
Instead of serving web ui on localhost, we use 127.0.0.1, in rare cases we saw some CORS issues due to this.

### How is this accomplished?

### Anything reviews should focus on/be aware of?
