### PR TITLE
(fix)DATAGO-112640 - RBAC not working due to scopes not enforced on tools - postfix

### DIFF
--- a/src/solace_agent_mesh/agent/sac/component.py
+++ b/src/solace_agent_mesh/agent/sac/component.py
@@ -1110,13 +1110,12 @@ class SamAgentComponent(SamComponentBase):
         """
         Helper method to extract the origin of a tool from various possible attributes.
         """
-        if hasattr(tool, 'origin'):
+        if hasattr(tool, "origin") and tool.origin is not None:
             return tool.origin
-        elif hasattr(tool.func, 'origin'):
+        elif hasattr(tool, "func") and hasattr(tool.func, "origin") and tool.func.origin is not None:
             return tool.func.origin
         else:
             return getattr(tool, "origin", "unknown")
-
 
     def get_agent_context(self) -> Dict[str, Any]:
         """Get agent context for middleware calls."""

--- a/tests/unit/agent/sac/test_component.py
+++ b/tests/unit/agent/sac/test_component.py
@@ -1,0 +1,56 @@
+#!/usr/bin/env python3
+"""
+Unit tests for the SamAgentComponent class
+"""
+
+import pytest
+from unittest.mock import Mock
+
+from src.solace_agent_mesh.agent.sac.component import SamAgentComponent
+
+
+class TestExtractToolOrigin:
+    """Test cases for the _extract_tool_origin static method in SamAgentComponent."""
+
+    def test_extract_tool_origin_with_direct_origin(self):
+        """Test _extract_tool_origin when tool has a direct origin attribute."""
+        tool = Mock()
+        tool.origin = "direct_origin"
+
+        result = SamAgentComponent._extract_tool_origin(tool)
+        assert result == "direct_origin"
+
+    def test_extract_tool_origin_with_func_origin(self):
+        """Test _extract_tool_origin when tool has a func with origin attribute."""
+
+        tool = Mock()
+        tool.origin = None
+        tool.func = Mock()
+        tool.func.origin = "func_origin"
+
+        result = SamAgentComponent._extract_tool_origin(tool)
+        assert result == "func_origin"
+
+    def test_extract_tool_origin_with_getattr_fallback(self):
+        """Test _extract_tool_origin when using getattr fallback."""
+
+        class CustomTool:
+            pass
+
+        custom_tool = CustomTool()
+        setattr(custom_tool, "origin", "getattr_origin")
+
+        result = SamAgentComponent._extract_tool_origin(custom_tool)
+        assert result == "getattr_origin"
+
+    def test_extract_tool_origin_unknown_fallback(self):
+        """Test _extract_tool_origin when no origin is found."""
+        tool = Mock()
+        tool.origin = None
+        tool.func = None
+
+        if hasattr(tool, "origin"):
+            delattr(tool, "origin")
+
+        result = SamAgentComponent._extract_tool_origin(tool)
+        assert result == "unknown"


### PR DESCRIPTION
- introduced guard check for tool origin source + unit test coverage

to test, run:
```
 solace-agent-mesh git:(DATAGO-112640-postfix) hatch run pytest tests/unit/agent/sac/test_component.py                                            
=================================================================================================================================================== test session starts ====================================================================================================================================================
platform darwin -- Python 3.11.13, pytest-8.4.2, pluggy-1.6.0
rootdir: /Users/eugenenavitaniuc/work/solace-agent-mesh
configfile: pyproject.toml
plugins: asyncio-1.2.0, anyio-4.11.0, httpx-0.35.0
asyncio: mode=Mode.AUTO, debug=False, asyncio_default_fixture_loop_scope=function, asyncio_default_test_loop_scope=function
collected 4 items                                                                                                                                                                                                                                                                                                          

tests/unit/agent/sac/test_component.py ....                                                                                                                                                                                                                                                                          [100%]

==================================================================================================================================================== 4 passed in 3.43s =====================================================================================================================================================

```