### PR TITLE
fix(DATAGO-111703): Buffer task events that arrive in the gateway before the frontend creates an SSE connection

### DIFF
--- a/src/solace_agent_mesh/gateway/http_sse/app.py
+++ b/src/solace_agent_mesh/gateway/http_sse/app.py
@@ -44,6 +44,14 @@ class WebUIBackendAppConfig(BaseGatewayAppConfig):
         default=200,
         description="Maximum size of the SSE connection queues. Adjust based on expected load.",
     )
+    sse_buffer_max_age_seconds: int = Field(
+        default=600,  # 10 minutes
+        description="Maximum age in seconds for a pending event buffer before it is cleaned up.",
+    )
+    sse_buffer_cleanup_interval_seconds: int = Field(
+        default=300,  # 5 minutes
+        description="How often to run the cleanup task for stale pending event buffers.",
+    )
     resolve_artifact_uris_in_gateway: bool = Field(
         default=True,
         description="If true, the gateway will resolve artifact:// URIs found in A2A messages and embed the content as bytes before sending to the UI. If false, URIs are passed through.",

--- a/src/solace_agent_mesh/gateway/http_sse/sse_event_buffer.py
+++ b/src/solace_agent_mesh/gateway/http_sse/sse_event_buffer.py
@@ -1,0 +1,79 @@
+"""
+A thread-safe buffer for holding early SSE events before a client connects.
+"""
+import datetime
+import threading
+from typing import Any, Dict, List, Optional, Tuple
+
+from solace_ai_connector.common.log import log
+
+
+class SSEEventBuffer:
+    """Manages buffering and cleanup of SSE events for tasks without active listeners."""
+
+    def __init__(self, max_queue_size: int, max_age_seconds: int):
+        self._pending_events: Dict[str, Tuple[datetime.datetime, List[Dict[str, Any]]]] = {}
+        self._lock = threading.Lock()
+        self._max_queue_size = max_queue_size
+        self._max_age_seconds = max_age_seconds
+        self.log_identifier = "[SSEEventBuffer]"
+        log.info(
+            "%s Initialized with max_age:%ds, max_size:%d",
+            self.log_identifier,
+            self._max_age_seconds,
+            self._max_queue_size,
+        )
+
+    def buffer_event(self, task_id: str, event: Dict[str, Any]):
+        """Buffers an event for a given task ID."""
+        with self._lock:
+            if task_id not in self._pending_events:
+                self._pending_events[task_id] = (datetime.datetime.now(datetime.timezone.utc), [])
+
+            if len(self._pending_events[task_id][1]) < self._max_queue_size:
+                self._pending_events[task_id][1].append(event)
+            else:
+                log.warning(
+                    "%s Buffer full for Task ID: %s. Event dropped.",
+                    self.log_identifier,
+                    task_id,
+                )
+
+    def get_and_remove_buffer(self, task_id: str) -> Optional[List[Dict[str, Any]]]:
+        """Atomically retrieves and removes the event buffer for a task."""
+        with self._lock:
+            buffer_tuple = self._pending_events.pop(task_id, None)
+            if buffer_tuple:
+                log.info(
+                    "%s Flushing %d events for Task ID: %s",
+                    self.log_identifier,
+                    len(buffer_tuple[1]),
+                    task_id,
+                )
+                return buffer_tuple[1]
+            return None
+
+    def remove_buffer(self, task_id: str):
+        """Explicitly removes a buffer for a task, e.g., on finalization."""
+        with self._lock:
+            if self._pending_events.pop(task_id, None):
+                log.debug("%s Removed buffer for task %s.", self.log_identifier, task_id)
+
+    def cleanup_stale_buffers(self):
+        """Removes all pending event buffers older than the max age."""
+        with self._lock:
+            now = datetime.datetime.now(datetime.timezone.utc)
+            stale_tasks = [
+                task_id
+                for task_id, (timestamp, _) in self._pending_events.items()
+                if (now - timestamp).total_seconds() > self._max_age_seconds
+            ]
+
+            if stale_tasks:
+                log.info(
+                    "%s Cleaning up %d stale event buffers.",
+                    self.log_identifier,
+                    len(stale_tasks),
+                )
+                for task_id in stale_tasks:
+                    del self._pending_events[task_id]

--- a/src/solace_agent_mesh/gateway/http_sse/sse_event_buffer.py
+++ b/src/solace_agent_mesh/gateway/http_sse/sse_event_buffer.py
@@ -1,6 +1,7 @@
 """
 A thread-safe buffer for holding early SSE events before a client connects.
 """
+
 import datetime
 import threading
 from typing import Any, Dict, List, Optional, Tuple
@@ -12,12 +13,14 @@ class SSEEventBuffer:
     """Manages buffering and cleanup of SSE events for tasks without active listeners."""
 
     def __init__(self, max_queue_size: int, max_age_seconds: int):
-        self._pending_events: Dict[str, Tuple[datetime.datetime, List[Dict[str, Any]]]] = {}
+        self._pending_events: Dict[
+            str, Tuple[datetime.datetime, List[Dict[str, Any]]]
+        ] = {}
         self._lock = threading.Lock()
         self._max_queue_size = max_queue_size
         self._max_age_seconds = max_age_seconds
         self.log_identifier = "[SSEEventBuffer]"
-        log.info(
+        log.debug(
             "%s Initialized with max_age:%ds, max_size:%d",
             self.log_identifier,
             self._max_age_seconds,
@@ -28,7 +31,10 @@ class SSEEventBuffer:
         """Buffers an event for a given task ID."""
         with self._lock:
             if task_id not in self._pending_events:
-                self._pending_events[task_id] = (datetime.datetime.now(datetime.timezone.utc), [])
+                self._pending_events[task_id] = (
+                    datetime.datetime.now(datetime.timezone.utc),
+                    [],
+                )
 
             if len(self._pending_events[task_id][1]) < self._max_queue_size:
                 self._pending_events[task_id][1].append(event)
@@ -44,7 +50,7 @@ class SSEEventBuffer:
         with self._lock:
             buffer_tuple = self._pending_events.pop(task_id, None)
             if buffer_tuple:
-                log.info(
+                log.debug(
                     "%s Flushing %d events for Task ID: %s",
                     self.log_identifier,
                     len(buffer_tuple[1]),
@@ -57,7 +63,9 @@ class SSEEventBuffer:
         """Explicitly removes a buffer for a task, e.g., on finalization."""
         with self._lock:
             if self._pending_events.pop(task_id, None):
-                log.debug("%s Removed buffer for task %s.", self.log_identifier, task_id)
+                log.debug(
+                    "%s Removed buffer for task %s.", self.log_identifier, task_id
+                )
 
     def cleanup_stale_buffers(self):
         """Removes all pending event buffers older than the max age."""
@@ -70,7 +78,7 @@ class SSEEventBuffer:
             ]
 
             if stale_tasks:
-                log.info(
+                log.debug(
                     "%s Cleaning up %d stale event buffers.",
                     self.log_identifier,
                     len(stale_tasks),

--- a/src/solace_agent_mesh/gateway/http_sse/sse_manager.py
+++ b/src/solace_agent_mesh/gateway/http_sse/sse_manager.py
@@ -67,7 +67,6 @@ class SSEManager:
         else:
             return str(obj)
 
-
     async def create_sse_connection(self, task_id: str) -> asyncio.Queue:
         """
         Creates a new queue for an SSE connection subscribing to a task.
@@ -159,8 +158,7 @@ class SSEManager:
 
             try:
                 serialized_data = json.dumps(
-                    self._sanitize_json(event_data),
-                    allow_nan=False
+                    self._sanitize_json(event_data), allow_nan=False
                 )
             except Exception as json_err:
                 log.error(

--- a/src/solace_agent_mesh/gateway/http_sse/sse_manager.py
+++ b/src/solace_agent_mesh/gateway/http_sse/sse_manager.py
@@ -91,7 +91,7 @@ class SSEManager:
                     await connection_queue.put(event)
 
             self._connections[task_id].append(connection_queue)
-            log.info(
+            log.debug(
                 "%s Created SSE connection queue for Task ID: %s. Total queues for task: %d",
                 self.log_identifier,
                 task_id,
@@ -114,7 +114,7 @@ class SSEManager:
             if task_id in self._connections:
                 try:
                     self._connections[task_id].remove(connection_queue)
-                    log.info(
+                    log.debug(
                         "%s Removed SSE connection queue for Task ID: %s. Remaining queues: %d",
                         self.log_identifier,
                         task_id,
@@ -122,7 +122,7 @@ class SSEManager:
                     )
                     if not self._connections[task_id]:
                         del self._connections[task_id]
-                        log.info(
+                        log.debug(
                             "%s Removed Task ID entry: %s as no connections remain.",
                             self.log_identifier,
                             task_id,
@@ -236,7 +236,7 @@ class SSEManager:
 
                 if not current_queues:
                     del self._connections[task_id]
-                    log.info(
+                    log.debug(
                         "%s Removed Task ID entry: %s after cleaning queues.",
                         self.log_identifier,
                         task_id,
@@ -247,7 +247,7 @@ class SSEManager:
         Signals a specific SSE connection queue to close by putting None.
         Also removes the queue from the manager.
         """
-        log.info(
+        log.debug(
             "%s Closing specific SSE connection queue for Task ID: %s",
             self.log_identifier,
             task_id,
@@ -288,7 +288,7 @@ class SSEManager:
                 # This is the "normal" case: a client is or was connected.
                 # It's safe to clean up everything.
                 queues_to_close = self._connections.pop(task_id)
-                log.info(
+                log.debug(
                     "%s Closing %d SSE connections for Task ID: %s and cleaning up buffer.",
                     self.log_identifier,
                     len(queues_to_close),
@@ -319,7 +319,7 @@ class SSEManager:
 
                 # Since a connection existed, the buffer is no longer needed.
                 self._event_buffer.remove_buffer(task_id)
-                log.info(
+                log.debug(
                     "%s Removed Task ID entry: %s and signaled queues to close.",
                     self.log_identifier,
                     task_id,
@@ -350,7 +350,7 @@ class SSEManager:
         self.cleanup_old_locks()
         lock = self._get_lock()
         async with lock:
-            log.info("%s Closing all active SSE connections...", self.log_identifier)
+            log.debug("%s Closing all active SSE connections...", self.log_identifier)
             all_task_ids = list(self._connections.keys())
             closed_count = 0
             for task_id in all_task_ids:
@@ -362,7 +362,7 @@ class SSEManager:
                             await asyncio.wait_for(q.put(None), timeout=0.1)
                         except Exception:
                             pass
-            log.info(
+            log.debug(
                 "%s Closed %d connections for tasks: %s",
                 self.log_identifier,
                 closed_count,


### PR DESCRIPTION
It seems to be possible sometimes for an agent to send events back to the user before the SSE connection is established for that task. We need to buffer those events until the SSE connection arrives