### PR TITLE
AI-660: Agent registry must support expiration and config updates

### DIFF
--- a/configs/orchestrator.yaml
+++ b/configs/orchestrator.yaml
@@ -50,7 +50,7 @@ flows:
         component_base_path: .
         component_module: src.orchestrator.components.orchestrator_register_component
         component_config:
-          agent_ttl_ms: 60000000
+          agent_ttl_ms: 60000
         component_input:
           source_expression: input.payload
 

--- a/src/orchestrator/components/orchestrator_action_manager_timeout_component.py
+++ b/src/orchestrator/components/orchestrator_action_manager_timeout_component.py
@@ -30,6 +30,10 @@ class OrchestratorActionManagerTimeoutComponent(ComponentBase):
         # Need to go through all the active action_requests and check if any of them have timed out
         timeout_events = self.action_manager.do_timeout_check()
 
+        # Also check on agents
+        orchestrator_state = self.kv_store_get("orchestrator_state")
+        orchestrator_state.age_out_agents()
+
         # Now turn these into messages
         messages = []
         for event in timeout_events:

--- a/src/orchestrator/orchestrator_main.py
+++ b/src/orchestrator/orchestrator_main.py
@@ -46,8 +46,9 @@ class OrchestratorState:
         with self._lock:
             agent_name = agent.get("agent_name")
             agent["state"] = "closed"
-            if agent_name not in self.registered_agents:
-                self.registered_agents[agent_name] = agent
+
+            # Always update the agent information
+            self.registered_agents[agent_name] = agent
 
             # Reset its TTL
             self.registered_agents[agent_name][
@@ -145,7 +146,9 @@ class OrchestratorState:
 
         for agent_name, agent in self.registered_agents.items():
             actions = agent.get("actions", [])
-            filtered_actions = middleware_service.get("filter_action")(user_properties, actions)
+            filtered_actions = middleware_service.get("filter_action")(
+                user_properties, actions
+            )
 
             if filtered_actions:
                 agent_state = self.get_agent_state(session_id).get(agent_name, {})


### PR DESCRIPTION
### What is the purpose of this change?

1. When agent registration messages have not be received for 60s, the agent must be removed from the list of available agents
2. If an agent of the same name registers with different configuration, then the new config must be used. This will happen on upgrades and during dev work

### How is this accomplished?

1. The agent age out method and tracking all already existed. We just needed to hook a call into it in a place where it would be called periodically. This was done in the action response timer handler
2. The orchestrator config file had a very long timeout (60k seconds). This was changed to 60s, which means 4 registrations would need to be missed before removing the agent
3. Previously, we would not update agent configuration when registering the agent. Now we always take the config from the last registration, which will allow agents to be upgraded and changed


