### PR TITLE
DATAGO-112640 - RBAC not working due to scopes not enforced on tools

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -152,6 +152,9 @@ playground.py
 evaluation/results/
 tests/integration/reports/
 
+#  JetBrains
+.idea/
+
 # Node
 node_modules/
 my-dev-project

--- a/src/solace_agent_mesh/agent/sac/component.py
+++ b/src/solace_agent_mesh/agent/sac/component.py
@@ -1114,9 +1114,9 @@ class SamAgentComponent(SamComponentBase):
             return tool.origin
         elif hasattr(tool.func, 'origin'):
             return tool.func.origin
-        elif hasattr(tool.func, '_original_func') and hasattr(tool.func, '_tool_name'):
-            return getattr(tool.func, 'origin', 'unknown')
-        return 'unknown'
+        else:
+            return getattr(tool, "origin", "unknown")
+
 
     def get_agent_context(self) -> Dict[str, Any]:
         """Get agent context for middleware calls."""

--- a/src/solace_agent_mesh/agent/sac/component.py
+++ b/src/solace_agent_mesh/agent/sac/component.py
@@ -997,7 +997,7 @@ class SamAgentComponent(SamComponentBase):
             for func_decl in original_tool.function_declarations:
                 func_decl_name = func_decl.name
                 tool_object = llm_request.tools_dict.get(func_decl_name)
-                origin = getattr(tool_object, "origin", "unknown")
+                origin = SamAgentComponent._extract_tool_origin(tool_object)
 
                 feature_descriptor = {
                     "feature_type": "tool_function",
@@ -1104,6 +1104,19 @@ class SamAgentComponent(SamComponentBase):
             )
 
         return None
+
+    @staticmethod
+    def _extract_tool_origin(tool) -> str:
+        """
+        Helper method to extract the origin of a tool from various possible attributes.
+        """
+        if hasattr(tool, 'origin'):
+            return tool.origin
+        elif hasattr(tool.func, 'origin'):
+            return tool.func.origin
+        elif hasattr(tool.func, '_original_func') and hasattr(tool.func, '_tool_name'):
+            return getattr(tool.func, 'origin', 'unknown')
+        return 'unknown'
 
     def get_agent_context(self) -> Dict[str, Any]:
         """Get agent context for middleware calls."""


### PR DESCRIPTION
- fixed tool origin extraction, currently this affects enterprise since RBAC is not enforced.