### PR TITLE
DATAGO-108108: Add Docker instructions to quick start guide for sample applications

### DIFF
--- a/docs/docs/documentation/getting-started/quick-start.md
+++ b/docs/docs/documentation/getting-started/quick-start.md
@@ -9,6 +9,23 @@ sidebar_position: 30
 Looking to get started with plugins? For more information, see the [Plugins](../concepts/plugins.md).
 :::
 
+<details>
+  <summary>Running Sample Applications</summary>
+
+  You can run pre-made sample applications to quickly get started with Solace Agent Mesh without needing to set up a project from scratch. These samples are available in the [`samples` directory of the Solace Agent Mesh repository](https://github.com/SolaceLabs/solace-agent-mesh/tree/main/samples).
+
+  :::tip[Running Sample Applications in Docker]
+  The sample applications come pre-packaged in Solace Agent Mesh Docker image. You can run them using the following command:
+
+  ```sh
+  docker run --rm -it -p 8000:8000 solace/solace-agent-mesh:latest run /samples/<sample-name>
+  ```
+  - Replace `<sample-name>` with the name of the sample you want to run, such as `core` or `basic`.
+  - Provide the environment variables required as specified in the sample's `env-template` file.
+  :::
+</details>
+
+
 To get started with Solace Agent Mesh, you must first create a project.
 
 ## Prerequisites


### PR DESCRIPTION
## What is the purpose of this change?

This change enhances the Quick Start guide by adding instructions on how to run sample applications in Docker, making it easier for users to get started with Solace Agent Mesh without setting up a project from scratch.

## How is this accomplished?

- Add section for running sample applications in Docker to quick start guide
- Create a collapsible "Running Sample Applications" section with Docker instructions
- Include tips on how to run samples using the Solace Agent Mesh Docker image

## Anything reviews should focus on/be aware of?

Ensure the Docker command and path to samples directory is correct and matches the actual repository structure.