### PR TITLE
chore(DATAGO-111340): tidying session ui (part 1)

### DIFF
--- a/client/webui/frontend/src/lib/components/chat/ChatSessionDeleteDialog.tsx
+++ b/client/webui/frontend/src/lib/components/chat/ChatSessionDeleteDialog.tsx
@@ -8,19 +8,19 @@ import {
 } from "@/lib/components/ui/dialog";
 import { Button } from "@/lib/components/ui/button";
 
-interface DeleteConfirmationModalProps {
+interface ChatSessionDeleteDialogProps {
   isOpen: boolean;
   onClose: () => void;
   onConfirm: () => void;
   sessionName: string;
 }
 
-const DeleteConfirmationModal = ({
+export const ChatSessionDeleteDialog = ({
   isOpen,
   onClose,
   onConfirm,
   sessionName,
-}: DeleteConfirmationModalProps) => {
+}: ChatSessionDeleteDialogProps) => {
   if (!isOpen) {
     return null;
   }
@@ -29,23 +29,16 @@ const DeleteConfirmationModal = ({
     <Dialog open={isOpen} onOpenChange={onClose}>
       <DialogContent>
         <DialogHeader>
-          <DialogTitle>Are you sure?</DialogTitle>
+          <DialogTitle>Delete Chat Session?</DialogTitle>
           <DialogDescription>
-            This action cannot be undone. This will permanently delete the chat
-            session: <strong>{sessionName}</strong>.
+            This action cannot be undone. This chat session and any associated artifacts will be permanently deleted: <strong>{sessionName}</strong>.
           </DialogDescription>
         </DialogHeader>
         <DialogFooter>
-          <Button variant="outline" onClick={onClose}>
-            Cancel
-          </Button>
-          <Button variant="destructive" onClick={onConfirm}>
-            Delete
-          </Button>
+          <Button variant="outline" onClick={onClose} title="Cancel">Cancel</Button>
+          <Button onClick={onConfirm} title="Delete">Delete</Button>
         </DialogFooter>
       </DialogContent>
     </Dialog>
   );
 };
-
-export default DeleteConfirmationModal;

--- a/client/webui/frontend/src/lib/components/pages/ChatPage.tsx
+++ b/client/webui/frontend/src/lib/components/pages/ChatPage.tsx
@@ -13,7 +13,7 @@ import { useChatContext, useSessionPreview, useTaskContext } from "@/lib/hooks";
 import { ChatSidePanel } from "../chat/ChatSidePanel";
 import { ChatSessionDialog } from "../chat/ChatSessionDialog";
 import { SessionSidePanel } from "../chat/SessionSidePanel";
-import DeleteConfirmationModal from "../chat/DeleteConfirmationModal";
+import { ChatSessionDeleteDialog } from "../chat/ChatSessionDeleteDialog";
 import type { ChatMessageListRef } from "../ui/chat/chat-message-list";
 
 // Constants for sidepanel behavior
@@ -251,7 +251,7 @@ export function ChatPage() {
                 </div>
             </div>
             <ChatSessionDialog isOpen={isChatSessionDialogOpen} onClose={() => setChatSessionDialogOpen(false)} />
-            <DeleteConfirmationModal
+            <ChatSessionDeleteDialog
                 isOpen={!!sessionToDelete}
                 onClose={closeSessionDeleteModal}
                 onConfirm={confirmSessionDelete}

--- a/client/webui/frontend/src/lib/hooks/index.ts
+++ b/client/webui/frontend/src/lib/hooks/index.ts
@@ -1,4 +1,4 @@
-export * from "./useAgents";
+export * from "./useAgentCards";
 export * from "./useArtifacts";
 export * from "./useAuthContext";
 export * from "./useBeforeUnload";

--- a/client/webui/frontend/src/lib/hooks/useSessionPreview.ts
+++ b/client/webui/frontend/src/lib/hooks/useSessionPreview.ts
@@ -5,7 +5,7 @@ import { useChatContext } from "./useChatContext";
 
 
 export const useSessionPreview = (): string => {
-    const { messages, sessionName } = useChatContext();
+    const { messages } = useChatContext();
 
     return useMemo(() => {
         const firstUserMessage = messages.find(msg => {
@@ -24,5 +24,5 @@ export const useSessionPreview = (): string => {
         }
 
         return "New Chat";
-    }, [messages, sessionName]);
+    }, [messages]);
 };


### PR DESCRIPTION
This PR:
* removes lint warnings in session support
* updates the sessions UI to be more consistent with Solace styles and components

https://github.com/user-attachments/assets/b09ed6ca-25bd-4968-9472-ac844b199301


Note: there is an outstanding bug around chat session naming - they are inconsistent between side panel, chat and dialog.