### PR TITLE
AI-663: Add ability to overwrite env vars in .env during sam init

### DIFF
--- a/cli/commands/add/gateway.py
+++ b/cli/commands/add/gateway.py
@@ -107,11 +107,25 @@ def _update_gateway_yaml(yaml_string, interface_gateway_config):
 
         # Inject long-term memory before history_policy
         if history_config.get("long_term_memory", {}).get("enabled", False):
-            llm_config = f"\n        {''.join(f'{key}: {value}\n        ' for key, value in history_config['long_term_memory'].get('llm_config', {}).items())}\n" \
-                if history_config["long_term_memory"].get("llm_config", {}) else " {} \n"
+            # Build llm_config string
+            llm_config_items = history_config['long_term_memory'].get('llm_config', {})
+            if llm_config_items:
+                llm_config_parts = []
+                for key, value in llm_config_items.items():
+                    llm_config_parts.append(f"{key}: {value}")
+                llm_config = "\n        " + "\n        ".join(llm_config_parts) + "\n"
+            else:
+                llm_config = " {} \n"
             
-            store_config = f"\n        {''.join(f'{key}: {value}\n        ' for key, value in history_config['long_term_memory'].get('store_config', {}).items())}\n" \
-                if history_config["long_term_memory"].get("store_config", {}) else " {} \n"
+            # Build store_config string
+            store_config_items = history_config['long_term_memory'].get('store_config', {})
+            if store_config_items:
+                store_config_parts = []
+                for key, value in store_config_items.items():
+                    store_config_parts.append(f"{key}: {value}")
+                store_config = "\n        " + "\n        ".join(store_config_parts) + "\n"
+            else:
+                store_config = " {} \n"
             long_term_yaml = (
                 'long_term_memory: true\n'
                 '    long_term_memory_config:\n'


### PR DESCRIPTION
## What is the purpose of this change?

This PR adds the capability to overwrite environment variables in .env files during the sam init command

## How is this accomplished?

1. Added capability to overwrite environment variables in .env files to prevent duplicating environment variables

## Anything reviews should focus on/be aware of?
