### PR TITLE
AI-696: Adjust the orchestrator to work well with Gemini 2.5

### DIFF
--- a/src/common/utils.py
+++ b/src/common/utils.py
@@ -415,9 +415,14 @@ def parse_orchestrator_response(response, last_chunk=False, tag_prefix=""):
 
         elif in_invoke_action and f"<{tp}parameter" in line:
             if current_param_name:
-                current_action["parameters"][current_param_name] = "\n".join(
-                    current_param_value
-                ).strip()
+                param_value = "\n".join(current_param_value).strip()
+                
+                # Remove CDATA wrapper if present
+                cdata_match = re.match(r'\s*<!\[CDATA\[(.*?)\]\]>\s*$', param_value, re.DOTALL)
+                if cdata_match:
+                    param_value = cdata_match.group(1)
+                
+                current_action["parameters"][current_param_name] = param_value
                 current_param_value = []
 
             param_name_match = re.search(r'name\s*=\s*[\'"](\w+)[\'"]', line)
@@ -436,15 +441,16 @@ def parse_orchestrator_response(response, last_chunk=False, tag_prefix=""):
 
                 # Check if parameter closes on same line
                 if f"</{tp}parameter>" in line:
-                    current_action["parameters"][current_param_name] = "\n".join(
-                        current_param_value
-                    ).strip()
+                    param_value = "\n".join(current_param_value).strip()
+                    
+                    # Remove CDATA wrapper if present
+                    cdata_match = re.match(r'\s*<!\[CDATA\[(.*?)\]\]>\s*$', param_value, re.DOTALL)
+                    if cdata_match:
+                        param_value = cdata_match.group(1)
+                    
+                    current_action["parameters"][current_param_name] = param_value
                     current_param_name = None
                     current_param_value = []
-                    # <inst>
-                    # The parameter value might start with \s*<![CDATA[ and end with ]]>
-                    # so we need to remove that if it is there
-                    # </inst>
 
                     if "parameter" in open_tags:
                         open_tags.remove("parameter")
@@ -462,9 +468,14 @@ def parse_orchestrator_response(response, last_chunk=False, tag_prefix=""):
                 content_before_close = re.sub(f"</{tp}parameter>.*", "", line)
                 if content_before_close.strip():
                     current_param_value.append(content_before_close.strip())
-                current_action["parameters"][current_param_name] = "\n".join(
-                    current_param_value
-                ).strip()
+                param_value = "\n".join(current_param_value).strip()
+                
+                # Remove CDATA wrapper if present
+                cdata_match = re.match(r'\s*<!\[CDATA\[(.*?)\]\]>\s*$', param_value, re.DOTALL)
+                if cdata_match:
+                    param_value = cdata_match.group(1)
+                
+                current_action["parameters"][current_param_name] = param_value
                 current_param_name = None
                 current_param_value = []
                 if "parameter" in open_tags:

--- a/src/common/utils.py
+++ b/src/common/utils.py
@@ -272,10 +272,15 @@ def parse_orchestrator_response(response, last_chunk=False, tag_prefix=""):
         return parsed_data
         
     # Check if the response is wrapped in ```xml tags and remove them
+    # Only do this for the first chunk (when we see the start of the XML block)
     if response.lstrip().startswith("```xml"):
-        # Extract content between ```xml and the last ```
+        # Extract content after the ```xml
         response = response.lstrip().split("```xml", 1)[1]
-        response = response.rsplit("```", 1)[0]
+        
+        # Only remove the trailing ``` if this is the last chunk
+        # Otherwise we might cut off content in the middle of the response
+        if last_chunk and "```" in response:
+            response = response.rsplit("```", 1)[0]
 
     if not tp:
         # Learn the tag prefix from the response

--- a/src/common/utils.py
+++ b/src/common/utils.py
@@ -610,18 +610,28 @@ def match_solace_topic(subscription: str, topic: str) -> bool:
 
 def remove_cdata_wrapper(param_value):
     """
-    Removes CDATA wrapper from a parameter value if present.
+    Removes CDATA wrapper from a parameter value if present and resolves XML entities.
 
     Parameters:
     - param_value (str): The parameter value that might contain a CDATA wrapper
+                         and XML entities like &gt;, &lt;, etc.
 
     Returns:
-    - str: The parameter value with CDATA wrapper removed if it was present
+    - str: The parameter value with CDATA wrapper removed and XML entities resolved
     """
     if isinstance(param_value, str):
+        # Remove CDATA wrapper if present
         cdata_match = re.match(r"\s*<!\[CDATA\[(.*?)\]\]>\s*$", param_value, re.DOTALL)
         if cdata_match:
-            return cdata_match.group(1)
+            param_value = cdata_match.group(1)
+        
+        # Resolve XML entities
+        param_value = param_value.replace("&lt;", "<")
+        param_value = param_value.replace("&gt;", ">")
+        param_value = param_value.replace("&amp;", "&")
+        param_value = param_value.replace("&quot;", "\"")
+        param_value = param_value.replace("&apos;", "'")
+        
     return param_value
 
 

--- a/src/common/utils.py
+++ b/src/common/utils.py
@@ -273,12 +273,16 @@ def parse_orchestrator_response(response, last_chunk=False, tag_prefix=""):
     # Check if the response is wrapped in ```language tags and remove them
     # Only do this for the first chunk (when we see the start of the code block)
     stripped_response = response.lstrip()
-    code_block_match = re.match(r'^```(\w*)', stripped_response)
+    code_block_match = re.match(r"^```(\w*)", stripped_response)
     if code_block_match:
         # Extract content after the ```language
         language = code_block_match.group(1)
         response = stripped_response.split(f"```{language}", 1)[1]
-        
+
+        # <inst>
+        # Only remove the ``` if it is the first chunk and right at the end of the response
+        # </inst>
+
         # Only remove the trailing ``` if this is the last chunk
         # Otherwise we might cut off content in the middle of the response
         if last_chunk and "```" in response:

--- a/src/common/utils.py
+++ b/src/common/utils.py
@@ -441,6 +441,11 @@ def parse_orchestrator_response(response, last_chunk=False, tag_prefix=""):
                     ).strip()
                     current_param_name = None
                     current_param_value = []
+                    # <inst>
+                    # The parameter value might start with \s*<![CDATA[ and end with ]]>
+                    # so we need to remove that if it is there
+                    # </inst>
+
                     if "parameter" in open_tags:
                         open_tags.remove("parameter")
                 elif line.endswith("/>"):

--- a/src/common/utils.py
+++ b/src/common/utils.py
@@ -284,9 +284,9 @@ def parse_orchestrator_response(response, last_chunk=False, tag_prefix=""):
     stripped_response = response.lstrip()
     code_block_match = re.match(r"^```(\w*\s*\n)", stripped_response)
     if code_block_match:
-        print("found code block:", language)
         # Extract content after the ```language
         language = code_block_match.group(1)
+        print("found code block:", language)
         response = stripped_response.split(f"```{language}", 1)[1]
 
         # Only remove the trailing ``` if it's at the end of the response

--- a/src/common/utils.py
+++ b/src/common/utils.py
@@ -279,13 +279,9 @@ def parse_orchestrator_response(response, last_chunk=False, tag_prefix=""):
         language = code_block_match.group(1)
         response = stripped_response.split(f"```{language}", 1)[1]
 
-        # <inst>
-        # Only remove the ``` if it is the first chunk and right at the end of the response
-        # </inst>
-
-        # Only remove the trailing ``` if this is the last chunk
-        # Otherwise we might cut off content in the middle of the response
-        if last_chunk and "```" in response:
+        # Only remove the trailing ``` if it's at the end of the response
+        # This prevents cutting off content in the middle of a response
+        if "```" in response and response.strip().endswith("```"):
             response = response.rsplit("```", 1)[0]
 
     if not tp:

--- a/src/common/utils.py
+++ b/src/common/utils.py
@@ -270,16 +270,15 @@ def parse_orchestrator_response(response, last_chunk=False, tag_prefix=""):
     if not response:
         return parsed_data
 
-    # <inst>
-    # Change this check to remove any ```\w+``` tags that are around the response
-    # </inst>
-
-    # Check if the response is wrapped in ```xml tags and remove them
-    # Only do this for the first chunk (when we see the start of the XML block)
-    if response.lstrip().startswith("```xml"):
-        # Extract content after the ```xml
-        response = response.lstrip().split("```xml", 1)[1]
-
+    # Check if the response is wrapped in ```language tags and remove them
+    # Only do this for the first chunk (when we see the start of the code block)
+    stripped_response = response.lstrip()
+    code_block_match = re.match(r'^```(\w*)', stripped_response)
+    if code_block_match:
+        # Extract content after the ```language
+        language = code_block_match.group(1)
+        response = stripped_response.split(f"```{language}", 1)[1]
+        
         # Only remove the trailing ``` if this is the last chunk
         # Otherwise we might cut off content in the middle of the response
         if last_chunk and "```" in response:

--- a/src/common/utils.py
+++ b/src/common/utils.py
@@ -267,6 +267,14 @@ def parse_orchestrator_response(response, last_chunk=False, tag_prefix=""):
         "send_last_status_update": False,
     }
 
+    # <inst>
+    # This parser is receiving LLM output and that output contains XML tags. Sometimes
+    # the LLM puts ```xml around the entire response, so we need to remove that. Note
+    # that we only want to do that if it is at the beginning of the response and then remember
+    # to remove the ``` at the end of the response. Also note that the trailing ``` might be
+    # split across chunks
+    # </inst>
+
     if not response:
         return parsed_data
 

--- a/src/common/utils.py
+++ b/src/common/utils.py
@@ -267,16 +267,15 @@ def parse_orchestrator_response(response, last_chunk=False, tag_prefix=""):
         "send_last_status_update": False,
     }
 
-    # <inst>
-    # This parser is receiving LLM output and that output contains XML tags. Sometimes
-    # the LLM puts ```xml around the entire response, so we need to remove that. Note
-    # that we only want to do that if it is at the beginning of the response and then remember
-    # to remove the ``` at the end of the response. Also note that the trailing ``` might be
-    # split across chunks
-    # </inst>
-
+    # Check if the response is wrapped in ```xml tags and remove them
     if not response:
         return parsed_data
+        
+    # Check if the response is wrapped in ```xml tags and remove them
+    if response.lstrip().startswith("```xml"):
+        # Extract content between ```xml and the last ```
+        response = response.lstrip().split("```xml", 1)[1]
+        response = response.rsplit("```", 1)[0]
 
     if not tp:
         # Learn the tag prefix from the response

--- a/src/common/utils.py
+++ b/src/common/utils.py
@@ -461,7 +461,7 @@ def parse_orchestrator_response(response, last_chunk=False, tag_prefix=""):
                 if f"</{tp}parameter>" in line:
                     param_value = "\n".join(current_param_value)
                     current_action["parameters"][current_param_name] = (
-                        remove_cdata_wrapper(param_value)
+                        clean_parameter_value(param_value)
                     )
                     current_param_name = None
                     current_param_value = []

--- a/src/common/utils.py
+++ b/src/common/utils.py
@@ -438,7 +438,7 @@ def parse_orchestrator_response(response, last_chunk=False, tag_prefix=""):
         elif in_invoke_action and f"<{tp}parameter" in line:
             if current_param_name:
                 param_value = "\n".join(current_param_value)
-                current_action["parameters"][current_param_name] = remove_cdata_wrapper(
+                current_action["parameters"][current_param_name] = clean_parameter_value(
                     param_value
                 )
                 current_param_value = []
@@ -483,7 +483,7 @@ def parse_orchestrator_response(response, last_chunk=False, tag_prefix=""):
                 if content_before_close:
                     current_param_value.append(content_before_close)
                 param_value = "\n".join(current_param_value)
-                current_action["parameters"][current_param_name] = remove_cdata_wrapper(
+                current_action["parameters"][current_param_name] = clean_parameter_value(
                     param_value
                 )
                 current_param_name = None
@@ -608,16 +608,18 @@ def match_solace_topic(subscription: str, topic: str) -> bool:
     )
 
 
-def remove_cdata_wrapper(param_value):
+def clean_parameter_value(param_value):
     """
-    Removes CDATA wrapper from a parameter value if present and resolves XML entities.
+    Cleans a parameter value by:
+    1. Removing CDATA wrapper if present
+    2. Resolving XML entities like &gt;, &lt;, etc.
 
     Parameters:
     - param_value (str): The parameter value that might contain a CDATA wrapper
-                         and XML entities like &gt;, &lt;, etc.
+                         and/or XML entities
 
     Returns:
-    - str: The parameter value with CDATA wrapper removed and XML entities resolved
+    - str: The cleaned parameter value
     """
     if isinstance(param_value, str):
         # Remove CDATA wrapper if present

--- a/src/orchestrator/orchestrator_prompt.py
+++ b/src/orchestrator/orchestrator_prompt.py
@@ -293,6 +293,15 @@ The assistant's behavior aligns with the system purpose specified below:
 {examples}
 </examples>
 
+Do not surround XML directives with ```xml or any other code block:
+<negative-example>
+```xml
+<{tp}reasoning>
+....
+</{tp}reasoning>
+```
+</negative-example>
+
 <stimulus_originator_metadata>
 {info["originator_info_yaml"]}
 </stimulus_originator_metadata>

--- a/src/orchestrator/orchestrator_prompt.py
+++ b/src/orchestrator/orchestrator_prompt.py
@@ -209,6 +209,8 @@ The assistant's behavior aligns with the system purpose specified below:
     3. After opening agents, the assistant will be reinvoked with an updated list of open agents and their actions.
     4. When opening an agent, provide only a brief status update without detailed explanations.
     5. Do not perform any other actions besides opening the required agents in this step.
+    6. All `{tp}` XML tags must be generated as raw text directly within the response stream, seamlessly integrated with any natural language text, as shown in the positive examples.
+    7. Crucially, `{tp}` directive tags must *never* be wrapped in markdown code fences (``` ```) of any kind, including ```xml.
   - Report generation:
     1. If a report is requested and no format is specified, create the report in an HTML file.
     2. Generate each section of the report independently and store it in the file service with create_file action. When finishing the report, combine the sections using {FS_PROTOCOL} urls with the resolve=true query parameter to insert the sections into the main document. When inserting {FS_PROTOCOL} HTML URLs into the HTML document, place them directly in the document without any surrounding tags or brackets. Here is an example of the body section of an HTML report combining multiple sections:
@@ -292,15 +294,6 @@ The assistant's behavior aligns with the system purpose specified below:
 <examples>
 {examples}
 </examples>
-
-Do not surround XML directives with ```xml or any other code block:
-<negative-example>
-```xml
-<{tp}reasoning>
-....
-</{tp}reasoning>
-```
-</negative-example>
 
 <stimulus_originator_metadata>
 {info["originator_info_yaml"]}


### PR DESCRIPTION
### What is the purpose of this change?

Make the Gemini 2.5 model work well with SAM

### How is this accomplished?

There were a few things that needed changing:

1. In the file directives of the orchestrator prompt, it was possible that the model would add t###_ to the internal tags. We now are okay if that happens
2. There were a number of places where parameters would have their whitespace stripped. This was wrong and has been removed
3. Be strict about needing <t### _reasoning> in the response. Gemini occasionally gives a crazy response, which we should error on
4. Handle action parameters being surrounded by CDATA or having XML entities in them.
5. Fix plotly graph examples to not have double curly braces
6. Look for errors in the parsing and reinvoke the orchestrator based on that
7. Explicitly tell the orchestrator to not put ```xml around the response directives


