### PR TITLE
Fix an issue with missing LLM requests caused by timestamp

### DIFF
--- a/client/webui/frontend/src/lib/components/activities/FlowChart/taskToFlowData.ts
+++ b/client/webui/frontend/src/lib/components/activities/FlowChart/taskToFlowData.ts
@@ -664,7 +664,17 @@ export const transformProcessedStepsToTimelineFlow = (processedSteps: Visualizer
 
     const filteredSteps = processedSteps.filter(step => RELEVANT_STEP_TYPES.includes(step.type));
 
-    for (const step of filteredSteps) {
+    // Ensure the first USER_REQUEST step is processed first
+    const firstUserRequestIndex = filteredSteps.findIndex(step => step.type === "USER_REQUEST");
+    let reorderedSteps = filteredSteps;
+
+    if (firstUserRequestIndex > 0) {
+        // Move the first USER_REQUEST to the beginning
+        const firstUserRequest = filteredSteps[firstUserRequestIndex];
+        reorderedSteps = [firstUserRequest, ...filteredSteps.slice(0, firstUserRequestIndex), ...filteredSteps.slice(firstUserRequestIndex + 1)];
+    }
+
+    for (const step of reorderedSteps) {
         // Special handling for AGENT_LLM_RESPONSE_TOOL_DECISION if it's a peer delegation trigger
         // This step often precedes AGENT_TOOL_INVOCATION_START for peers.
         // The plan implies AGENT_TOOL_INVOCATION_START is the primary trigger for peer delegation.


### PR DESCRIPTION
The message of User Request and LLM request almost happens at the same time. 
Because they have the different timestamp source, it could results LLM request happens a couple of millisecond ahead of User Request, which causes LLM node is not created in the flowchart as it depends on the User node first.

Before the timestamp issue is solved, this change manually put the User Request step as the first step in a task step array to fix the missing LLM node in some cases.