### PR TITLE
PLUGINS-PATH: Update official registry Git branch to main

### DIFF
--- a/cli/commands/plugin_cmd/official_registry.py
+++ b/cli/commands/plugin_cmd/official_registry.py
@@ -59,6 +59,8 @@ def _fetch_github_plugins(github_url: str, branch: str = None) -> Dict[str, str]
 
         owner, repo = parts[0], parts[1]
         api_url = f"https://api.github.com/repos/{owner}/{repo}/contents"
+        if branch:
+            api_url += f"?ref={branch}"
 
         with httpx.Client() as client:
             response = client.get(api_url, timeout=10.0)

--- a/config_portal/backend/plugin_catalog/constants.py
+++ b/config_portal/backend/plugin_catalog/constants.py
@@ -16,7 +16,7 @@ except ImportError:
 DEFAULT_OFFICIAL_REGISTRY_URL = (
         "https://github.com/SolaceLabs/solace-agent-mesh-core-plugins"
 )
-OFFICIAL_REGISTRY_GIT_BRANCH = "dev"
+OFFICIAL_REGISTRY_GIT_BRANCH = "main"
 IGNORE_OFFICIAL_FLAG_REPOS = []
 
 USER_REGISTRIES_PATH = SAM_HOME / "plugin_catalog_registries.json"


### PR DESCRIPTION
## What is the purpose of this change?

Update the Git branch used for the official registry in the plugin catalog from 'dev' to 'main', ensuring that the plugin catalog points to the stable main branch of the Solace Agent Mesh core plugins repository.

## How is this accomplished?

- Update official registry Git branch to main

## Anything reviews should focus on/be aware of?

Verify that the main branch of the repository contains the expected stable content for production use.