### PR TITLE
rename package so it is recognized with local install

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ requires = ["hatchling"]
 build-backend = "hatchling.build"
 
 [project]
-name = "solace-agent-mesh"
+name = "solace_agent_mesh"
 dynamic = ["version"]
 description = "Solace Agent Mesh is an open-source framework for building event-driven, multi-agent AI systems where specialized agents collaborate on complex tasks."
 readme = "README.md"


### PR DESCRIPTION
get error before name change with pip install -e . 

Traceback (most recent call last):
  File "line 5, in <module>
    from solace_agent_mesh.cli.main import cli
ModuleNotFoundError: No module named 'solace_agent_mesh.cli'

