### PR TITLE
fix(DEP): remove SAM version references from plugin creation and template files

### DIFF
--- a/cli/commands/plugin_cmd/create_cmd.py
+++ b/cli/commands/plugin_cmd/create_cmd.py
@@ -242,7 +242,6 @@ def create_plugin_cmd(
         "__PLUGIN_DESCRIPTION__": options["description"],
         "__PLUGIN_VERSION__": options["version"],
         "__PLUGIN_META_DATA_TYPE__": options["type"].lower(),
-        "__SAM_VERSION__": cli_version,
         "__COMPONENT_KEBAB_CASE_NAME__": "__COMPONENT_KEBAB_CASE_NAME__",
         "__COMPONENT_PASCAL_CASE_NAME__": "__COMPONENT_PASCAL_CASE_NAME__",
         "__COMPONENT_UPPER_SNAKE_CASE_NAME__": "__COMPONENT_UPPER_SNAKE_CASE_NAME__",

--- a/cli/commands/plugin_cmd/plugin_cmd_llm.txt
+++ b/cli/commands/plugin_cmd/plugin_cmd_llm.txt
@@ -89,7 +89,7 @@ sam plugin create my-plugin --author-name "John Doe" --author-email "john@exampl
 - `__PLUGIN_AUTHOR_EMAIL__` - Author's email
 - `__PLUGIN_DESCRIPTION__` - Plugin description
 - `__PLUGIN_VERSION__` - Plugin version
-- `__SAM_VERSION__` - CLI version
+
 
 #### `add_plugin_component_cmd`
 ```python

--- a/templates/plugin_pyproject_template.toml
+++ b/templates/plugin_pyproject_template.toml
@@ -18,7 +18,6 @@ description = "__PLUGIN_DESCRIPTION__"
 readme = "README.md"
 requires-python = ">=3.10"
 dependencies = [
-    "solace_agent_mesh~=__SAM_VERSION__",
     # Add plugin-specific dependencies here
 ]
 


### PR DESCRIPTION
## What is the purpose of this change?

This change removes SAM version references from plugin creation and template files to eliminate unnecessary version coupling between plugins and the SAM framework.

## How is this accomplished?

- fix: remove SAM version references from plugin creation and template files
  - Removed `__SAM_VERSION__` from the replacements dictionary in `create_plugin_cmd.py`
  - Removed reference to `__SAM_VERSION__` in the plugin command LLM documentation
  - Removed the `solace_agent_mesh~=__SAM_VERSION__` dependency from the plugin pyproject template

## Anything reviews should focus on/be aware of?

Ensure that removing these version references doesn't break any existing plugin creation or functionality processes.