### PR TITLE
chore(DATAGO-108497): adding breadcrumb support

### DIFF
--- a/client/webui/frontend/src/lib/components/header/Header.tsx
+++ b/client/webui/frontend/src/lib/components/header/Header.tsx
@@ -1,4 +1,11 @@
+import { Button } from "@/lib/components/ui";
+import { ChevronRight } from "lucide-react";
 import React from "react";
+
+export interface BreadcrumbItem {
+    label: string;
+    onClick?: () => void;
+}
 
 export interface Tab {
     id: string;
@@ -9,19 +16,39 @@ export interface Tab {
 
 export interface HeaderProps {
     title: string;
+    breadcrumbs?: BreadcrumbItem[];
     tabs?: Tab[];
     buttons?: React.ReactNode[];
     leadingAction?: React.ReactNode;
 }
 
-export const Header: React.FC<HeaderProps> = ({ title, tabs, buttons, leadingAction }) => {
+export const Header: React.FC<HeaderProps> = ({ title, breadcrumbs, tabs, buttons, leadingAction }) => {
     return (
-        <div className="flex max-h-[80px] min-h-[80px] w-full items-center border-b px-8">
+        <div className="relative flex max-h-[80px] min-h-[80px] w-full items-center border-b px-8">
+            
+            {/* Breadcrumbs */}
+            {breadcrumbs && breadcrumbs.length > 0 && (
+                <div className="absolute top-0 left-8 flex items-center h-8">
+                    {breadcrumbs.map((crumb, index) => (
+                        <React.Fragment key={index}>
+                            {index > 0 && <span className="mx-1"><ChevronRight size={14}/></span>}
+                            {crumb.onClick ? (
+                                <Button variant="link" className="p-0 m-0" onClick={crumb.onClick}>
+                                    {crumb.label}
+                                </Button>
+                            ) : (
+                                <div>{crumb.label}</div>
+                            )}
+                        </React.Fragment>
+                    ))}
+                </div>
+            )}
+            
             {/* Leading Action */}
             {leadingAction && <div className="mr-4 flex items-center pt-[35px]">{leadingAction}</div>}
 
             {/* Title */}
-            <div className="truncate pt-[35px] text-xl text-nowrap">{title}</div>
+            <div className="truncate text-xl text-nowrap pt-[35px]">{title}</div>
 
             {/* Tabs */}
             {tabs && tabs.length > 0 && (

--- a/client/webui/frontend/src/lib/components/ui/button.tsx
+++ b/client/webui/frontend/src/lib/components/ui/button.tsx
@@ -6,8 +6,8 @@ import { cn } from "@/lib/utils";
 
 import {  Tooltip, TooltipContent, TooltipTrigger } from "./tooltip";
 
-const commonButtonStyles =
-    "text-[var(--color-primary-wMain)] hover:text-[var(--color-primary-text-w60)] hover:bg-[var(--color-primary-w10)] dark:text-[var(--color-primary-w20)] dark:hover:text-[var(--color-primary-text-w10)] dark:hover:bg-[var(--color-primary-w60)]";
+const commonTextStyles = "text-[var(--color-primary-wMain)] hover:text-[var(--color-primary-text-w60)] dark:text-[var(--color-primary-w20)] dark:hover:text-[var(--color-primary-text-w10)]";
+const commonButtonStyles = commonTextStyles + " hover:bg-[var(--color-primary-w10)] dark:hover:bg-[var(--color-primary-w60)]";
 
 const buttonVariants = cva(
     "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-sm font-semibold transition-all disabled:opacity-50 [&_svg]:pointer-events-none [&_svg:not([class*='size-'])]:size-4 shrink-0 [&_svg]:shrink-0 cursor-pointer disabled:cursor-not-allowed disabled:hover:bg-transparent dark:disabled:hover:bg-transparent",
@@ -19,7 +19,7 @@ const buttonVariants = cva(
                 outline: commonButtonStyles + " border border-1 border-[var(--color-primary-wMain)]",
                 secondary: commonButtonStyles,
                 ghost: commonButtonStyles,
-                link: "underline-offset-4 hover:underline",
+                link: commonTextStyles + " underline-offset-4 hover:underline",
             },
             size: {
                 default: "h-9 px-5 py-2 has-[>svg]:px-3",


### PR DESCRIPTION
Adding basic breadcrumb support to header. 
Note: we are still using a single page app so no href is supported, only `onClick`.

<img width="464" height="237" alt="Screenshot 2025-08-20 at 4 42 45 PM" src="https://github.com/user-attachments/assets/0170b189-c52f-48f2-99b3-69ff2f85d2f9" />
