### PR TITLE
fix: filter S3 config to only valid boto3 parameters

### DIFF
--- a/src/solace_agent_mesh/agent/adk/services.py
+++ b/src/solace_agent_mesh/agent/adk/services.py
@@ -270,19 +270,24 @@ def initialize_artifact_service(component) -> BaseArtifactService:
 
         try:
             from .artifacts.s3_artifact_service import S3ArtifactService
-            
-            s3_config = {}
-            
-            for key, value in config.items():
-                if key not in ["type", "bucket_name", "artifact_scope"]:
-                    s3_config[key] = value
-            
+
+            valid_boto3_params = [
+                "endpoint_url",
+                "aws_access_key_id",
+                "aws_secret_access_key",
+                "aws_session_token",
+                "region_name",
+                "config"
+            ]
+
+            s3_config = {k: v for k, v in config.items() if k in valid_boto3_params}
+
             if "endpoint_url" not in s3_config:
                 s3_config["endpoint_url"] = "https://s3.amazonaws.com"
-                
+
             aws_access_key_id = config.get("aws_access_key_id") or os.environ.get("AWS_ACCESS_KEY_ID")
             aws_secret_access_key = config.get("aws_secret_access_key") or os.environ.get("AWS_SECRET_ACCESS_KEY")
-            
+
             if aws_access_key_id:
                 s3_config["aws_access_key_id"] = aws_access_key_id
             if aws_secret_access_key:


### PR DESCRIPTION
Changed S3 artifact service initialization to use an inclusion list of valid boto3.client() parameters instead of an exclusion list. This prevents errors when extra config properties (like base_path) are present in the configuration.

Valid boto3 parameters: endpoint_url, aws_access_key_id, aws_secret_access_key, aws_session_token, region_name, config

