### PR TITLE
feat: pass user profile to the get_user_profile

### DIFF
--- a/src/solace_agent_mesh/common/services/identity_service.py
+++ b/src/solace_agent_mesh/common/services/identity_service.py
@@ -33,7 +33,7 @@ class BaseIdentityService(ABC):
 
     @abstractmethod
     async def get_user_profile(
-        self, auth_claims: Dict[str, Any]
+        self, auth_claims: Dict[str, Any], **kwargs: Any
     ) -> Optional[Dict[str, Any]]:
         """
         Fetches additional profile details for an already authenticated user.
@@ -42,6 +42,7 @@ class BaseIdentityService(ABC):
             auth_claims: A dictionary of claims from the primary authentication
                          system (e.g., decoded JWT, session data). It's guaranteed
                          to contain at least a primary user identifier.
+            kwargs: Optional additional parameters for provider-specific logic.
 
         Returns:
             A dictionary containing additional user details (e.g., title, manager)

--- a/src/solace_agent_mesh/common/services/providers/local_file_identity_service.py
+++ b/src/solace_agent_mesh/common/services/providers/local_file_identity_service.py
@@ -68,7 +68,7 @@ class LocalFileIdentityService(BaseIdentityService):
             raise
 
     async def get_user_profile(
-        self, auth_claims: Dict[str, Any]
+        self, auth_claims: Dict[str, Any], **kwargs: Any
     ) -> Optional[Dict[str, Any]]:
         """Looks up a user profile from the in-memory index."""
         lookup_value = auth_claims.get(self.lookup_key)

--- a/src/solace_agent_mesh/gateway/http_sse/main.py
+++ b/src/solace_agent_mesh/gateway/http_sse/main.py
@@ -376,7 +376,8 @@ def setup_dependencies(component: "WebUIBackendComponent", database_url: str = N
                             else user_identifier
                         )
                         user_profile = await identity_service.get_user_profile(
-                            {identity_service.lookup_key: lookup_value}
+                            {identity_service.lookup_key: lookup_value}, 
+                            user_info=user_info
                         )
                         if not user_profile:
                             log.error(


### PR DESCRIPTION
This change sends the whole user information to the identity provider. It is necessary because some Identity Providers need more information than the lookup identifier.