### PR TITLE
Build ARM images

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -130,6 +130,7 @@ jobs:
         with:
           context: .
           file: Dockerfile
+          platforms: linux/amd64,linux/arm64
           tags: ${{ steps.tag_images.outputs.tags }}
           push: ${{ fromJSON(env.DOCKER_PUSH)}}
           cache-from: type=gha

--- a/.github/workflows/push-docker.yml
+++ b/.github/workflows/push-docker.yml
@@ -120,6 +120,7 @@ jobs:
         with:
           context: .
           file: Dockerfile
+          platforms: linux/amd64,linux/arm64
           tags: ${{ steps.ecr_tags.outputs.tags }}
           push: true
           cache-from: type=gha


### PR DESCRIPTION
Now that [this PR](https://github.com/SolaceLabs/solace-agent-mesh/pull/272) is merged, we can build ARM images. Since, the existing workflows are entrenched in ECR, I can't easily test this locally. I also leverage the emulation layer instead of using an ARM builder image ([I have an example of this in my fork](https://github.com/SolaceLabs/solace-agent-mesh/compare/main...j-setiawan:solace-agent-mesh:build)) to keep this change conservative, so I expect much longer docker build times.