### PR TITLE
fix: add user_profile

### DIFF
--- a/src/solace_agent_mesh/common/services/identity_service.py
+++ b/src/solace_agent_mesh/common/services/identity_service.py
@@ -33,7 +33,7 @@ class BaseIdentityService(ABC):
 
     @abstractmethod
     async def get_user_profile(
-        self, auth_claims: Dict[str, Any], **kwargs: Any
+        self, auth_claims: Dict[str, Any]
     ) -> Optional[Dict[str, Any]]:
         """
         Fetches additional profile details for an already authenticated user.

--- a/src/solace_agent_mesh/common/services/providers/local_file_identity_service.py
+++ b/src/solace_agent_mesh/common/services/providers/local_file_identity_service.py
@@ -68,7 +68,7 @@ class LocalFileIdentityService(BaseIdentityService):
             raise
 
     async def get_user_profile(
-        self, auth_claims: Dict[str, Any], **kwargs: Any
+        self, auth_claims: Dict[str, Any]
     ) -> Optional[Dict[str, Any]]:
         """Looks up a user profile from the in-memory index."""
         lookup_value = auth_claims.get(self.lookup_key)

--- a/src/solace_agent_mesh/gateway/http_sse/component.py
+++ b/src/solace_agent_mesh/gateway/http_sse/component.py
@@ -844,6 +844,7 @@ class WebUIBackendComponent(BaseGatewayComponent):
 
         request = external_event_data
         try:
+            user_info = {}
             if hasattr(request.state, "user") and request.state.user:
                 user_info = request.state.user
                 username = user_info.get("username")
@@ -853,7 +854,7 @@ class WebUIBackendComponent(BaseGatewayComponent):
                         log_id_prefix,
                         username,
                     )
-                    return {"id": username, "name": username, "email": username}
+                    return {"id": username, "name": username, "email": username, "user_info": user_info}
 
             log.debug(
                 "%s No authenticated user in request.state, falling back to SessionManager.",
@@ -863,7 +864,7 @@ class WebUIBackendComponent(BaseGatewayComponent):
             log.debug(
                 "%s Extracted user_id '%s' via SessionManager.", log_id_prefix, user_id
             )
-            return {"id": user_id, "name": user_id}
+            return {"id": user_id, "name": user_id, "user_info": user_info}
 
         except Exception as e:
             log.error("%s Failed to extract user_id from request: %s", log_id_prefix, e)

--- a/src/solace_agent_mesh/gateway/http_sse/main.py
+++ b/src/solace_agent_mesh/gateway/http_sse/main.py
@@ -376,8 +376,7 @@ def setup_dependencies(component: "WebUIBackendComponent", database_url: str = N
                             else user_identifier
                         )
                         user_profile = await identity_service.get_user_profile(
-                            {identity_service.lookup_key: lookup_value}, 
-                            user_info=user_info
+                            {identity_service.lookup_key: lookup_value, "user_info": user_info}
                         )
                         if not user_profile:
                             log.error(


### PR DESCRIPTION
**Goal:**
- Revert passing _kwargs_ parameter to the identity provider
- Instead, include the user profile in the auth_claims parameter