### PR TITLE
feat(DATAGO-111479): Improve Mermaid diagram Rendering

### DIFF
--- a/client/webui/frontend/src/lib/components/chat/ChatMessage.tsx
+++ b/client/webui/frontend/src/lib/components/chat/ChatMessage.tsx
@@ -69,7 +69,7 @@ const MessageContent: React.FC<{ message: MessageFE }> = ({ message }) => {
             const finalContent = decodeBase64Content(item.content);
             if (finalContent) {
                 contentElements.push(
-                    <div key={`embedded-${index}`} className="my-2 h-auto w-md max-w-md overflow-hidden">
+                    <div key={`embedded-${index}`} className="my-2 h-auto w-md max-w-md">
                         <ContentRenderer content={finalContent} rendererType={item.type} mime_type={item.mimeType} setRenderError={setRenderError} />
                     </div>
                 );
@@ -143,7 +143,7 @@ const getChatBubble = (message: MessageFE, chatContext: ChatContextValue, isLast
             <ChatBubbleMessage variant={variant}>
                 {textContent && <MessageContent message={message} />}
                 {message.artifactNotification && (
-                    <div className="flex items-center p-2 my-1 bg-blue-100 dark:bg-blue-900/50 rounded-md">
+                    <div className="my-1 flex items-center rounded-md bg-blue-100 p-2 dark:bg-blue-900/50">
                         <FileText className="mr-2 text-blue-500 dark:text-blue-400" />
                         <span className="text-sm">
                             Artifact created: <strong>{message.artifactNotification.name}</strong>

--- a/client/webui/frontend/src/lib/components/chat/preview/Renderers/MermaidRenderer.tsx
+++ b/client/webui/frontend/src/lib/components/chat/preview/Renderers/MermaidRenderer.tsx
@@ -196,12 +196,12 @@ export const MermaidRenderer: React.FC<BaseRendererProps> = ({ content, setRende
     }, [sanitizedContent]);
 
     return (
-        <div className="bg-background h-full max-w-[100vw] overflow-hidden p-4">
+        <div className="bg-background h-full p-4">
             <iframe
                 srcDoc={srcDoc}
                 title="Mermaid Diagram Preview"
                 sandbox="allow-scripts allow-same-origin allow-downloads"
-                className="h-full w-full border-none"
+                className="h-96 w-full resize border-none"
                 onError={() => setRenderError("Failed to load Mermaid content.")}
                 onLoad={() => setRenderError(null)}
             />


### PR DESCRIPTION
# Description
Made Mermaid diagrams larger by default and made them resizable

# Example
<img width="963" height="625" alt="Screenshot 2025-09-16 at 9 54 24 AM" src="https://github.com/user-attachments/assets/9149736c-841e-4295-9cdc-eea4e676f15e" />
