### PR TITLE
fix(DATAGO-111345): adding display name to sam agent definition

### DIFF
--- a/src/solace_agent_mesh/agent/sac/app.py
+++ b/src/solace_agent_mesh/agent/sac/app.py
@@ -217,6 +217,7 @@ class SamAgentAppConfig(SamConfigBase):
         ..., description="Absolute topic prefix for A2A communication (e.g., 'myorg/dev')."
     )
     agent_name: str = Field(..., description="Unique name for this ADK agent instance.")
+    display_name: str = Field(default=None, description="Human-friendly display name for this ADK agent instance.")
     model: Union[str, Dict[str, Any]] = Field(
         ..., description="ADK model name (string) or BaseLlm config dict."
     )


### PR DESCRIPTION
Issue:
Display names were never being returned to the FE.

Fix: 
It was traced it back to it never returning in the app config despite being in the YAML configuration. It seems that it was missing from the app configuration and thus never populated.