### PR TITLE
FIX: Update compatibility for Python 3.10 environment

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -98,4 +98,4 @@ installer = "pip"
 
 
 [[tool.hatch.envs.hatch-test.matrix]]
-python = ["3.11", "3.12", "3.13"]
+python = ["3.10", "3.11", "3.12", "3.13"]


### PR DESCRIPTION
## What is the purpose of this change?

The purpose of this change is to ensure compatibility with Python 3.10 environments, which might have been previously overlooked or unsupported in the testing configuration.

## How is this accomplished?

- Quick fix for python 3.10 env

The modification involves updating the testing matrix in the project configuration to include Python 3.10.

## Anything reviews should focus on/be aware of?

Ensure that adding Python 3.10 to the testing matrix does not inadvertently affect existing workflows or compatibility checks.