### PR TITLE
chore(DATAGO-111334): Add Pagination ui component

### DIFF
--- a/client/webui/frontend/src/lib/components/header/Header.tsx
+++ b/client/webui/frontend/src/lib/components/header/Header.tsx
@@ -76,7 +76,7 @@ export const Header: React.FC<HeaderProps> = ({ title, breadcrumbs, tabs, button
 
             {/* Buttons */}
             {buttons && buttons.length > 0 && (
-                <div className="flex items-center gap-2">
+                <div className="flex items-center gap-2 pt-[35px]">
                     {buttons.map((button, index) => (
                         <React.Fragment key={index}>{button}</React.Fragment>
                     ))}

--- a/client/webui/frontend/src/lib/components/ui/button.tsx
+++ b/client/webui/frontend/src/lib/components/ui/button.tsx
@@ -35,20 +35,14 @@ const buttonVariants = cva(
     }
 );
 
-function Button({
-    className,
-    variant,
-    size,
-    asChild = false,
-    tooltip = "",
-    testid = "",
-    ...props
-}: React.ComponentProps<"button"> &
+export type ButtonProps = React.ComponentProps<"button"> &
     VariantProps<typeof buttonVariants> & {
         asChild?: boolean;
         tooltip?: string;
         testid?: string;
-    }) {
+    };
+
+function Button({ className, variant, size, asChild = false, tooltip = "", testid = "", ...props }: ButtonProps) {
     const Comp = asChild ? Slot : "button";
     const buttonProps = tooltip ? { ...props, "aria-label": tooltip } : props;
     const ButtonComponent = <Comp data-slot="button" data-testid={testid || tooltip || props.title} className={cn(buttonVariants({ variant, size, className }))} {...buttonProps} />;
@@ -65,4 +59,5 @@ function Button({
     return ButtonComponent;
 }
 
-export { Button };
+// eslint-disable-next-line react-refresh/only-export-components
+export { Button, buttonVariants };

--- a/client/webui/frontend/src/lib/components/ui/index.ts
+++ b/client/webui/frontend/src/lib/components/ui/index.ts
@@ -5,6 +5,7 @@ export { Textarea } from "./textarea";
 export { Avatar, AvatarImage, AvatarFallback } from "./avatar";
 export { Dialog, DialogTrigger, DialogContent, DialogHeader, DialogTitle, DialogDescription } from "./dialog";
 export { ResizablePanelGroup, ResizablePanel, ResizableHandle } from "./resizable";
+export { Pagination, PaginationContent, PaginationLink, PaginationItem, PaginationPrevious, PaginationNext, PaginationEllipsis } from "./pagination";
 
 // Layout Components
 export { SidePanel, type SidePanelProps } from "./side-panel";

--- a/client/webui/frontend/src/lib/components/ui/pagination.tsx
+++ b/client/webui/frontend/src/lib/components/ui/pagination.tsx
@@ -1,0 +1,60 @@
+import * as React from "react";
+import { ChevronLeft, ChevronRight, MoreHorizontal } from "lucide-react";
+
+import { cn } from "@/lib/utils/index";
+import { type ButtonProps, buttonVariants } from "@/lib/components/ui/button";
+
+const Pagination = ({ className, ...props }: React.ComponentProps<"nav">) => <nav role="navigation" aria-label="pagination" className={cn("mx-auto flex w-full justify-center", className)} {...props} />;
+Pagination.displayName = "Pagination";
+
+const PaginationContent = React.forwardRef<HTMLUListElement, React.ComponentProps<"ul">>(({ className, ...props }, ref) => <ul ref={ref} className={cn("flex flex-row items-center gap-1", className)} {...props} />);
+PaginationContent.displayName = "PaginationContent";
+
+const PaginationItem = React.forwardRef<HTMLLIElement, React.ComponentProps<"li">>(({ className, ...props }, ref) => <li ref={ref} className={cn("", className)} {...props} />);
+PaginationItem.displayName = "PaginationItem";
+
+type PaginationLinkProps = {
+    isActive?: boolean;
+} & Pick<ButtonProps, "size"> &
+    React.ComponentProps<"a">;
+
+const PaginationLink = ({ className, isActive, size = "icon", ...props }: PaginationLinkProps) => (
+    <a
+        aria-current={isActive ? "page" : undefined}
+        className={cn(
+            buttonVariants({
+                variant: isActive ? "outline" : "ghost",
+                size,
+            }),
+            className
+        )}
+        {...props}
+    />
+);
+PaginationLink.displayName = "PaginationLink";
+
+const PaginationPrevious = ({ className, ...props }: React.ComponentProps<typeof PaginationLink>) => (
+    <PaginationLink aria-label="Go to previous page" size="default" className={cn("gap-1 pl-2.5", className)} {...props}>
+        <ChevronLeft className="h-4 w-4" />
+        <span>Previous</span>
+    </PaginationLink>
+);
+PaginationPrevious.displayName = "PaginationPrevious";
+
+const PaginationNext = ({ className, ...props }: React.ComponentProps<typeof PaginationLink>) => (
+    <PaginationLink aria-label="Go to next page" size="default" className={cn("gap-1 pr-2.5", className)} {...props}>
+        <span>Next</span>
+        <ChevronRight className="h-4 w-4" />
+    </PaginationLink>
+);
+PaginationNext.displayName = "PaginationNext";
+
+const PaginationEllipsis = ({ className, ...props }: React.ComponentProps<"span">) => (
+    <span aria-hidden className={cn("flex h-9 w-9 items-center justify-center", className)} {...props}>
+        <MoreHorizontal className="h-4 w-4" />
+        <span className="sr-only">More pages</span>
+    </span>
+);
+PaginationEllipsis.displayName = "PaginationEllipsis";
+
+export { Pagination, PaginationContent, PaginationLink, PaginationItem, PaginationPrevious, PaginationNext, PaginationEllipsis };


### PR DESCRIPTION
This pull request introduces a new reusable pagination component to the UI library and improves the flexibility and consistency of button components. The main changes include adding the pagination component and its exports, refactoring button types for better type safety, and making minor UI adjustments.

**UI Library Additions:**

* Added a new pagination component with supporting elements (`Pagination`, `PaginationContent`, `PaginationLink`, `PaginationItem`, `PaginationPrevious`, `PaginationNext`, `PaginationEllipsis`) in `pagination.tsx` for consistent pagination controls across the app.
* Exported the new pagination components from the UI library index file (`ui/index.ts`) to make them available for use throughout the project.

**Button Component Improvements:**

* Refactored the button component to use a dedicated `ButtonProps` type for improved type safety and maintainability.
* Updated the button component export to include both `Button` and `buttonVariants`, supporting more flexible styling and usage.

**Minor UI Adjustment:**

* Added top padding to the buttons section in the header component to improve visual alignment.