### PR TITLE
DATAGO-99407: add custom build hook for config_portal build

### DIFF
--- a/.github/helper_scripts/build_frontend.py
+++ b/.github/helper_scripts/build_frontend.py
@@ -1,0 +1,27 @@
+# noqa: INP001
+import os
+import shutil
+import subprocess
+from sys import stderr
+
+from hatchling.builders.hooks.plugin.interface import BuildHookInterface
+
+
+class CustomBuildHook(BuildHookInterface):
+    def initialize(self, version, build_data):
+        super().initialize(version, build_data)
+        stderr.write(">>> Building Solace Agent Mesh frontend\n")
+        npm = shutil.which("npm")
+        if npm is None:
+            raise RuntimeError(
+                "NodeJS `npm` is required for building Solace Agent Mesh frontend but it was not found"
+            )
+
+        os.chdir("config_portal/frontend")
+        try:
+            stderr.write("### npm install\n")
+            subprocess.run([npm, "install"], check=True)
+            stderr.write("\n### npm run build\n")
+            subprocess.run([npm, "run", "build"], check=True)
+        finally:
+            os.chdir("..")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,8 +60,13 @@ documentation = "https://github.com/SolaceLabs/solace-agent-mesh/blob/main/docs/
 "config_portal/frontend/static" = "solace_agent_mesh/config_portal/frontend/static"
 "config_portal/backend" = "solace_agent_mesh/config_portal/backend"
 
+
 [tool.hatch.build.targets.sdist.force-include]
 "web-visualizer/dist" = "/assets/web-visualizer"
+"config_portal/frontend/static" = "/assets/config_portal"
+
+
+
 
 [project.scripts]
 solace-agent-mesh = "solace_agent_mesh.cli.main:main"
@@ -70,6 +75,11 @@ sam = "solace_agent_mesh.cli.main:main"
 [tool.hatch.build.targets.wheel]
 packages = ["solace_agent_mesh"]
 
+[tool.hatch.build.targets.sdist.hooks.custom]
+path = ".github/helper_scripts/build_frontend.py"
+
+[tool.hatch.build.targets.wheel.hooks.custom]
+path = ".github/helper_scripts/build_frontend.py"
 
 [tool.hatch.version]
 path = "cli/__init__.py"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,6 +59,7 @@ documentation = "https://github.com/SolaceLabs/solace-agent-mesh/blob/main/docs/
 "web-visualizer/dist" = "solace_agent_mesh/assets/web-visualizer"
 "config_portal/frontend/static" = "solace_agent_mesh/config_portal/frontend/static"
 "config_portal/backend" = "solace_agent_mesh/config_portal/backend"
+"config_portal/__init__.py" = "solace_agent_mesh/config_portal/__init__.py"
 
 
 [tool.hatch.build.targets.sdist.force-include]


### PR DESCRIPTION
### What is the purpose of this change?

- install npm deps and build the UI on `hatch build`

