### PR TITLE
AI-643: Make examples llm agnostic

### DIFF
--- a/src/agents/global/actions/plotly_graph.py
+++ b/src/agents/global/actions/plotly_graph.py
@@ -37,46 +37,44 @@ class PlotlyGraph(Action):
                 ],
                 "required_scopes": ["global:plotly:read"],
                 "examples": [
-                    """    <example>
-        <example_docstring>
-            This is an example of a user asking for a bar graph. The plotly action from the global agent is invoked to generate the graph.
-        </example_docstring>
-        <example_stimulus>
-            <{tp}stimulus starting_id="12">
-            Please generate a random bar graph for me
-            </{tp}stimulus>
-            <{tp}stimulus_metadata>
-            local_time: 2024-09-04 15:59:02 EDT-0400 (Wednesday)
-            </{tp}stimulus_metadata>
-        </example_stimulus>
-        <example_response>
-            <{tp}reasoning>
-            - user has requested a random bar graph
-            - invoke the plotly action from the global agent to generate a bar graph with random data
-            </{tp}reasoning>
-            Certainly! I'd be happy to generate a random bar graph for you.
-            <{tp}status_update>I'll use our plotting tool to create this for you right away.</{tp}status_update>
-            <{tp}invoke_action agent="global" action="plotly">
-            <{tp}parameter name="plotly_figure_config">
-            {{
-                "data": [
-                {{
-                    "x": ["A", "B", "C", "D", "E"],
-                    "y": [23, 45, 56, 78, 90],
-                    "type": "bar"
-                }}
-                ],
-                "layout": {{
-                "title": "Random Bar Graph",
-                "xaxis": {{"title": "Categories"}},
-                "yaxis": {{"title": "Values"}}
-                }}
-            }}
-            </{tp}parameter>
-            </{tp}invoke_action>
-        </example_response>
-    </example>
-"""
+                    {
+                        "docstring": "This is an example of a user asking for a bar graph. The plotly action from the global agent is invoked to generate the graph.",
+                        "tag_prefix_placeholder": "{tp}",
+                        "starting_id": "12",
+                        "user_input": "Please generate a random bar graph for me",
+                        "metadata": [
+                            "local_time: 2024-09-04 15:59:02 EDT-0400 (Wednesday)"
+                        ],
+                        "reasoning": [
+                            "- user has requested a random bar graph",
+                            "- invoke the plotly action from the global agent to generate a bar graph with random data"
+                        ],
+                        "response_text": "Certainly! I'd be happy to generate a random bar graph for you.",
+                        "status_update": "I'll use our plotting tool to create this for you right away.",
+                        "action": {
+                            "agent": "global",
+                            "name": "plotly",
+                            "parameter_name": "plotly_figure_config",
+                            "parameters": {
+                                "plotly_figure_config": [
+                                    "{{",
+                                    "    \"data\": [",
+                                    "    {{",
+                                    "        \"x\": [\"A\", \"B\", \"C\", \"D\", \"E\"],",
+                                    "        \"y\": [23, 45, 56, 78, 90],",
+                                    "        \"type\": \"bar\"",
+                                    "    }}",
+                                    "    ],",
+                                    "    \"layout\": {{",
+                                    "    \"title\": \"Random Bar Graph\",",
+                                    "    \"xaxis\": {{\"title\": \"Categories\"}},",
+                                    "    \"yaxis\": {{\"title\": \"Values\"}}",
+                                    "    }}",
+                                    "}}"
+                                ]
+                            }
+                        }
+                    }
                 ],
             },
             **kwargs,

--- a/src/agents/web_request/actions/do_web_request.py
+++ b/src/agents/web_request/actions/do_web_request.py
@@ -31,37 +31,31 @@ class DoWebRequest(Action):
                 ],
                 "required_scopes": ["web_request:do_web_request:read"],
                 "examples": [
-                    """    <example>
-        <example_docstring>
-            This is an example of a user requesting to fetch information from the web. The web_request agent is open so invoke the do_web_request action to fetch the content from the url and process the information according to the llm_prompt.
-        </example_docstring>
-        <example_stimulus>
-            <{tp}stimulus starting_id="10"/>
-            What is the weather in Ottawa?
-            </{tp}stimulus>
-            <{tp}stimulus_metadata>
-            local_time: 2024-11-06 12:33:12 EST-0500 (Wednesday)
-            </{tp}stimulus_metadata>
-        </example_stimulus>
-        <example_response>
-            <{tp}reasoning>
-            - User is asking for current weather information in Ottawa
-            - We need to fetch up-to-date weather data
-            - Use the web_request agent to get the latest weather information
-            - Plan to use the Environment Canada website for accurate local weather data
-            </{tp}reasoning>
-
-            Certainly! I\'ll fetch the current weather information for Ottawa for you right away.
-
-            <{tp}invoke_action agent="web_request" action="do_web_request">
-            <{tp}parameter name="url">https://weather.gc.ca/city/pages/on-118_metric_e.html</{tp}parameter>
-            <{tp}parameter name="llm_prompt">Extract the current temperature, weather conditions, and any important weather alerts or warnings for Ottawa from the webpage. Format the response as a bulleted list with emoji where appropriate.</{tp}parameter>
-            </{tp}invoke_action>
-
-            <{tp}status_update>Retrieving the latest weather data for Ottawa...</{tp}status_update>'
-        </example_response>
-    </example>
-"""
+                    {
+                        "docstring": "This is an example of a user requesting to fetch information from the web. The web_request agent is open so invoke the do_web_request action to fetch the content from the url and process the information according to the llm_prompt.",
+                        "tag_prefix_placeholder": "{tp}",
+                        "starting_id": "10",
+                        "user_input": "What is the weather in Ottawa?",
+                        "metadata": [
+                            "local_time: 2024-11-06 12:33:12 EST-0500 (Wednesday)"
+                        ],
+                        "reasoning": [
+                            "- User is asking for current weather information in Ottawa",
+                            "- We need to fetch up-to-date weather data",
+                            "- Use the web_request agent to get the latest weather information",
+                            "- Plan to use the Environment Canada website for accurate local weather data"
+                        ],
+                        "response_text": "Certainly! I'll fetch the current weather information for Ottawa for you right away.",
+                        "status_update": "Retrieving the latest weather data for Ottawa...",
+                        "action": {
+                            "agent": "web_request",
+                            "name": "do_web_request",
+                            "parameters": {
+                                "url": "https://weather.gc.ca/city/pages/on-118_metric_e.html",
+                                "llm_prompt": "Extract the current temperature, weather conditions, and any important weather alerts or warnings for Ottawa from the webpage. Format the response as a bulleted list with emoji where appropriate."
+                            }
+                        }
+                    }
                 ],
             },
             **kwargs,

--- a/src/orchestrator/orchestrator_prompt.py
+++ b/src/orchestrator/orchestrator_prompt.py
@@ -414,7 +414,7 @@ you should ask the originator for more information. Include links to the source 
 """
 
 
-def format_examples_by_llm_type( examples: list, llm_type: str = "anthropic") -> list:
+def format_examples_by_llm_type(examples: list, llm_type: str = "anthropic") -> list:
     """
     Render examples based on llm type
     
@@ -436,7 +436,10 @@ def format_examples_by_llm_type( examples: list, llm_type: str = "anthropic") ->
 
     return formatted_examples
 
-def format_example_for_anthropic( example: dict) -> str:
+def format_example_for_anthropic(example: dict) -> str:
+    """
+    Format an example for the Anthropic's LLMs
+    """
     
     tag_prefix = example.get("tag_prefix_placeholder", "t123")
     starting_id = example.get("starting_id", "1")

--- a/src/orchestrator/orchestrator_prompt.py
+++ b/src/orchestrator/orchestrator_prompt.py
@@ -2,6 +2,7 @@ from typing import Dict, Any, List
 import yaml
 from langchain_core.messages import HumanMessage
 from ..services.file_service import FS_PROTOCOL, Types, LLM_QUERY_OPTIONS, TRANSFORMERS
+from solace_ai_connector.common.log import log
 
 # Cap the number of examples so we don't overwhelm the LLM
 MAX_SYSTEM_PROMPT_EXAMPLES = 6
@@ -430,6 +431,8 @@ def format_examples_by_llm_type( examples: list, llm_type: str = "anthropic") ->
         for example in examples:
             formatted_example = format_example_for_anthropic(example)
             formatted_examples.append(formatted_example)
+    else:
+        log.error(f"Unsupported LLM type: {llm_type}")
 
     return formatted_examples
 

--- a/src/orchestrator/orchestrator_prompt.py
+++ b/src/orchestrator/orchestrator_prompt.py
@@ -428,12 +428,12 @@ def format_examples_by_llm_type( examples: list, llm_type: str = "anthropic") ->
 
     if llm_type == "anthropic":
         for example in examples:
-            formatted_example = _format_example_for_anthropic(example)
+            formatted_example = format_example_for_anthropic(example)
             formatted_examples.append(formatted_example)
 
     return formatted_examples
 
-def _format_example_for_anthropic( example: dict) -> str:
+def format_example_for_anthropic( example: dict) -> str:
     
     tag_prefix = example.get("tag_prefix_placeholder", "t123")
     starting_id = example.get("starting_id", "1")

--- a/src/orchestrator/orchestrator_prompt.py
+++ b/src/orchestrator/orchestrator_prompt.py
@@ -8,36 +8,32 @@ MAX_SYSTEM_PROMPT_EXAMPLES = 6
 
 # Examples that should always be included in the prompt
 fixed_examples = [
-    """    <example>
-        <example_docstring>
-          This example shows a stimulus from a chatbot gateway in which a user is asking about the top stories on the website hacker news. The web_request is not yet open, so the change_agent_status action is invoked to open the web_request agent.
-        </example_docstring> 
-        <example_stimulus>
-          <{tp}stimulus starting_id="1"/>
-          What is the top story on hacker news?
-          </{tp}stimulus>
-          <{tp}stimulus_metadata>
-          local_time: 2024-11-06 15:58:04 EST-0500 (Wednesday)
-          </{tp}stimulus_metadata>    
-        </example_stimulus>
-        <example_response>
-          <{tp}reasoning>
-          - User is asking for the top story on Hacker News
-          - We need to use the web_request agent to fetch the latest information
-          - The web_request agent is currently closed, so we need to open it first
-          - After opening the agent, we\'ll need to make a web request to Hacker News
-          </{tp}reasoning>
-
-          <{tp}status_update>To get the latest top story from Hacker News, I\'ll need to access the web. I\'m preparing to do that now.</{tp}status_update>
-
-          <{tp}invoke_action agent="global" action="change_agent_status">
-          <{tp}parameter name="agent_name">web_request</{tp}parameter>
-          <{tp}parameter name="new_state">open</{tp}parameter>
-          </{tp}invoke_action>
-        </example_response>
-    </example>
-"""
-]
+                    {
+                        "docstring": "This example shows a stimulus from a chatbot gateway in which a user is asking about the top stories on the website hacker news. The web_request is not yet open, so the change_agent_status action is invoked to open the web_request agent.",
+                        "tag_prefix_placeholder": "{tp}",
+                        "starting_id": "1",
+                        "user_input": "What is the top story on hacker news?",
+                        "metadata": [
+                            "local_time: 2024-11-06 15:58:04 EST-0500 (Wednesday)"
+                        ],
+                        "reasoning": [
+                            "- User is asking for the top story on Hacker News",
+                            "- We need to use the web_request agent to fetch the latest information",
+                            "- The web_request agent is currently closed, so we need to open it first",
+                            "- After opening the agent, we'll need to make a web request to Hacker News"
+                        ],
+                        "response_text": "",
+                        "status_update": "To get the latest top story from Hacker News, I'll need to access the web. I'm preparing to do that now.",
+                        "action": {
+                            "agent": "global",
+                            "name": "change_agent_status",
+                            "parameters": {
+                                "agent_name": "web_request",
+                                "new_state": "open"
+                            }
+                        }
+                    }
+                  ]
 
 
 def get_file_handling_prompt(tp: str) -> str:
@@ -156,7 +152,9 @@ def create_examples(
         String containing all examples with replaced placeholders
     """
     examples = (fixed_examples + agent_examples)[:MAX_SYSTEM_PROMPT_EXAMPLES]
-    return "\n".join([example.replace("{tp}", tp) for example in examples])
+    formatted_examples = format_examples_by_llm_type(examples)
+    
+    return "\n".join([example.replace("{tp}", tp) for example in formatted_examples])
 
 
 def SystemPrompt(info: Dict[str, Any], action_examples: List[str]) -> str:
@@ -413,3 +411,101 @@ you should ask the originator for more information. Include links to the source 
 {context}
 </context>
 """
+
+
+def format_examples_by_llm_type( examples: list, llm_type: str = "anthropic") -> list:
+    """
+    Render examples based on llm type
+    
+    Args:
+        llm_type (str): The type of LLM to render examples for (default: "anthropic")
+        examples (list): List of examples in model-agnostic format
+        
+    Returns:
+        list: List of examples formatted for the specified LLM
+    """
+    formatted_examples = []
+
+    if llm_type == "anthropic":
+        for example in examples:
+            formatted_example = _format_example_for_anthropic(example)
+            formatted_examples.append(formatted_example)
+
+    return formatted_examples
+
+def _format_example_for_anthropic( example: dict) -> str:
+    
+    tag_prefix = example.get("tag_prefix_placeholder", "t123")
+    starting_id = example.get("starting_id", "1")
+    docstring = example.get("docstring", "")
+    user_input = example.get("user_input", "")
+    metadata_lines = example.get("metadata", [])
+    reasoning_lines = example.get("reasoning", [])
+    response_text = example.get("response_text", "")
+    
+    # Start building the XML structure, add the description and user input
+    xml_content = f"""<example>
+        <example_docstring>
+            {docstring}
+        </example_docstring>
+        <example_stimulus>
+            <{tag_prefix}stimulus starting_id="{starting_id}">
+            {user_input}
+            </{tag_prefix}stimulus>
+            <{tag_prefix}stimulus_metadata>
+            """
+    
+    # Add metadata lines
+    for metadata_line in metadata_lines:
+        xml_content += f"{metadata_line}\n"
+    
+    xml_content += f"""</{tag_prefix}stimulus_metadata>
+        </example_stimulus>
+        <example_response>
+            <{tag_prefix}reasoning>
+            """
+    
+    # Add reasoning lines
+    for reasoning_line in reasoning_lines:
+        xml_content += f"{reasoning_line}\n"
+    
+    xml_content += f"""</{tag_prefix}reasoning>
+            {response_text}"""
+    
+    # Add action invocation section
+    if "action" in example:
+        action_data = example.get("action", {})
+        status_update = example.get("status_update", "")
+        agent_name = action_data.get("agent", "")
+        action_name = action_data.get("name", "")
+        
+        xml_content += f"""
+            <{tag_prefix}status_update>{status_update}</{tag_prefix}status_update>
+            <{tag_prefix}invoke_action agent="{agent_name}" action="{action_name}">"""
+        
+        # Handle parameters as dictionary
+        parameter_dict = action_data.get("parameters", {})
+        for param_name, param_value in parameter_dict.items():
+            xml_content += f"""
+            <{tag_prefix}parameter name="{param_name}">"""
+            
+            # Handle parameter names and values (as lists)
+            if isinstance(param_value, list):
+                for line in param_value:
+                    xml_content += f"\n{line}"
+                xml_content += "\n"
+            else:
+                # For simple string values
+                xml_content += f"{param_value}"
+                
+            xml_content += f"</{tag_prefix}parameter>\n"
+    
+        xml_content += f"</{tag_prefix}invoke_action>"
+    
+    # Close the XML structure
+    xml_content += """
+        </example_response>
+    </example>
+    """
+
+    return xml_content


### PR DESCRIPTION
### What is the purpose of this change?
Make examples llm agnostic, so that in the future they can be easily rendered in another format for example markdown for open ai. 

### How is this accomplished?
Before passing in the exampls we convert them based on the given llm_type.


### Anything reviews should focus on/be aware of?
