### PR TITLE
DATAGO-108430: Fix log level stdio configuration

### DIFF
--- a/cli/commands/run_cmd.py
+++ b/cli/commands/run_cmd.py
@@ -66,6 +66,20 @@ def run(files: tuple[str, ...], skip_files: tuple[str, ...], system_env: bool):
         if env_path:
             click.echo(f"Loading environment variables from: {env_path}")
             load_dotenv(dotenv_path=env_path, override=True)
+
+            # Resolve LOGGING_CONFIG_PATH to absolute path if it's relative
+            logging_config_path = os.getenv("LOGGING_CONFIG_PATH")
+            if logging_config_path and not os.path.isabs(logging_config_path):
+                absolute_logging_path = os.path.abspath(logging_config_path)
+                os.environ["LOGGING_CONFIG_PATH"] = absolute_logging_path
+
+            # Reconfigure logging now that environment variables are loaded
+            try:
+                from solace_ai_connector.common.log import reconfigure_logging
+                if reconfigure_logging():
+                    click.echo("Logging reconfigured from LOGGING_CONFIG_PATH")
+            except ImportError:
+                pass  # solace_ai_connector might not be available yet
         else:
             click.echo(
                 click.style(


### PR DESCRIPTION
### What is the purpose of this change?
Re-configuring the logging after solace ai connector startup

### How is this accomplished?
Calling the reconfigure logging once the `run` command is called

### Anything reviews should focus on/be aware of?
This change goes hand to hand with another change in the solace-ai-connector repo
Does not rely on the changes to solace-ai-connector