### PR TITLE
DATAGO-108707: removing scroll button when response is streaming

### DIFF
--- a/client/webui/frontend/src/lib/components/ui/chat/chat-message-list.tsx
+++ b/client/webui/frontend/src/lib/components/ui/chat/chat-message-list.tsx
@@ -18,6 +18,7 @@ const ChatMessageList = React.forwardRef<ChatMessageListRef, ChatMessageListProp
         isAtBottom,
         disableAutoScroll,
         scrollToBottom,
+        userHasScrolled,
     } = useAutoScroll({
         smooth: true,
         content: children,
@@ -36,7 +37,7 @@ const ChatMessageList = React.forwardRef<ChatMessageListRef, ChatMessageListProp
                 <div className="flex flex-col gap-6" style={CHAT_STYLES}>{children}</div>
             </div>
 
-            {!isAtBottom && (
+            {!isAtBottom && userHasScrolled && (
                 <Button
                     onClick={() => {
                         scrollToBottom();

--- a/client/webui/frontend/src/lib/components/ui/chat/hooks/useAutoScroll.tsx
+++ b/client/webui/frontend/src/lib/components/ui/chat/hooks/useAutoScroll.tsx
@@ -126,5 +126,6 @@ export function useAutoScroll(options: UseAutoScrollOptions = {}) {
         autoScrollEnabled: scrollState.autoScrollEnabled,
         scrollToBottom: () => scrollToBottom(),
         disableAutoScroll,
+        userHasScrolled: userHasScrolled.current,
     };
 }


### PR DESCRIPTION
Issue:
When the agent response was streaming, the "scroll to bottom" button was appearing between message parts.

Fix:
Only show the "scroll to bottom" button when the content is not at the bottom AND the user has taken over scrolling 