### PR TITLE
FIX: Remove space from path

### DIFF
--- a/config_portal/backend/plugin_catalog/registry_manager.py
+++ b/config_portal/backend/plugin_catalog/registry_manager.py
@@ -23,7 +23,7 @@ class RegistryManager:
         default_official_registry = Registry(
             id=default_id,
             path_or_url=DEFAULT_OFFICIAL_REGISTRY_URL,
-            name="Official SAM Plugins",
+            name="official_sam_plugins",
             type=(
                 "git"
                 if DEFAULT_OFFICIAL_REGISTRY_URL.startswith(


### PR DESCRIPTION
## What is the purpose of this change?

This change updates the naming convention for the Official SAM Plugins registry to remove spaces from its name, making it more consistent and machine-friendly.

## How is this accomplished?

- remove space form path - Changed the registry name from "Official SAM Plugins" to "official_sam_plugins"

## Anything reviews should focus on/be aware of?

Check if this name change impacts any references or UI display of the registry name elsewhere in the system.