### PR TITLE
feat(DATAGO-UNKNOWN): Lazy load all commands

### DIFF
--- a/cli/lazy_group.py
+++ b/cli/lazy_group.py
@@ -1,0 +1,39 @@
+# in lazy_group.py
+import importlib
+import click
+
+# From the click documentation
+class LazyGroup(click.Group):
+    def __init__(self, *args, lazy_subcommands=None, **kwargs):
+        super().__init__(*args, **kwargs)
+        # lazy_subcommands is a map of the form:
+        #
+        #   {command-name} -> {module-name}.{command-object-name}
+        #
+        self.lazy_subcommands = lazy_subcommands or {}
+
+    def list_commands(self, ctx):
+        base = super().list_commands(ctx)
+        lazy = sorted(self.lazy_subcommands.keys())
+        return base + lazy
+
+    def get_command(self, ctx, cmd_name):
+        if cmd_name in self.lazy_subcommands:
+            return self._lazy_load(cmd_name)
+        return super().get_command(ctx, cmd_name)
+
+    def _lazy_load(self, cmd_name):
+        # lazily loading a command, first get the module name and attribute name
+        import_path = self.lazy_subcommands[cmd_name]
+        modname, cmd_object_name = import_path.rsplit(".", 1)
+        # do the import
+        mod = importlib.import_module(modname)
+        # get the Command object from that module
+        cmd_object = getattr(mod, cmd_object_name)
+        # check the result to make debugging easier
+        if not isinstance(cmd_object, click.Command):
+            raise ValueError(
+                f"Lazy loading of {import_path} failed by returning "
+                "a non-command object"
+            )
+        return cmd_object

--- a/cli/main.py
+++ b/cli/main.py
@@ -1,50 +1,24 @@
 import click
 import os
 import sys
-import importlib
+
+from cli.lazy_group import LazyGroup
 
 SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
 sys.path.append(os.path.dirname(SCRIPT_DIR))
 
 from cli import __version__
 
-
-class LazyCommand(click.Command):
-    """A command that imports its callback lazily when invoked"""
-
-    def __init__(self, name, module_path, command_name, **kwargs):
-        self.module_path = module_path
-        self.command_name = command_name
-        self._original_command = None
-        super().__init__(name, callback=self._lazy_callback, **kwargs)
-
-    def _lazy_callback(self, *args, **kwargs):
-        """Load the actual command on first invocation"""
-        if self._original_command is None:
-            try:
-                module = importlib.import_module(self.module_path)
-                self._original_command = getattr(module, self.command_name)
-            except (ImportError, AttributeError) as e:
-                click.echo(f"Error loading command {self.name}: {e}", err=True)
-                sys.exit(1)
-
-        # Get the context and invoke the original command
-        ctx = click.get_current_context()
-        return ctx.invoke(self._original_command, *args, **kwargs)
-
-    def get_help(self, ctx):
-        """Load command to get help text"""
-        if self._original_command is None:
-            try:
-                module = importlib.import_module(self.module_path)
-                self._original_command = getattr(module, self.command_name)
-            except (ImportError, AttributeError):
-                return "Help unavailable - command failed to load"
-
-        return self._original_command.get_help(ctx)
-
-
-@click.group()
+@click.group(context_settings=dict(help_option_names=['-h', '--help']),
+             cls=LazyGroup,
+             lazy_subcommands={
+                 "init": "cli.commands.init_cmd.init",
+                 "run": "cli.commands.run_cmd.run",
+                 "add": "cli.commands.add_cmd.add",
+                 "plugin": "cli.commands.plugin_cmd.plugin",
+                 "eval": "cli.commands.eval_cmd.eval_cmd",
+                 "docs": "cli.commands.docs_cmd.docs"
+             })
 @click.version_option(
     __version__, "-v", "--version", help="Show the CLI version and exit."
 )
@@ -52,14 +26,6 @@ def cli():
     """Solace CLI Application"""
     pass
 
-
-# Add lazy-loaded commands
-cli.add_command(LazyCommand("init", "cli.commands.init_cmd", "init"))
-cli.add_command(LazyCommand("run", "cli.commands.run_cmd", "run"))
-cli.add_command(LazyCommand("add", "cli.commands.add_cmd", "add"))
-cli.add_command(LazyCommand("plugin", "cli.commands.plugin_cmd", "plugin"))
-cli.add_command(LazyCommand("eval", "cli.commands.eval_cmd", "eval_cmd"))
-cli.add_command(LazyCommand("docs", "cli.commands.docs_cmd", "docs"))
 
 
 def main():


### PR DESCRIPTION
# What
- reduces time for sam --help by 3 seconds, tested using time command
- Speeds up sam run by an unknown amount. Not sure how to test this but it feels close to 3 seconds as well
- Manual tests indicate that this works. 
# How
Adds a Click command wrapper that calls module = __import__(self.module_path, fromlist=[self.command_name]) to import the module and call through to the function when the command wrapper happens. 
In theory there should be no changes to the underlying behaviour except that imports will happen at runtime instead of at start time and the heavy imports don't need to be imported. Like pandas etc. 

Also removed the context settings from the group annotation because -h --help are default 