### PR TITLE
Update documentation for web UI to use 127.0.0.1 instead of localhost

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ To get started with Solace Agent Mesh, follow these steps:
 
 5. **Connect to the Web Interface**:
 
-   Open the web interface at [http://localhost:5001](http://localhost:5001) or with the port specified during `init`.
+   Open the web interface at [http://127.0.0.1:5001](http://127.0.0.1:5001) or with the port specified during `init`.
 
 6. **Send a REST Request**:
 

--- a/docs/docs/documentation/getting-started/quick-start.md
+++ b/docs/docs/documentation/getting-started/quick-start.md
@@ -84,7 +84,7 @@ To learn more about the other CLI commands, see the [CLI documentation](../conce
 
 ## Interacting with SAM
 
-You can use different gateway interfaces to communicate with the system such REST, Web UI, Slack, MS Teams, etc. To keep it simple for this demo, we will use the browser UI. To connect to the browser UI, open a browser and navigate to `http://localhost:5001`. If you chose another port during the `init` step, use that port instead.
+You can use different gateway interfaces to communicate with the system such REST, Web UI, Slack, MS Teams, etc. To keep it simple for this demo, we will use the browser UI. To connect to the browser UI, open a browser and navigate to `http://127.0.0.1:5001`. If you chose another port during the `init` step, use that port instead.
 
 This will provide a simple chat interface where you can interact with the Agent Mesh. Try some commands like `What is the capital of France?` or `Give me a diagram of the oAuth process`.
 

--- a/docs/docs/documentation/tutorials/sql-database.md
+++ b/docs/docs/documentation/tutorials/sql-database.md
@@ -89,7 +89,7 @@ The `-e` flag loads environment variables from the `.env` file, and the `-b` fla
 
 ## Interacting with the Database
 
-Once SAM is running, you can interact with the ABC Coffee database through the web interface at http://localhost:5001.
+Once SAM is running, you can interact with the ABC Coffee database through the web interface at http://127.0.0.1:5001.
 
 You can ask natural language questions about the ABC Coffee Co. database, such as:
 


### PR DESCRIPTION
### What is the purpose of this change?
This is being done because we recently switched the Web UI host to 127.0.0.1 from localhost, this was done because in rare cases there would be CORS errors. This is the documentation update for that change. Reference: #31 

### How is this accomplished?

### Anything reviews should focus on/be aware of?
