### PR TITLE
DATAGO-98396: relax min python requirement to 3.10.16

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -18,7 +18,7 @@ jobs:
   ci:
     uses: SolaceDev/solace-public-workflows/.github/workflows/hatch_ci.yml@main
     with:
-      min-python-version: "3.11"
+      min-python-version: "3.10"
       max-python-version: "3.13"
       whitesource_product_name: "solace-agent-mesh"
       whitesource_config_file: "wss-unified-agent.config"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -81,7 +81,5 @@ lint.ignore = ["F401", "E731"]
 installer = "pip"
 
 
-
-
 [[tool.hatch.envs.hatch-test.matrix]]
 python = ["3.10", "3.12"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -81,5 +81,7 @@ lint.ignore = ["F401", "E731"]
 installer = "pip"
 
 
+
+
 [[tool.hatch.envs.hatch-test.matrix]]
 python = ["3.10", "3.12"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -82,4 +82,4 @@ installer = "pip"
 
 
 [[tool.hatch.envs.hatch-test.matrix]]
-python = ["3.10", "3.12"]
+python = ["3.10", "3.13"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,9 +12,10 @@ authors = [
 ]
 description = "Solace Agent Mesh is an EDA AI-first platform powered by Solace"
 readme = "README.md"
-requires-python = ">=3.11"
+requires-python = ">=3.10.16"
 classifiers = [
     "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
@@ -81,4 +82,4 @@ installer = "pip"
 
 
 [[tool.hatch.envs.hatch-test.matrix]]
-python = ["3.11", "3.12", "3.13"]
+python = ["3.10", "3.12"]


### PR DESCRIPTION
### What is the purpose of this change?
- set min and max versions correctly 3.10.16 and 3.13

