### PR TITLE
AI-657: Fix localhost CORS bug with web ui

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ To get started with Solace Agent Mesh, follow these steps:
 
 5. **Connect to the Web Interface**:
 
-   Open the web interface at [http://127.0.0.1:5001](http://127.0.0.1:5001) or with the port specified during `init`.
+   Open the web interface at [http://localhost:5001](http://localhost:5001) or with the port specified during `init`.
 
 6. **Send a REST Request**:
 

--- a/cli/commands/init/init.py
+++ b/cli/commands/init/init.py
@@ -43,7 +43,7 @@ default_options = {
     "rest_api_gateway_name": "rest-api",
     "webui_enabled": True,
     "webui_listen_port": "5001",
-    "webui_host": "127.0.0.1"
+    "webui_host": "localhost"
 }
 """
 Default options for the init command.

--- a/docs/docs/documentation/getting-started/quick-start.md
+++ b/docs/docs/documentation/getting-started/quick-start.md
@@ -85,7 +85,7 @@ To learn more about the other CLI commands, see the [CLI documentation](../conce
 
 ## Interacting with SAM
 
-You can use different gateway interfaces to communicate with the system such as REST, Web UI, Slack, MS Teams, etc. To keep it simple for this demo, we will use the browser UI. To connect to the browser UI, open a browser and navigate to `http://127.0.0.1:5001`. If you chose another port during the `init` step, use that port instead.
+You can use different gateway interfaces to communicate with the system such as REST, Web UI, Slack, MS Teams, etc. To keep it simple for this demo, we will use the browser UI. To connect to the browser UI, open a browser and navigate to `http://localhost:5001`. If you chose another port during the `init` step, use that port instead.
 
 This will provide a simple chat interface where you can interact with the Agent Mesh. Try some commands like `Suggest some good outdoor activities in London given the season and current weather conditions.` or `Generate a mermaid diagram of the OAuth login flow`.
 

--- a/docs/docs/documentation/tutorials/sql-database.md
+++ b/docs/docs/documentation/tutorials/sql-database.md
@@ -90,7 +90,7 @@ The `-e` flag loads environment variables from the `.env` file, and the `-b` fla
 
 ## Interacting with the Database
 
-After Solace Agent Mesh is running, you can interact with the ABC Coffee database through the web interface at `http://127.0.0.1:5001`.
+After Solace Agent Mesh is running, you can interact with the ABC Coffee database through the web interface at `http://localhost:5001`.
 
 You can ask natural language questions about the ABC Coffee Co. database, such as:
 

--- a/docs/docs/documentation/user-guide/advanced/advanced-configuration/web-ui.md
+++ b/docs/docs/documentation/user-guide/advanced/advanced-configuration/web-ui.md
@@ -42,7 +42,9 @@ export WEBUI_FRONTEND_COLLECT_FEEDBACK=true
 export SOLACE_BROKER_REST_MESSAGING_URL="your-rest-messaging-url"
 export SOLACE_BROKER_BASIC_AUTH="your-auth-credentials"
 ```
+
 These settings can also be defined in an .env file for easier management.
+
 ```
 WEBUI_PORT=5001
 WEBUI_HOST=127.0.0.1

--- a/docs/docs/documentation/user-guide/advanced/advanced-configuration/web-ui.md
+++ b/docs/docs/documentation/user-guide/advanced/advanced-configuration/web-ui.md
@@ -43,7 +43,7 @@ export SOLACE_BROKER_REST_MESSAGING_URL="your-rest-messaging-url"
 export SOLACE_BROKER_BASIC_AUTH="your-auth-credentials"
 ```
 
-These settings can also be defined in an .env file for easier management.
+These settings can also be defined in an `.env` file for easier management.
 
 ```
 WEBUI_PORT=5001

--- a/docs/docs/documentation/user-guide/advanced/advanced-configuration/web-ui.md
+++ b/docs/docs/documentation/user-guide/advanced/advanced-configuration/web-ui.md
@@ -15,6 +15,9 @@ Setting `WEBUI_FRONTEND_COLLECT_FEEDBACK` to `true` requires additional configur
 | Environment Variable | Description |
 |----------------------|-------------|
 | `WEBUI_ENABLED` | Set to `true` to enable Web UI. |
+| `WEBUI_PORT` | Port number for the Web UI (default: 5001). |
+| `WEBUI_HOST` | Host address for the Web UI (default: localhost). |
+| `WEBUI_FRONTEND_URL` | Full URL where the frontend will be accessed from. Used for CORS policy configuration (e.g., http://localhost:5001). |
 | `WEBUI_FRONTEND_COLLECT_FEEDBACK` | Set to `true` to enable feedback collection (requires additional feedback-related variables). |
 | `WEBUI_FRONTEND_WELCOME_MESSAGE` | Custom welcome message (leave empty for default). |
 
@@ -32,14 +35,18 @@ To enable feedback collection, set `WEBUI_FRONTEND_COLLECT_FEEDBACK=True`. When 
 To configure these settings, set the corresponding environment variables in your deployment. Example:
 
 ```sh
+export WEBUI_PORT=5001
+export WEBUI_HOST=127.0.0.1
+export WEBUI_FRONTEND_URL=http://127.0.0.1:5001
 export WEBUI_FRONTEND_COLLECT_FEEDBACK=true
 export SOLACE_BROKER_REST_MESSAGING_URL="your-rest-messaging-url"
 export SOLACE_BROKER_BASIC_AUTH="your-auth-credentials"
 ```
-
-These settings can also be defined in an `.env` file for easier management.
-
-```env
+These settings can also be defined in an .env file for easier management.
+```
+WEBUI_PORT=5001
+WEBUI_HOST=127.0.0.1
+WEBUI_FRONTEND_URL=http://127.0.0.1:5001
 WEBUI_FRONTEND_COLLECT_FEEDBACK=true
 SOLACE_BROKER_REST_MESSAGING_URL=your-messaging-url
 SOLACE_BROKER_BASIC_AUTH=your-auth-credentials


### PR DESCRIPTION
### What is the purpose of this change?
This is the documentation update that goes along with this PR https://github.com/SolaceLabs/solace-ai-connector-web/pull/16. It also updates the default host for the web ui to be `localhost`

### How is this accomplished?

### Anything reviews should focus on/be aware of?
