### PR TITLE
FIX: Fix memory issues

### DIFF
--- a/src/services/history_service/history_providers/sql_history_provider.py
+++ b/src/services/history_service/history_providers/sql_history_provider.py
@@ -72,7 +72,7 @@ class SQLHistoryProvider(BaseHistoryProvider):
         query = f"SELECT data FROM {self.table_name} WHERE session_id = %s"
         cursor = self.db.execute(query, (session_id,))
         row = cursor.fetchone()
-        if not row.get("data"):
+        if not row or not row.get("data"):
             return {}
         data = row["data"] if isinstance(row["data"], dict) else json.loads(row["data"])
         return data


### PR DESCRIPTION
## What is the purpose of this change?

This change fixes a potential memory error that could occur when retrieving a non-existent session from the SQL history provider.

## How is this accomplished?

- Added slight fix for memory by modifying the `get_session` method to check if `row` exists before accessing its data

## Anything reviews should focus on/be aware of?

This is a small defensive coding fix to prevent accessing attributes on a None object when no session is found.