### PR TITLE
ENHANCE: Add proper Git conventions to empty file

### DIFF
--- a/cli/commands/add/agent.py
+++ b/cli/commands/add/agent.py
@@ -101,7 +101,7 @@ def add_agent_command(name):
 
         click.echo(f"Created sample action at: {get_display_path(action_path)}")
 
-        temp_file = os.path.join(config_directory, "__TEMPLATES_WILL_BE_HERE__")
+        temp_file = os.path.join(config_directory, ".gitkeep")
         if os.path.exists(temp_file):
             os.remove(temp_file)
     except IOError as e:

--- a/cli/commands/add/copy_from_plugin.py
+++ b/cli/commands/add/copy_from_plugin.py
@@ -83,7 +83,7 @@ def copy_from_plugin(name, plugin_name, entity_type):
         log_error("Invalid entity type.")
         return 1
 
-    temp_file = os.path.join(config_directory, "__TEMPLATES_WILL_BE_HERE__")
+    temp_file = os.path.join(config_directory, ".gitkeep")
     if os.path.exists(temp_file):
         os.remove(temp_file)
 

--- a/cli/commands/add/gateway.py
+++ b/cli/commands/add/gateway.py
@@ -289,7 +289,7 @@ def add_gateway_command(name, interfaces):
 
         created_file_names.append(gateway_config_path)
             
-        temp_file = os.path.join(config_directory, "__TEMPLATES_WILL_BE_HERE__")
+        temp_file = os.path.join(config_directory, ".gitkeep")
         if os.path.exists(temp_file):
             os.remove(temp_file)
 
@@ -328,7 +328,7 @@ def add_interface_command(name):
     try:
         os.makedirs(interfaces_directory, exist_ok=True)
 
-        temp_file = os.path.join(interfaces_directory, "__INTERFACES_WILL_BE_HERE__")
+        temp_file = os.path.join(interfaces_directory, ".gitkeep")
         if os.path.exists(temp_file):
             os.remove(temp_file)
 

--- a/cli/commands/plugin/create.py
+++ b/cli/commands/plugin/create.py
@@ -8,7 +8,7 @@ from cli.utils import log_error, ask_question
 
 DEFAULT_DESCRIPTION = "A solace-agent-mesh plugin project."
 DEFAULT_AUTHOR = "Author Name"
-EMPTY_FILE_MSG = "THIS WILL IS ONLY HERE TO PREVENT GIT FROM IGNORING THIS DIRECTORY"
+EMPTY_FILE_MSG = ""
 
 def create_command(
     path: str, description: str = None, author: str = None, skip: bool = False
@@ -87,10 +87,10 @@ def create_command(
         with open(os.path.join(py_path, "__init__.py"), "w", encoding="utf-8") as f:
             f.write("")
 
-    with open(os.path.join("configs", "__TEMPLATES_WILL_BE_HERE__"), "w", encoding="utf-8") as f:
+    with open(os.path.join("configs", ".gitkeep"), "w", encoding="utf-8") as f:
         f.write(EMPTY_FILE_MSG)
 
-    with open(os.path.join("interfaces", "__INTERFACES_WILL_BE_HERE__"), "w", encoding="utf-8") as f:
+    with open(os.path.join("interfaces", ".gitkeep"), "w", encoding="utf-8") as f:
         f.write(EMPTY_FILE_MSG)
 
     with open(os.path.join("src", "__init__.py"), "w", encoding="utf-8") as f:


### PR DESCRIPTION
## What is the purpose of this change?

To update the plugin creation process to follow Git conventions by using `.gitkeep` files instead of custom named placeholder files for empty directories.

## How is this accomplished?

- Update emtpy file to use git convensions
  - Changed placeholder files from custom names (`__TEMPLATES_WILL_BE_HERE__`, `__INTERFACES_WILL_BE_HERE__`) to standard `.gitkeep`
  - Removed the explicit message in empty files that previously explained their purpose

## Anything reviews should focus on/be aware of?

This is a simple convention change that doesn't affect functionality but improves adherence to standard Git practices.