### PR TITLE
BUG: fix enterprise init

### DIFF
--- a/src/solace_agent_mesh/common/utils/initializer.py
+++ b/src/solace_agent_mesh/common/utils/initializer.py
@@ -24,8 +24,7 @@ def initialize():
     if enterprise_config and isinstance(enterprise_config, str):
         if enterprise_config.endswith('.yaml') or enterprise_config.endswith('.yml'):
             try:
-                with open(enterprise_config, 'r', encoding='utf-8') as file:
-                    enterprise_config = load_config(enterprise_config)
+                enterprise_config = load_config(enterprise_config)
             except Exception as e:
                 log.error("Failed to load YAML config from SAM_ENTERPRISE_CONFIG: %s", e, exc_info=True)
                 raise


### PR DESCRIPTION
Environment variables were not being dereferenced in enterprise initialization. 