### PR TITLE
DATAGO-110479: update the maximum capacity of loading artifacts

### DIFF
--- a/src/solace_agent_mesh/agent/sac/app.py
+++ b/src/solace_agent_mesh/agent/sac/app.py
@@ -23,7 +23,7 @@ from ...common.a2a import (
     get_agent_status_subscription_topic,
     get_sam_events_subscription_topic,
 )
-from ...common.constants import DEFAULT_COMMUNICATION_TIMEOUT
+from ...common.constants import DEFAULT_COMMUNICATION_TIMEOUT, TEXT_ARTIFACT_CONTEXT_MAX_LENGTH_CAPACITY
 from ...agent.sac.component import SamAgentComponent
 from ...agent.utils.artifact_helpers import DEFAULT_SCHEMA_MAX_KEYS
 from ...common.utils.pydantic_utils import SamConfigBase
@@ -353,9 +353,9 @@ class SamAgentAppConfig(SamConfigBase):
         description="Configuration for the agent's custom cleanup function.",
     )
     text_artifact_content_max_length: int = Field(
-        default=1000,
+        default=100000,
         ge=100,
-        le=100000,
+        le=TEXT_ARTIFACT_CONTEXT_MAX_LENGTH_CAPACITY,
         description="Maximum character length for text-based artifact content.",
     )
     max_llm_calls_per_task: int = Field(

--- a/src/solace_agent_mesh/agent/sac/app.py
+++ b/src/solace_agent_mesh/agent/sac/app.py
@@ -23,7 +23,7 @@ from ...common.a2a import (
     get_agent_status_subscription_topic,
     get_sam_events_subscription_topic,
 )
-from ...common.constants import DEFAULT_COMMUNICATION_TIMEOUT, TEXT_ARTIFACT_CONTEXT_MAX_LENGTH_CAPACITY
+from ...common.constants import DEFAULT_COMMUNICATION_TIMEOUT, TEXT_ARTIFACT_CONTEXT_MAX_LENGTH_CAPACITY, TEXT_ARTIFACT_CONTEXT_DEFAULT_LENGTH
 from ...agent.sac.component import SamAgentComponent
 from ...agent.utils.artifact_helpers import DEFAULT_SCHEMA_MAX_KEYS
 from ...common.utils.pydantic_utils import SamConfigBase
@@ -353,7 +353,7 @@ class SamAgentAppConfig(SamConfigBase):
         description="Configuration for the agent's custom cleanup function.",
     )
     text_artifact_content_max_length: int = Field(
-        default=100000,
+        default=TEXT_ARTIFACT_CONTEXT_DEFAULT_LENGTH,
         ge=100,
         le=TEXT_ARTIFACT_CONTEXT_MAX_LENGTH_CAPACITY,
         description="Maximum character length for text-based artifact content.",

--- a/src/solace_agent_mesh/agent/utils/artifact_helpers.py
+++ b/src/solace_agent_mesh/agent/utils/artifact_helpers.py
@@ -19,6 +19,7 @@ from google.genai import types as adk_types
 from solace_ai_connector.common.log import log
 from ...common.a2a.types import ArtifactInfo
 from ...common.utils.mime_helpers import is_text_based_mime_type, is_text_based_file
+from ...common.constants import TEXT_ARTIFACT_CONTEXT_MAX_LENGTH_CAPACITY
 from ...agent.utils.context_helpers import get_original_session_id
 
 if TYPE_CHECKING:
@@ -819,7 +820,7 @@ async def load_artifact_content_or_metadata(
 
     if max_content_length is None and component:
         max_content_length = component.get_config(
-            "text_artifact_content_max_length", 1000
+            "text_artifact_content_max_length", 100000
         )
         if max_content_length < 100:
             log.warning(
@@ -828,13 +829,14 @@ async def load_artifact_content_or_metadata(
                 max_content_length,
             )
             max_content_length = 100
-        elif max_content_length > 100000:
+        elif max_content_length > TEXT_ARTIFACT_CONTEXT_MAX_LENGTH_CAPACITY:
             log.warning(
-                "%s text_artifact_content_max_length too large (%d), using maximum: 100000",
+                "%s text_artifact_content_max_length too large (%d), using maximum: %d",
                 log_identifier_req,
                 max_content_length,
+                TEXT_ARTIFACT_CONTEXT_MAX_LENGTH_CAPACITY,
             )
-            max_content_length = 100000
+            max_content_length = TEXT_ARTIFACT_CONTEXT_MAX_LENGTH_CAPACITY
     elif max_content_length is None:
         max_content_length = 1000
 
@@ -983,8 +985,11 @@ async def load_artifact_content_or_metadata(
                 if is_text:
                     try:
                         content_str = data_bytes.decode(encoding, errors=error_handling)
+                        message_to_llm = ""
                         if len(content_str) > max_content_length:
                             truncated_content = content_str[:max_content_length] + "..."
+                            message_to_llm = f"""This artifact content has been truncated to {max_content_length} characters. 
+                                                Please request again with larger max size up to {TEXT_ARTIFACT_CONTEXT_MAX_LENGTH_CAPACITY} for the full artifact"""
                             log.info(
                                 "%s Loaded and decoded text artifact '%s' v%d. Returning truncated content (%d chars, limit: %d).",
                                 log_identifier,
@@ -1008,6 +1013,7 @@ async def load_artifact_content_or_metadata(
                             "version": version_to_load,
                             "mime_type": mime_type,
                             "content": truncated_content,
+                            "message_to_llm": message_to_llm,
                             "size_bytes": size_bytes,
                         }
                     except UnicodeDecodeError as decode_err:

--- a/src/solace_agent_mesh/agent/utils/artifact_helpers.py
+++ b/src/solace_agent_mesh/agent/utils/artifact_helpers.py
@@ -19,7 +19,7 @@ from google.genai import types as adk_types
 from solace_ai_connector.common.log import log
 from ...common.a2a.types import ArtifactInfo
 from ...common.utils.mime_helpers import is_text_based_mime_type, is_text_based_file
-from ...common.constants import TEXT_ARTIFACT_CONTEXT_MAX_LENGTH_CAPACITY
+from ...common.constants import TEXT_ARTIFACT_CONTEXT_MAX_LENGTH_CAPACITY, TEXT_ARTIFACT_CONTEXT_DEFAULT_LENGTH
 from ...agent.utils.context_helpers import get_original_session_id
 
 if TYPE_CHECKING:
@@ -841,7 +841,7 @@ async def load_artifact_content_or_metadata(
             )
             max_content_length = TEXT_ARTIFACT_CONTEXT_MAX_LENGTH_CAPACITY
     elif max_content_length is None:
-        max_content_length = 1000
+        max_content_length = TEXT_ARTIFACT_CONTEXT_DEFAULT_LENGTH
 
     log.debug(
         "%s Using max_content_length: %d characters (from %s).",

--- a/src/solace_agent_mesh/agent/utils/artifact_helpers.py
+++ b/src/solace_agent_mesh/agent/utils/artifact_helpers.py
@@ -989,6 +989,7 @@ async def load_artifact_content_or_metadata(
                         if len(content_str) > max_content_length:
                             truncated_content = content_str[:max_content_length] + "..."
                             message_to_llm = f"""This artifact content has been truncated to {max_content_length} characters. 
+                                                The artifact is larger ({len(content_str)} characters).
                                                 Please request again with larger max size up to {TEXT_ARTIFACT_CONTEXT_MAX_LENGTH_CAPACITY} for the full artifact"""
                             log.info(
                                 "%s Loaded and decoded text artifact '%s' v%d. Returning truncated content (%d chars, limit: %d).",

--- a/src/solace_agent_mesh/common/constants.py
+++ b/src/solace_agent_mesh/common/constants.py
@@ -1,3 +1,4 @@
 
 DEFAULT_COMMUNICATION_TIMEOUT = 600  # 10 minutes
 TEXT_ARTIFACT_CONTEXT_MAX_LENGTH_CAPACITY = 200000  # maximum number of characters that can be loaded from a text artifact
+TEXT_ARTIFACT_CONTEXT_DEFAULT_LENGTH = 100000  # default number of characters to load from a text artifact 

--- a/src/solace_agent_mesh/common/constants.py
+++ b/src/solace_agent_mesh/common/constants.py
@@ -1,2 +1,3 @@
 
 DEFAULT_COMMUNICATION_TIMEOUT = 600  # 10 minutes
+TEXT_ARTIFACT_CONTEXT_MAX_LENGTH_CAPACITY = 200000  # maximum number of characters that can be loaded from a text artifact


### PR DESCRIPTION
**Goal:**
- Increased the maximum and default capacity of loading artifacts to 200K and 100K respectively.
- Added 'message-to-llm' data field to lead the LLM