### PR TITLE
BUG-FIXES: fix(registry_manager): Clean file paths and sanitize registry names

### DIFF
--- a/cli/commands/run_cmd.py
+++ b/cli/commands/run_cmd.py
@@ -119,7 +119,7 @@ def run(files: tuple[str, ...], skip_files: tuple[str, ...], system_env: bool):
                 "shared_config"
             ):
                 click.echo(
-                    f"  Skipping discovery: {filepath.relative_to(project_root)} (underscore prefix or shared_config)"
+                    f"  Skipping discovery: {filepath} (underscore prefix or shared_config)"
                 )
                 continue
             config_files_to_run.append(str(filepath.resolve()))
@@ -129,7 +129,7 @@ def run(files: tuple[str, ...], skip_files: tuple[str, ...], system_env: bool):
                 "shared_config"
             ):
                 click.echo(
-                    f"  Skipping discovery: {filepath.relative_to(project_root)} (underscore prefix or shared_config)"
+                    f"  Skipping discovery: {filepath} (underscore prefix or shared_config)"
                 )
                 continue
             if str(filepath.resolve()) not in config_files_to_run:
@@ -148,7 +148,7 @@ def run(files: tuple[str, ...], skip_files: tuple[str, ...], system_env: bool):
                             "shared_config"
                         ):
                             click.echo(
-                                f"  Skipping discovery: {filepath.relative_to(path)} (underscore prefix or shared_config)"
+                                f"  Skipping discovery: {filepath} (underscore prefix or shared_config)"
                             )
                             continue
                         processed_files.add(str(filepath.resolve()))
@@ -168,7 +168,7 @@ def run(files: tuple[str, ...], skip_files: tuple[str, ...], system_env: bool):
         for cf in config_files_to_run:
             if os.path.basename(cf) in skipped_basenames:
                 click.echo(
-                    f"  Skipping execution: {Path(cf).relative_to(project_root)} (due to --skip)"
+                    f"  Skipping execution: {cf} (due to --skip)"
                 )
                 continue
             final_list.append(cf)
@@ -184,9 +184,6 @@ def run(files: tuple[str, ...], skip_files: tuple[str, ...], system_env: bool):
 
     click.echo(click.style("Final list of configuration files to run:", bold=True))
     for cf_path_str in config_files_to_run:
-        try:
-            click.echo(f"  - {Path(cf_path_str).relative_to(project_root)}")
-        except ValueError:
             click.echo(f"  - {cf_path_str}")
 
     return_code = _execute_with_solace_ai_connector(config_files_to_run)

--- a/config_portal/backend/plugin_catalog/registry_manager.py
+++ b/config_portal/backend/plugin_catalog/registry_manager.py
@@ -109,10 +109,9 @@ class RegistryManager:
                 final_name = Path(original_path_or_url).name.replace(".git", "")
             else:
                 final_name = Path(path_or_url).name
-        else:
-            # Sanitize name to be filesystem-friendly
-            final_name = "".join(c if c.isalnum() else '_' for c in final_name)
 
+        # Sanitize name to be filesystem-friendly
+        final_name = "".join(c if c.isalnum() else '_' for c in final_name)
         is_official_src = path_or_url == DEFAULT_OFFICIAL_REGISTRY_URL
 
         try:

--- a/config_portal/backend/plugin_catalog/registry_manager.py
+++ b/config_portal/backend/plugin_catalog/registry_manager.py
@@ -46,7 +46,7 @@ class RegistryManager:
 
         if self.user_registries_file.exists():
             try:
-                with open(self.user_registries_file, "r") as f:
+                with open(self.user_registries_file, "r", encoding="utf-8") as f:
                     loaded_data = json.load(f)
                     if isinstance(loaded_data, list):
                         for reg_dict in loaded_data:
@@ -102,13 +102,16 @@ class RegistryManager:
                 return False
 
         registry_id = self._generate_registry_id(path_or_url)
-
+   
         final_name = name
         if not final_name:
             if registry_type == "git":
                 final_name = Path(original_path_or_url).name.replace(".git", "")
             else:
                 final_name = Path(path_or_url).name
+        else:
+            # Sanitize name to be filesystem-friendly
+            final_name = "".join(c if c.isalnum() else '_' for c in final_name)
 
         is_official_src = path_or_url == DEFAULT_OFFICIAL_REGISTRY_URL
 
@@ -128,7 +131,7 @@ class RegistryManager:
         current_registries_data: List[Dict[str, Any]] = []
         if self.user_registries_file.exists():
             try:
-                with open(self.user_registries_file, "r") as f:
+                with open(self.user_registries_file, "r", encoding="utf-8") as f:
                     loaded_data = json.load(f)
                     if isinstance(loaded_data, list):
                         current_registries_data = [
@@ -154,7 +157,7 @@ class RegistryManager:
         current_registries_data.append(new_registry.model_dump())
 
         try:
-            with open(self.user_registries_file, "w") as f:
+            with open(self.user_registries_file, "w", encoding="utf-8") as f:
                 json.dump(current_registries_data, f, indent=2)
             return True
         except Exception as e:


### PR DESCRIPTION
## What is the purpose of this change?

This pull request addresses issue #262 by fixing filepath handling in the registry manager and implementing registry name sanitization to ensure filesystem compatibility.

## How is this accomplished?

- fix(registry_manager): Cleaned file path and sanitize registry names.
  - Improved display of file paths in the run command by removing the unnecessary conversion to relative paths
  - Added proper UTF-8 encoding when reading/writing registry files
  - Added sanitization of registry names to ensure they're filesystem-friendly by converting non-alphanumeric characters to underscores

## Anything reviews should focus on/be aware of?

The registry name sanitization implementation converts all non-alphanumeric characters to underscores. Reviewers should consider if this approach is sufficient or if a more nuanced sanitization might be needed for certain use cases.