### PR TITLE
chore(DATAGO-110389): improving handling of decoding errors 

### DIFF
--- a/client/webui/frontend/src/lib/components/chat/ChatMessage.tsx
+++ b/client/webui/frontend/src/lib/components/chat/ChatMessage.tsx
@@ -55,7 +55,6 @@ const MessageContent: React.FC<{ message: MessageFE }> = ({ message }) => {
         modifiedText = modifiedText.replace(item.originalMatch, "");
 
         if (item.type === "file") {
-            // This is our new case for non-renderable data URIs
             const fileAttachment: FileAttachment = {
                 name: item.filename || "downloaded_file",
                 content: item.content,
@@ -66,24 +65,15 @@ const MessageContent: React.FC<{ message: MessageFE }> = ({ message }) => {
                     <FileAttachmentMessage fileAttachment={fileAttachment} isEmbedded={true} />
                 </div>
             );
-        } else {
-            // Existing logic for renderable content
-            let finalContent = item.content;
-            if (!RENDER_TYPES_WITH_RAW_CONTENT.includes(item.type)) {
-                try {
-                    finalContent = decodeBase64Content(item.content);
-                } catch (e) {
-                    console.error("Failed to decode base64 content for embedded item:", e);
-                    setRenderError("Failed to decode content for preview.");
-                    // maybe skip this item
-                    return;
-                }
+        } else if (!RENDER_TYPES_WITH_RAW_CONTENT.includes(item.type)) {
+            const finalContent = decodeBase64Content(item.content);
+            if (finalContent) {
+                contentElements.push(
+                    <div key={`embedded-${index}`} className="my-2 h-auto w-md max-w-md overflow-hidden">
+                        <ContentRenderer content={finalContent} rendererType={item.type} mime_type={item.mimeType} setRenderError={setRenderError} />
+                    </div>
+                );
             }
-            contentElements.push(
-                <div key={`embedded-${index}`} className="my-2 h-auto w-md max-w-md overflow-hidden">
-                    <ContentRenderer content={finalContent} rendererType={item.type} mime_type={item.mimeType} setRenderError={setRenderError} />
-                </div>
-            );
         }
     });
 

--- a/client/webui/frontend/src/lib/components/chat/preview/previewUtils.ts
+++ b/client/webui/frontend/src/lib/components/chat/preview/previewUtils.ts
@@ -200,7 +200,6 @@ export function getRenderType(fileName?: string, mimeType?: string): string | nu
         return "yaml";
     }
 
-
     if (isCsvFile(fileName, mimeType)) {
         return "csv";
     }
@@ -224,7 +223,6 @@ export function getRenderType(fileName?: string, mimeType?: string): string | nu
  */
 export function decodeBase64Content(content: string): string {
     try {
-
         const bytes = Uint8Array.from(atob(content), c => c.charCodeAt(0));
         return new TextDecoder("utf-8", { fatal: false }).decode(bytes);
     } catch (error) {
@@ -234,7 +232,7 @@ export function decodeBase64Content(content: string): string {
             return atob(content);
         } catch (atobError) {
             console.error("Failed to decode base64 content with atob fallback:", atobError);
-            throw new Error("Invalid base64 string");
+            return content;
         }
     }
 }


### PR DESCRIPTION
If the BE returned a message with string content that was not base64 encoded, the FE would fall over in the attempt to decode it. Now, it will be rendered as is. This can likely be improved and BE changes are coming to improve the content returned, but this change will prevent the UI from falling over.