### PR TITLE
fix(DATAGO-109069): Docker builds fail when installing playright chromium deps

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,25 +9,28 @@ RUN apt-get update && \
     git \
     curl \
     ffmpeg \
-    libnss3 \
-    libxss1 \
     libasound2 \
-    libxtst6 \
-    libgtk-3-0 \
-    libgbm1 \
-    libxrandr2 \
-    libu2f-udev \
+    libatk-bridge2.0-0 \
+    libatk1.0-0 \
+    libatspi2.0-0 \
+    libcairo2 \
+    libcups2 \
+    libdbus-1-3 \
     libdrm2 \
+    libgbm1 \
+    libglib2.0-0 \
+    libnspr4 \
+    libnss3 \
+    libpango-1.0-0 \
+    libx11-6 \
+    libxcb1 \
     libxcomposite1 \
     libxdamage1 \
+    libxext6 \
     libxfixes3 \
     libxkbcommon0 \
-    libatspi2.0-0 \
-    libatk1.0-0 \
-    libatk-bridge2.0-0 \
-    libcups2 \
-    fonts-liberation \
-    fonts-dejavu-core && \
+    libxrandr2 \
+    fonts-liberation && \
     curl -sL https://deb.nodesource.com/setup_24.x | bash - && \
     apt-get install -y --no-install-recommends nodejs && \
     apt-get purge -y --auto-remove && \


### PR DESCRIPTION
Playwright deps is not natively supported in python3.11-slim images: 
```
 #16 [10/14] RUN playwright install-deps chromium
#16 0.574 BEWARE: your OS is not officially supported by Playwright; installing dependencies for ubuntu20.04-x64 as a fallback.
#16 0.574 Installing dependencies...
```

The suggested workaround is to install the packages required by playwright manually instead of using playwright install-deps chromium, or finding a base image that's compatible. 

Since we want to keep this image as light as possible, we stuck with python slim