### PR TITLE
DATAGO-96202: run npm builds before hatch setup

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -16,7 +16,7 @@ permissions:
 
 jobs:
   ci:
-    uses: SolaceDev/solace-public-workflows/.github/workflows/hatch_ci.yml@main
+    uses: SolaceDev/solace-public-workflows/.github/workflows/hatch_ci.yml@npm_builds
     with:
       min-python-version: "3.11"
       whitesource_product_name: "solace-agent-mesh"


### PR DESCRIPTION
### What is the purpose of this change?

### How is this accomplished?

### Anything reviews should focus on/be aware of?
