### PR TITLE
AI-709: Use .env file by default and introduce new option -u

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,10 +82,10 @@ To get started with Solace Agent Mesh, follow these steps:
 4. **Run the Project**:
 
    ```sh
-   solace-agent-mesh run -e
+   solace-agent-mesh run
    ```
 
-   _(Use `-eb` to combine build and run steps.)_
+   _(Use `-b` to combine build and run steps.)_
 
 5. **Connect to the Web Interface**:
 

--- a/cli/commands/run.py
+++ b/cli/commands/run.py
@@ -21,7 +21,7 @@ FILES_TO_EXCLUDE = []
 
 
 def run_command(
-    use_env, config_files, exclude_files, quick_build, ignore_build, force_build
+    use_system_env, config_files, exclude_files, quick_build, ignore_build, force_build
 ):
     """Run the Solace Agent Mesh application."""
 
@@ -34,7 +34,7 @@ def run_command(
 
     click.echo("Running Solace Agent Mesh application")
 
-    if use_env:
+    if not use_system_env:
         try:
             from dotenv import load_dotenv
 

--- a/cli/main.py
+++ b/cli/main.py
@@ -66,11 +66,11 @@ def build(y, no_init):
 
 @cli.command()
 @click.option(
-    "-e",
-    "--use-env",
+    "-u",
+    "--use-system-env",
     default=False,
     is_flag=True,
-    help="Loads the environment variables file defined in the config.",
+    help="Use only system environment variables (ignore environment variables defined in the config).",
 )
 @click.option(
     "-s",
@@ -100,13 +100,13 @@ def build(y, no_init):
     is_flag=True,
     help="Runs the build command first regardless of the build directory. Mutually exclusive with --ignore-build.",
 )
-def run(use_env, files, skip, quick_build, ignore_build, force_build):
+def run(use_system_env, files, skip, quick_build, ignore_build, force_build):
     """Run the Solace Agent Mesh application.
 
     FILES: Config files to run. Uses all the yaml files in the build directory if not provided.
     """
     return run_command(
-        use_env, list(files), list(skip), quick_build, ignore_build, force_build
+        use_system_env, list(files), list(skip), quick_build, ignore_build, force_build
     )
 
 

--- a/docs/docs/documentation/concepts/cli.md
+++ b/docs/docs/documentation/concepts/cli.md
@@ -136,8 +136,10 @@ To run the SAM application, use the `run` command.
 sam run [OPTIONS] [FILES]...
 ```
 
-:::tip[Load environment variables]
-Use the `-e` or `--use-env` option to load environment variables from the configuration file.
+:::info[Environment variables]
+The `sam run` command automatically loads environment variables from your configuration file (typically a `.env` file at the project root) by default.
+
+If you want to use your system's environment variables instead, you can add the `-u` or `--use-system-env` option.
 :::
 
 :::tip[none to run]
@@ -153,12 +155,12 @@ Or, you can only run the provided files by providing them as arguments. You migh
 For example:
 
 ```sh
-solace-agent-mesh run -e build/configs/config1.yaml build/configs/config2.yaml
+solace-agent-mesh run build/configs/config1.yaml build/configs/config2.yaml
 ```
 
 ##### Options:
 
-- `-e, --use-env` – Loads environment variables from the configuration for execution.
+- `-u, --use-system-env` – Loads environment variables from your system instead of from the configuration file.
 - `-s, --skip TEXT` – Skips specified files during execution.
 - `-q, --quick-build` – Uses default behavior for `init` and `build` steps.
 - `-i, --ignore-build` – Skips `build` if the build directory is missing.

--- a/docs/docs/documentation/deployment/debugging.md
+++ b/docs/docs/documentation/deployment/debugging.md
@@ -15,7 +15,7 @@ Running only the necessary components in isolation can help pinpoint issues. The
 For example:
 
 ```bash
-sam run -e build/configs/agent_my_tool_1.yaml build/configs/agent_my_tool_2.yaml
+sam run build/configs/agent_my_tool_1.yaml build/configs/agent_my_tool_2.yaml
 ```
 
 This command runs only the agents defined in `agent_my_tool_1.yaml` and `agent_my_tool_2.yaml`, reducing noise from unrelated components.
@@ -61,7 +61,7 @@ If you're using VSCode, configure debugging in `.vscode/launch.json`:
       "envFile": "${workspaceFolder}/.env",
       "args": [
         "run",
-        "-eb",
+        "-b",
         "build/configs/orchestrator.yaml",
         "build/configs/service_llm.yaml",
         "build/configs/service_embedding.yaml",

--- a/docs/docs/documentation/deployment/deploy.md
+++ b/docs/docs/documentation/deployment/deploy.md
@@ -7,10 +7,10 @@ sidebar_position: 10
 
 ## Development
 
-In a development environment, you can use the Solace Agent Mesh CLI to run the project as a single application. Store environment variables in a `.env` file at the project root and load them at runtime using the `-e` flag:
+In a development environment, you can use the Solace Agent Mesh CLI to run the project as a single application. By default, environment variables are loaded from your configuration file (typically a `.env` file at the project root):
 
 ```bash
-sam run -eb
+sam run -b
 ```
 
 :::note
@@ -57,7 +57,7 @@ RUN chown -R samapp:samapp /app /tmp
 USER samapp
 
 # Default entry point
-ENTRYPOINT ["solace-agent-mesh", "run"]
+ENTRYPOINT ["solace-agent-mesh", "run", "--use-system-env"]
 
 # Default command for running multiple configurations
 CMD [
@@ -97,7 +97,7 @@ spec:
           - secretRef:
               name: solace-agent-mesh-secrets # Configure secrets in a Kubernetes Secret
 
-          command: ["solace-agent-mesh", "run"]
+          command: ["solace-agent-mesh", "run", "--use-system-env"]
           args:
             - "build/configs/orchestrator.yaml"
             - "build/configs/service_llm.yaml"

--- a/docs/docs/documentation/getting-started/quick-start.md
+++ b/docs/docs/documentation/getting-started/quick-start.md
@@ -70,15 +70,15 @@ You must run the `solace-agent-mesh` commands at the root directory of your proj
 To run the project, you can use the `run` command to execute all the components in a single, multi-threaded application. It's possible to split the components into separate processes. See the [deployment](../deployment/deploy.md) page for more information.
 
 ```sh
-solace-agent-mesh run -e
+solace-agent-mesh run
 ```
 
 :::tip
-You can use `-e` flag to load the local `.env` file when running the project.
+Environment variables are loaded from your configuration file (typically a `.env` file at the project root) by default. To use system environment variables instead, use the `-u` or `--use-system-env` option.
 :::
 
 :::tip
-You can combine the build and run steps by using `solace-agent-mesh run -eb`.
+You can combine the build and run steps by using `solace-agent-mesh run -b`.
 :::
 
 To learn more about the other CLI commands, see the [CLI documentation](../concepts/cli.md).

--- a/docs/docs/documentation/tutorials/event-mesh-gateway.md
+++ b/docs/docs/documentation/tutorials/event-mesh-gateway.md
@@ -111,7 +111,7 @@ No customization is required for `./configs/gateways/jira/gateway.yaml`
 Now, you can build and run the Event Mesh Gateway:
 
 ```sh
-sam run -be
+sam run -b
 ```
 
 For more information, see [Solace Agent Mesh CLI](../concepts/cli.md).

--- a/docs/docs/documentation/tutorials/mcp-integration.md
+++ b/docs/docs/documentation/tutorials/mcp-integration.md
@@ -73,7 +73,7 @@ Finally, add `mcp_server` to the plugin agents list in the `solace-agent-mesh.ya
 Now, you can build and run the plugin:
 
 ```sh
-sam run -be
+sam run -b
 ```
 
 For more information, see [Solace Agent Mesh CLI](../concepts/cli.md).

--- a/docs/docs/documentation/tutorials/slack-integration.md
+++ b/docs/docs/documentation/tutorials/slack-integration.md
@@ -144,7 +144,7 @@ After configuring your Slack App, the next step is to add the Slack interface an
 Launch the interface and gateway with:
 
 ```sh
-sam run -be
+sam run -b
 ```
 
 For detailed information about available SAM CLI commands, see [Solace Agent Mesh CLI](../concepts/cli.md).

--- a/docs/docs/documentation/tutorials/sql-database.md
+++ b/docs/docs/documentation/tutorials/sql-database.md
@@ -83,10 +83,11 @@ SQLite stores the database in a local file and doesn't require a username or pas
 Now, you can start Solace Agent Mesh with your new SQL database agent:
 
 ```sh
-sam run -eb
+sam run -b
 ```
-
-The `-e` flag loads environment variables from the `.env` file, and the `-b` flag will rebuild the sam config files
+:::info
+The `-b` option will rebuild the Solace Agent Mesh config files.
+:::
 
 ## Interacting with the Database
 

--- a/docs/docs/documentation/user-guide/custom-agents.md
+++ b/docs/docs/documentation/user-guide/custom-agents.md
@@ -451,7 +451,7 @@ ENTITY_TYPES="Name, Company, Query"
 Now, you can build and run the agent:
 
 ```sh
-sam run -be
+sam run -b
 ```
 
 For more information, see [Solace Agent Mesh CLI](../concepts/cli.md).

--- a/docs/docs/documentation/user-guide/custom-gateways.md
+++ b/docs/docs/documentation/user-guide/custom-gateways.md
@@ -542,7 +542,7 @@ class DirWatcherOutput(DirWatcherBase):
 To build and run the gateway, use the following command:
 
 ```bash
-solace-agent-mesh run
+solace-agent-mesh run -b
 ```
 
 This command builds and runs the gateway in one step. Alternatively, you can execute these steps separately.

--- a/docs/docs/documentation/user-guide/custom-gateways.md
+++ b/docs/docs/documentation/user-guide/custom-gateways.md
@@ -542,7 +542,7 @@ class DirWatcherOutput(DirWatcherBase):
 To build and run the gateway, use the following command:
 
 ```bash
-solace-agent-mesh run -eb
+solace-agent-mesh run
 ```
 
 This command builds and runs the gateway in one step. Alternatively, you can execute these steps separately.
@@ -654,5 +654,5 @@ This creates the gateway with the interface configurations.
 Now, you can build and run the SAM project with the new gateway:
 
 ```bash
-solace-agent-mesh run -eb
+solace-agent-mesh run -b
 ```


### PR DESCRIPTION
### What is the purpose of this change?
This changes the `sam run` command to utilize the `.env` file by default. For deployment purposes where users might prefer using system environment variables over the .env file, there is a new option `-u` or `--use-system-env` which will prefer the system environment over the .env file.
 In cases where `sam run` is called but there is no `.env` file we already automatically use the system environment, I have made no changes to this behavior.
 
This PR also contains all the documentation changes for the new option + removing references to the `-e` option

### How is this accomplished?
Changing the run command.

### Anything reviews should focus on/be aware of?
Reviewers should ensure documentation is updated properly and the new option works as expected
