### PR TITLE
DATAGO-107596: Remove the replay button from flow chart panel

### DIFF
--- a/client/webui/frontend/src/lib/components/activities/FlowChart/taskToFlowData.helpers.ts
+++ b/client/webui/frontend/src/lib/components/activities/FlowChart/taskToFlowData.helpers.ts
@@ -650,7 +650,6 @@ export function createTimelineEdge(
         const label = step.title && step.title.length > 30 ? step.type.replace(/_/g, " ").toLowerCase() : step.title || "";
 
         // For initial edge creation, assume all agent-to-tool requests start animated
-        // The animation service will determine the actual state during replay
         const isAgentToToolRequest = edgeAnimationService.isRequestStep(step);
 
         const newEdge: Edge = {

--- a/client/webui/frontend/src/lib/components/activities/FlowChartPanel.tsx
+++ b/client/webui/frontend/src/lib/components/activities/FlowChartPanel.tsx
@@ -315,9 +315,22 @@ const FlowRenderer: React.FC<FlowChartPanelProps> = ({ processedSteps, isRightPa
         }
     }, []);
 
+    const handlePopoverClose = useCallback(() => {
+        setIsPopoverOpen(false);
+        setSelectedStep(null);
+    }, []);
+
     const handleNodeClick = useCallback(
         (_event: React.MouseEvent, node: Node) => {
             setHasUserInteracted(true);
+
+            // If clicking on a group container, treat it like clicking on empty space
+            if (node.type === "group") {
+                setHighlightedStepId(null);
+                setSelectedEdgeId(null);
+                handlePopoverClose();
+                return;
+            }
 
             const sourceHandles = getNodeSourceHandles(node);
 
@@ -340,17 +353,12 @@ const FlowRenderer: React.FC<FlowChartPanelProps> = ({ processedSteps, isRightPa
                 handleEdgeClick(_event, targetEdge);
             }
         },
-        [getNodeSourceHandles, findEdgeBySourceAndHandle, handleEdgeClick, edges]
+        [getNodeSourceHandles, setHighlightedStepId, handlePopoverClose, findEdgeBySourceAndHandle, edges, handleEdgeClick]
     );
 
     const handleUserMove = useCallback((event: MouseEvent | TouchEvent | null) => {
         if (!event?.isTrusted) return; // Ignore synthetic events
         setHasUserInteracted(true);
-    }, []);
-
-    const handlePopoverClose = useCallback(() => {
-        setIsPopoverOpen(false);
-        setSelectedStep(null);
     }, []);
 
     useEffect(() => {

--- a/client/webui/frontend/src/lib/components/activities/FlowChartPanel.tsx
+++ b/client/webui/frontend/src/lib/components/activities/FlowChartPanel.tsx
@@ -1,9 +1,8 @@
 import React, { useCallback, useEffect, useMemo, useRef, useState } from "react";
 
-import { Background, ControlButton, Controls, MarkerType, Panel, ReactFlow, ReactFlowProvider, useEdgesState, useNodesState, useReactFlow } from "@xyflow/react";
+import { Background, Controls, MarkerType, Panel, ReactFlow, ReactFlowProvider, useEdgesState, useNodesState, useReactFlow } from "@xyflow/react";
 import type { Edge, Node } from "@xyflow/react";
 import "@xyflow/react/dist/style.css";
-import { FiPause, FiPlay } from "react-icons/fi";
 
 import { PopoverManual } from "@/lib/components/ui";
 import { useTaskContext } from "@/lib/hooks";
@@ -48,8 +47,8 @@ const FlowRenderer: React.FC<FlowChartPanelProps> = ({ processedSteps, isRightPa
     const [nodes, setNodes, onNodesChange] = useNodesState<Node>([]);
     const [edges, setEdges, onEdgesChange] = useEdgesState<Edge>([]);
     const { fitView } = useReactFlow();
-    const { highlightedStepId, setHighlightedStepId, setReplayState } = useTaskContext(); // Use context
-    const { taskIdInSidePanel } = useChatContext(); // Get taskIdInSidePanel from chat context
+    const { highlightedStepId, setHighlightedStepId } = useTaskContext();
+    const { taskIdInSidePanel } = useChatContext();
 
     const prevProcessedStepsRef = useRef<VisualizerStep[]>([]);
     const [hasUserInteracted, setHasUserInteracted] = useState(false);
@@ -62,40 +61,27 @@ const FlowRenderer: React.FC<FlowChartPanelProps> = ({ processedSteps, isRightPa
     // Track selected edge for highlighting
     const [selectedEdgeId, setSelectedEdgeId] = useState<string | null>(null);
 
-    const [isReplaying, setIsReplaying] = useState(false);
-    const [isReplayPaused, setIsReplayPaused] = useState(false);
-    const [replayedSteps, setReplayedSteps] = useState<VisualizerStep[]>([]);
-    const [currentReplayStepIndex, setCurrentReplayStepIndex] = useState(0);
-    const [pausedElapsedTime, setPausedElapsedTime] = useState(0);
-    const replayIntervalRef = useRef<number | null>(null); // Will hold setTimeout ID
-    const replayStartTimeRef = useRef<number | null>(null);
-    const firstStepTimestampRef = useRef<number | null>(null);
     const edgeAnimationServiceRef = useRef<EdgeAnimationService>(new EdgeAnimationService());
 
     const memoizedFlowData = useMemo(() => {
-        const stepsToUse = isReplaying ? replayedSteps : processedSteps;
-
-        if (!stepsToUse || stepsToUse.length === 0) {
+        if (!processedSteps || processedSteps.length === 0) {
             return { nodes: [], edges: [] };
         }
-        // Always use timeline flow
-        return transformProcessedStepsToTimelineFlow(stepsToUse);
-    }, [processedSteps, replayedSteps, isReplaying]);
+        return transformProcessedStepsToTimelineFlow(processedSteps);
+    }, [processedSteps]);
 
-    // Consolidated edge computation - replaces multiple redundant edge update effects
+    // Consolidated edge computation
     const computedEdges = useMemo(() => {
         if (!memoizedFlowData.edges.length) return [];
 
         return memoizedFlowData.edges.map(edge => {
             const edgeData = edge.data as unknown as AnimatedEdgeData;
 
-            // Determine animation state based on replay status
+            // Determine animation state
             let animationState = { isAnimated: false, animationType: "none" };
             if (edgeData?.visualizerStepId) {
-                const stepsToCheck = isReplaying ? replayedSteps : processedSteps;
-                const stepIndex = isReplaying ? replayedSteps.length - 1 : processedSteps.length - 1;
-
-                animationState = edgeAnimationServiceRef.current.getEdgeAnimationState(edgeData.visualizerStepId, stepIndex, stepsToCheck);
+                const stepIndex = processedSteps.length - 1;
+                animationState = edgeAnimationServiceRef.current.getEdgeAnimationState(edgeData.visualizerStepId, stepIndex, processedSteps);
             }
 
             // Determine if this edge should be selected
@@ -117,7 +103,7 @@ const FlowRenderer: React.FC<FlowChartPanelProps> = ({ processedSteps, isRightPa
                 } as unknown as Record<string, unknown>,
             };
         });
-    }, [memoizedFlowData.edges, isReplaying, replayedSteps, processedSteps, selectedEdgeId, highlightedStepId]);
+    }, [memoizedFlowData.edges, processedSteps, selectedEdgeId, highlightedStepId]);
 
     const updateGroupNodeSizes = useCallback(() => {
         setNodes(currentNodes => {
@@ -187,78 +173,6 @@ const FlowRenderer: React.FC<FlowChartPanelProps> = ({ processedSteps, isRightPa
         setEdges(computedEdges);
         updateGroupNodeSizes();
     }, [memoizedFlowData.nodes, computedEdges, setNodes, setEdges, updateGroupNodeSizes]);
-
-    useEffect(() => {
-        if (!isReplaying) {
-            setCurrentReplayStepIndex(0);
-            setReplayedSteps([]);
-            if (replayIntervalRef.current) {
-                clearTimeout(replayIntervalRef.current);
-                replayIntervalRef.current = null;
-            }
-            replayStartTimeRef.current = null;
-            firstStepTimestampRef.current = null;
-        }
-    }, [isReplaying]);
-
-    const startReplay = useCallback(() => {
-        if (processedSteps.length === 0 || isReplaying) return;
-
-        const firstTimestamp = Date.parse(processedSteps[0].timestamp);
-        if (isNaN(firstTimestamp)) {
-            console.error("Error: First step has an invalid timestamp. Cannot start replay.", processedSteps[0]);
-            return;
-        }
-
-        // 1. Clear the board by emptying main nodes and edges.
-        setNodes([]);
-        setEdges([]);
-        // 2. Reset replay step.
-        setCurrentReplayStepIndex(0);
-        setReplayedSteps([]);
-        // 3. Reset pause state
-        setIsReplayPaused(false);
-        setPausedElapsedTime(0);
-
-        // 4. Set up timing references for the replay.
-        firstStepTimestampRef.current = firstTimestamp;
-        replayStartTimeRef.current = Date.now();
-
-        // 5. Set isReplaying to true, which will trigger the replay loop useEffect.
-        setIsReplaying(true);
-
-        // 6. Notify context about replay start
-        setReplayState(true, 0);
-    }, [processedSteps, isReplaying, setNodes, setEdges, setCurrentReplayStepIndex, setIsReplaying, setReplayState]);
-
-    const pauseReplay = useCallback(() => {
-        if (!isReplaying || isReplayPaused) return;
-
-        // Calculate elapsed time up to this point
-        if (replayStartTimeRef.current) {
-            const currentElapsed = Date.now() - replayStartTimeRef.current;
-            setPausedElapsedTime(currentElapsed);
-        }
-
-        // Clear any pending timeouts
-        if (replayIntervalRef.current) {
-            clearTimeout(replayIntervalRef.current);
-            replayIntervalRef.current = null;
-        }
-
-        setIsReplayPaused(true);
-    }, [isReplaying, isReplayPaused]);
-
-    const resumeReplay = useCallback(() => {
-        if (!isReplaying || !isReplayPaused) return;
-
-        // Adjust the replay start time to account for the pause duration
-        if (replayStartTimeRef.current) {
-            replayStartTimeRef.current = Date.now() - pausedElapsedTime;
-        }
-
-        setIsReplayPaused(false);
-    }, [isReplaying, isReplayPaused, pausedElapsedTime]);
 
     const findEdgeBySourceAndHandle = useCallback(
         (sourceNodeId: string, sourceHandleId?: string): Edge | null => {
@@ -361,84 +275,6 @@ const FlowRenderer: React.FC<FlowChartPanelProps> = ({ processedSteps, isRightPa
         setHasUserInteracted(true);
     }, []);
 
-    useEffect(() => {
-        if (isReplaying && processedSteps.length > 0 && firstStepTimestampRef.current !== null && replayStartTimeRef.current !== null) {
-            const firstStepTime = firstStepTimestampRef.current;
-            const replayStartTime = replayStartTimeRef.current;
-            let animationFrameId: number | null = null;
-
-            const replayLoop = () => {
-                if (!isReplaying || currentReplayStepIndex >= processedSteps.length) {
-                    setIsReplaying(false);
-                    setReplayState(false, processedSteps.length);
-                    if (animationFrameId) cancelAnimationFrame(animationFrameId);
-                    if (replayIntervalRef.current) clearTimeout(replayIntervalRef.current);
-                    replayIntervalRef.current = null;
-                    return;
-                }
-
-                // If paused, don't process any steps, just wait
-                if (isReplayPaused) {
-                    if (replayIntervalRef.current) clearTimeout(replayIntervalRef.current);
-                    replayIntervalRef.current = window.setTimeout(() => {
-                        animationFrameId = requestAnimationFrame(replayLoop);
-                    }, 100); // Check pause state every 100ms
-                    return;
-                }
-
-                const elapsedRealTime = Date.now() - replayStartTime;
-                let nextStepIndex = currentReplayStepIndex;
-                let stepsProcessedInThisLoop = 0;
-
-                // Process steps based on their timestamps
-                while (nextStepIndex < processedSteps.length) {
-                    const step = processedSteps[nextStepIndex];
-                    const stepTimeOffset = Date.parse(step.timestamp) - firstStepTime;
-
-                    if (stepTimeOffset <= elapsedRealTime) {
-                        setReplayedSteps(prev => [...prev, step]);
-                        nextStepIndex++;
-                        stepsProcessedInThisLoop++;
-                    } else {
-                        break;
-                    }
-                }
-
-                if (stepsProcessedInThisLoop > 0) {
-                    setCurrentReplayStepIndex(nextStepIndex);
-                    updateGroupNodeSizes();
-                    setReplayState(true, nextStepIndex);
-                }
-
-                if (nextStepIndex >= processedSteps.length) {
-                    setIsReplaying(false);
-                    setReplayState(false, processedSteps.length);
-                    if (replayIntervalRef.current) clearTimeout(replayIntervalRef.current);
-                    replayIntervalRef.current = null;
-                } else {
-                    const nextStep = processedSteps[nextStepIndex];
-                    const nextStepTimeOffset = Date.parse(nextStep.timestamp) - firstStepTime;
-                    const delay = Math.max(0, nextStepTimeOffset - elapsedRealTime);
-
-                    if (replayIntervalRef.current) clearTimeout(replayIntervalRef.current);
-                    replayIntervalRef.current = window.setTimeout(() => {
-                        animationFrameId = requestAnimationFrame(replayLoop);
-                    }, delay);
-                }
-            };
-
-            animationFrameId = requestAnimationFrame(replayLoop);
-
-            return () => {
-                if (animationFrameId) cancelAnimationFrame(animationFrameId);
-                if (replayIntervalRef.current) {
-                    clearTimeout(replayIntervalRef.current);
-                    replayIntervalRef.current = null;
-                }
-            };
-        }
-    }, [isReplaying, isReplayPaused, processedSteps, currentReplayStepIndex, setIsReplaying, setCurrentReplayStepIndex, updateGroupNodeSizes, setReplayState, setReplayedSteps]);
-
     // Reset user interaction state when taskIdInSidePanel changes (new task loaded)
     useEffect(() => {
         setHasUserInteracted(false);
@@ -460,14 +296,16 @@ const FlowRenderer: React.FC<FlowChartPanelProps> = ({ processedSteps, isRightPa
         }
     }, [nodes.length, fitView, processedSteps, isSidePanelTransitioning, hasUserInteracted]);
 
+    // Combined effect for node highlighting and edge selection based on highlightedStepId
     useEffect(() => {
+        // Update node highlighting
         setNodes(currentFlowNodes =>
             currentFlowNodes.map(flowNode => {
                 const isHighlighted = flowNode.data?.visualizerStepId && flowNode.data.visualizerStepId === highlightedStepId;
 
                 // Find the original node from memoizedFlowData to get its base style
                 const originalNode = memoizedFlowData.nodes.find(n => n.id === flowNode.id);
-                const baseStyle = originalNode?.style || {}; // Get base style from original node
+                const baseStyle = originalNode?.style || {};
 
                 return {
                     ...flowNode,
@@ -479,10 +317,8 @@ const FlowRenderer: React.FC<FlowChartPanelProps> = ({ processedSteps, isRightPa
                 };
             })
         );
-    }, [highlightedStepId, setNodes, memoizedFlowData.nodes]);
 
-    // Simplified effect to update selectedEdgeId when highlightedStepId changes
-    useEffect(() => {
+        // Update selected edge
         if (highlightedStepId) {
             const relatedEdge = computedEdges.find(edge => {
                 const edgeData = edge.data as unknown as AnimatedEdgeData;
@@ -495,7 +331,7 @@ const FlowRenderer: React.FC<FlowChartPanelProps> = ({ processedSteps, isRightPa
         } else {
             setSelectedEdgeId(null);
         }
-    }, [highlightedStepId, computedEdges]);
+    }, [highlightedStepId, setNodes, memoizedFlowData.nodes, computedEdges]);
 
     if (!processedSteps || processedSteps.length === 0) {
         return <div className="flex h-full items-center justify-center text-gray-500 dark:text-gray-400">{Object.keys(processedSteps).length > 0 ? "Processing flow data..." : "No steps to display in flow chart."}</div>;
@@ -535,21 +371,6 @@ const FlowRenderer: React.FC<FlowChartPanelProps> = ({ processedSteps, isRightPa
             >
                 <Background />
                 <Controls className={getThemeButtonHtmlStyles()} />
-                <Panel position="bottom-right" className={`flex space-x-1 rounded bg-white p-1 dark:bg-gray-800 ${getThemeButtonHtmlStyles()}`}>
-                    {!isReplaying ? (
-                        <ControlButton onClick={startReplay} title="Replay Flow" disabled={processedSteps.length === 0}>
-                            <FiPlay />
-                        </ControlButton>
-                    ) : !isReplayPaused ? (
-                        <ControlButton onClick={pauseReplay} title="Pause Replay">
-                            <FiPause />
-                        </ControlButton>
-                    ) : (
-                        <ControlButton onClick={resumeReplay} title="Resume Replay">
-                            <FiPlay />
-                        </ControlButton>
-                    )}
-                </Panel>
                 <Panel position="top-right" className="flex items-center space-x-4">
                     <div ref={popoverAnchorRef} />
                 </Panel>

--- a/client/webui/frontend/src/lib/contexts/TaskContext.ts
+++ b/client/webui/frontend/src/lib/contexts/TaskContext.ts
@@ -9,8 +9,6 @@ interface TaskState {
     monitoredTasks: Record<string, TaskFE>;
     monitoredTaskOrder: string[];
     highlightedStepId: string | null;
-    isReplaying: boolean;
-    currentReplayStep: number;
     isReconnecting: boolean;
     reconnectionAttempts: number;
 }
@@ -19,7 +17,6 @@ interface TaskActions {
     connectTaskMonitorStream: () => Promise<void>;
     disconnectTaskMonitorStream: () => Promise<void>;
     setHighlightedStepId: (stepId: string | null) => void;
-    setReplayState: (isReplaying: boolean, currentStep: number) => void;
 }
 
 export type TaskContextValue = TaskState & TaskActions;

--- a/client/webui/frontend/src/lib/providers/TaskProvider.tsx
+++ b/client/webui/frontend/src/lib/providers/TaskProvider.tsx
@@ -19,9 +19,7 @@ export const TaskProvider: React.FC<TaskProviderProps> = ({ children }) => {
     const [taskMonitorSseError, setTaskMonitorSseError] = useState<string | null>(null);
     const [monitoredTasks, setMonitoredTasks] = useState<Record<string, TaskFE>>({});
     const [monitoredTaskOrder, setMonitoredTaskOrder] = useState<string[]>([]);
-    const [highlightedStepId, setHighlightedStepIdState] = useState<string | null>(null); 
-    const [isReplaying, setIsReplaying] = useState<boolean>(false);
-    const [currentReplayStep, setCurrentReplayStep] = useState<number>(0);
+    const [highlightedStepId, setHighlightedStepIdState] = useState<string | null>(null);
 
     // Reconnection state management
     const [reconnectionAttempts, setReconnectionAttempts] = useState<number>(0);
@@ -234,8 +232,6 @@ export const TaskProvider: React.FC<TaskProviderProps> = ({ children }) => {
         setMonitoredTasks({});
         setMonitoredTaskOrder([]);
         setHighlightedStepIdState(null);
-        setIsReplaying(false);
-        setCurrentReplayStep(0);
         setReconnectionAttempts(0);
         setIsReconnecting(false);
     }, [apiPrefix]);
@@ -304,11 +300,6 @@ export const TaskProvider: React.FC<TaskProviderProps> = ({ children }) => {
         setHighlightedStepIdState(stepId);
     }, []);
 
-    const setReplayState = useCallback((isReplayingState: boolean, currentStep: number) => {
-        setIsReplaying(isReplayingState);
-        setCurrentReplayStep(currentStep);
-    }, []);
-
     const contextValue: TaskContextValue = {
         isTaskMonitorConnecting,
         isTaskMonitorConnected,
@@ -316,14 +307,11 @@ export const TaskProvider: React.FC<TaskProviderProps> = ({ children }) => {
         monitoredTasks,
         monitoredTaskOrder,
         highlightedStepId,
-        isReplaying,
-        currentReplayStep,
         isReconnecting,
         reconnectionAttempts,
         connectTaskMonitorStream,
         disconnectTaskMonitorStream,
         setHighlightedStepId,
-        setReplayState,
     };
 
     return <TaskContext.Provider value={contextValue}>{children}</TaskContext.Provider>;

--- a/client/webui/llm_detail.txt
+++ b/client/webui/llm_detail.txt
@@ -1418,11 +1418,11 @@ const sizeString = formatBytes(1024); // Returns "1 KB"
 # DEVELOPER GUIDE: FlowChart
 
 ## Quick Summary
-The FlowChart directory provides a comprehensive React Flow-based visualization system for AI agent workflows and task monitoring. It combines a main panel component with custom nodes and edges to create interactive flowcharts that can display agent interactions, tool executions, and data flow with real-time animation and replay capabilities. The architecture separates the main flow panel logic from reusable custom node/edge components.
+The FlowChart directory provides a comprehensive React Flow-based visualization system for AI agent workflows and task monitoring. It combines a main panel component with custom nodes and edges to create interactive flowcharts that can display agent interactions, tool executions, and data flow with real-time animation. The architecture separates the main flow panel logic from reusable custom node/edge components.
 
 ## Files and Subdirectories Overview
 - **Direct files:**
-  - `FlowChartPanel.tsx` - Main React Flow panel component with replay functionality and task monitoring integration
+  - `FlowChartPanel.tsx` - Main React Flow panel component with task monitoring integration
 - **Subdirectories:**
   - `customEdges/` - Custom edge components with animation support for data flow visualization
   - `customNodes/` - Collection of specialized node components for different entity types (agents, tools, users, LLM)
@@ -1432,7 +1432,7 @@ The FlowChart directory provides a comprehensive React Flow-based visualization 
 ### Direct Files
 
 #### FlowChartPanel.tsx
-**Purpose:** Main React Flow panel component that orchestrates the entire flowchart visualization with replay capabilities
+**Purpose:** Main React Flow panel component that orchestrates the entire flowchart visualization
 **Import:** `import FlowChartPanel from 'frontend/src/components/TaskMonitor/FlowChart/FlowChartPanel'`
 
 **Interfaces:**
@@ -1446,7 +1446,6 @@ The FlowChart directory provides a comprehensive React Flow-based visualization 
 - `FlowRenderer: React.FC<FlowChartPanelProps>` - Internal component containing React Flow logic
 
 **Key Features:**
-- Real-time step replay with pause/resume functionality
 - Integration with TaskMonitorContext for state management
 - Custom node and edge type registration
 - Automatic layout using timeline flow transformation
@@ -1583,17 +1582,16 @@ import { useTaskMonitor } from 'frontend/src/contexts/TaskMonitorContext';
 import FlowChartPanel from 'frontend/src/components/TaskMonitor/FlowChart/FlowChartPanel';
 
 const TaskFlowVisualization: React.FC = () => {
-  const { 
-    processedSteps, 
-    highlightedStepId, 
-    setHighlightedStepId,
-    replayState 
+  const {
+    processedSteps,
+    highlightedStepId,
+    setHighlightedStepId
   } = useTaskMonitor();
   
   const [isFullScreen, setIsFullScreen] = useState(false);
 
   // The FlowChartPanel automatically integrates with TaskMonitorContext
-  // for step highlighting and replay state management
+  // for step highlighting
   return (
     <FlowChartPanel
       processedSteps={processedSteps}
@@ -1666,7 +1664,7 @@ const updateNodeStatus = (nodeId: string, status: string) => {
 };
 ```
 
-This comprehensive guide shows how the FlowChart directory components work together to create rich, interactive workflow visualizations with real-time updates, animations, and replay capabilities. The modular design allows for easy customization and extension of both node types and edge behaviors.
+This comprehensive guide shows how the FlowChart directory components work together to create rich, interactive workflow visualizations with real-time updates and animations. The modular design allows for easy customization and extension of both node types and edge behaviors.
 
 ================================================================================
 
@@ -1965,7 +1963,7 @@ The TaskMonitor directory provides a comprehensive React-based system for monito
 - `EventDetailsPanel: React.FC<EventDetailsPanelProps>` - Panel component that renders event list
 
 #### LinearStepViewPanel.tsx
-**Purpose:** Displays workflow steps in a linear timeline format with replay support and step highlighting
+**Purpose:** Displays workflow steps in a linear timeline format with step highlighting
 **Import:** `import LinearStepViewPanel from 'frontend/src/components/TaskMonitor/LinearStepViewPanel'`
 
 **Interfaces:**
@@ -2894,14 +2892,11 @@ function ChatInterface() {
   - `monitoredTasks: Record<string, MonitoredTask>` - Active tasks by ID
   - `monitoredTaskOrder: string[]` - Task display order
   - `highlightedStepId: string | null` - Currently highlighted step
-  - `isReplaying: boolean` - Replay mode status
-  - `currentReplayStep: number` - Current replay position
 
 - `TaskMonitorActions` - Task monitor actions
   - `connectTaskMonitorStream: () => Promise<void>` - Establish SSE connection
   - `disconnectTaskMonitorStream: () => Promise<void>` - Close SSE connection
   - `setHighlightedStepId: (stepId: string | null) => void` - Highlight specific step
-  - `setReplayState: (isReplaying: boolean, currentStep: number) => void` - Control replay
 
 **Usage Examples:**
 ```tsx


### PR DESCRIPTION
This change remove all the code relates the to Replay button in the flow chart panel. 
Together, it also fix a bug that when clicking on the group, it doesn't close the message popover.