### PR TITLE
REQUEST-RESPONSE: Add broker_request_response handling in SamAgentApp component definition

### DIFF
--- a/src/solace_agent_mesh/agent/sac/app.py
+++ b/src/solace_agent_mesh/agent/sac/app.py
@@ -558,6 +558,7 @@ class SamAgentApp(App):
         app_config = app_info.get("app_config", {})
         namespace = app_config.get("namespace")
         agent_name = app_config.get("agent_name")
+        broker_request_response = app_info.get("broker_request_response")
 
         if not namespace or not isinstance(namespace, str):
             raise ValueError(
@@ -626,6 +627,8 @@ class SamAgentApp(App):
             "component_config": {},
             "subscriptions": generated_subs,
         }
+        if broker_request_response:
+            component_definition["broker_request_response"] = broker_request_response
 
         app_info["components"] = [component_definition]
         log.debug("Replaced 'components' in app_info with programmatic definition.")


### PR DESCRIPTION
## What is the purpose of this change?

This change adds support for broker_request_response handling in the SamAgentApp component definition, allowing the agent to properly handle request-response patterns when communicating with the message broker.

## How is this accomplished?

- Add broker_request_response handling in SamAgentApp component definition
  - Added logic to extract broker_request_response from app_info
  - Conditionally added this configuration to the component definition when present

## Anything reviews should focus on/be aware of?
Verify that the broker_request_response parameter is properly forwarded to the component definition without modification.