### PR TITLE
AI-791 : Init GUI should not add provider/ if already provided by the user

### DIFF
--- a/config_portal/frontend/app/common/providerModels.ts
+++ b/config_portal/frontend/app/common/providerModels.ts
@@ -193,3 +193,16 @@ export async function fetchModelsFromCustomEndpoint(
     return [];
   }
 }
+
+  // Format model name for litellm
+  export const formatModelName = (modelName: string, provider: string): string => {
+  
+    // If model name already includes a provider prefix (contains '/'), return as is
+    if (modelName.includes('/')) {
+      return modelName;
+    }
+        
+    // Get the correct provider prefix
+    const providerPrefix = PROVIDER_PREFIX_MAP[provider] || provider;
+    return `${providerPrefix}/${modelName}`;
+  };

--- a/config_portal/frontend/app/components/steps/AIProviderSetup.tsx
+++ b/config_portal/frontend/app/components/steps/AIProviderSetup.tsx
@@ -14,8 +14,8 @@ import {
   fetchModelsFromCustomEndpoint,
   LLM_PROVIDER_OPTIONS,
   EMBEDDING_PROVIDER_OPTIONS,
-  PROVIDER_PREFIX_MAP,
   EMBEDDING_PROVIDER_MODELS,
+  formatModelName,
 } from '../../common/providerModels';
 
 type AIProviderSetupProps = {
@@ -242,26 +242,9 @@ export default function AIProviderSetup({ data, updateData, onNext, onPrevious }
     return isValid;
   };
   
-  // Format model name for litellm
-  const formatModelName = (modelName: string, provider: string): string => {
-  
-    // If model name already includes a provider prefix (contains '/'), return as is
-    if (modelName.includes('/')) {
-      return modelName;
-    }
-        
-    // Get the correct provider prefix
-    const providerPrefix = PROVIDER_PREFIX_MAP[provider] || provider;
-    return `${providerPrefix}/${modelName}`;
-  };
+
 
   const testLLMConfig = async () => {
-    // Exclude certain providers from testing as these require more auth than just a key
-    const EXCLUSION_LIST = ['bedrock']
-    if (EXCLUSION_LIST.includes(data.llm_provider)) {
-      onNext();
-      return;
-    }
     setIsTestingConfig(true);
     setTestError(null);
     

--- a/config_portal/frontend/app/components/steps/CompletionStep.tsx
+++ b/config_portal/frontend/app/components/steps/CompletionStep.tsx
@@ -408,7 +408,7 @@ export default function CompletionStep({ data, updateData, onPrevious }: Readonl
       data.embedding_model_name = formatModelName(data.embedding_model_name, data.embedding_provider);
       delete data.embedding_provider;
     }
-    
+
     // Handle image generation provider and model in env_var
     if (data.env_var && Array.isArray(data.env_var)) {
       let imageGenProvider = '';

--- a/config_portal/frontend/app/components/steps/CompletionStep.tsx
+++ b/config_portal/frontend/app/components/steps/CompletionStep.tsx
@@ -6,6 +6,7 @@ import {
   EMBEDDING_PROVIDER_PREFIX_MAP,
   IMAGE_GEN_PROVIDER_PREFIX_MAP,
   LLM_PROVIDER_OPTIONS,
+  formatModelName,
 } from '../../common/providerModels';
 
 type CompletionStepProps = {
@@ -377,11 +378,10 @@ export default function CompletionStep({ data, updateData, onPrevious }: Readonl
     if (data.namespace && !data.namespace.endsWith('/')) {
       data.namespace += '/';
     }
-    if (data.container_started){
+    if (data.container_started) {
       //remove container_started from data
       delete data.container_started;
     }
-
     // first dereference the providers to the actual prefixes
     if (data.llm_provider) {
       data.llm_provider = PROVIDER_PREFIX_MAP[data.llm_provider];
@@ -390,24 +390,25 @@ export default function CompletionStep({ data, updateData, onPrevious }: Readonl
       data.embedding_provider = EMBEDDING_PROVIDER_PREFIX_MAP[data.embedding_provider];
     }
     
-    //join provider and model name
-    if (data.llm_model_name && data.llm_provider){
-      data.llm_model_name = `${data.llm_provider}/${data.llm_model_name}`;
-      delete data.llm_provider
+    //join provider and model name for LLM
+    if (data.llm_model_name && data.llm_provider) {
+      data.llm_model_name = formatModelName(data.llm_model_name, data.llm_provider);
+      delete data.llm_provider;
     }
-
+    
     // if embedding service is not enabled, put empty strings for embedding fields
-    if (!data.embedding_service_enabled){
+    if (!data.embedding_service_enabled) {
       data.embedding_api_key = "";
       data.embedding_model_name = "";
       data.embedding_endpoint_url = "";
-      
     }
-    if (data.embedding_model_name && data.embedding_provider){
-      data.embedding_model_name = `${data.embedding_provider}/${data.embedding_model_name}`;
-      delete data.embedding_provider
+    
+    // Join provider and model name for embeddings
+    if (data.embedding_model_name && data.embedding_provider) {
+      data.embedding_model_name = formatModelName(data.embedding_model_name, data.embedding_provider);
+      delete data.embedding_provider;
     }
-
+    
     // Handle image generation provider and model in env_var
     if (data.env_var && Array.isArray(data.env_var)) {
       let imageGenProvider = '';
@@ -428,8 +429,8 @@ export default function CompletionStep({ data, updateData, onPrevious }: Readonl
         // Get the provider prefix
         const providerPrefix = IMAGE_GEN_PROVIDER_PREFIX_MAP[imageGenProvider] || imageGenProvider;
         
-        // Format the model name
-        const formattedModel = `${providerPrefix}/${imageGenModel}`;
+        // Format the model name using the utility function
+        const formattedModel = formatModelName(imageGenModel, providerPrefix);
         
         // Update env_var array
         data.env_var = data.env_var.map((env: string) => {


### PR DESCRIPTION
### What is the purpose of this change?
This came up in testing where if the user provides the model name as `openai/<model_name>`in the init GUI then when they submit another `openai/` is added to this causing the model name to be `openai/openai/<model_name>`

### How is this accomplished?

### Anything reviews should focus on/be aware of?
