### PR TITLE
fix: properly handle S3 endpoint_url configuration with environment variable

### DIFF
--- a/src/solace_agent_mesh/agent/adk/services.py
+++ b/src/solace_agent_mesh/agent/adk/services.py
@@ -272,7 +272,6 @@ def initialize_artifact_service(component) -> BaseArtifactService:
             from .artifacts.s3_artifact_service import S3ArtifactService
 
             valid_boto3_params = [
-                "endpoint_url",
                 "aws_access_key_id",
                 "aws_secret_access_key",
                 "aws_session_token",
@@ -282,8 +281,8 @@ def initialize_artifact_service(component) -> BaseArtifactService:
 
             s3_config = {k: v for k, v in config.items() if k in valid_boto3_params}
 
-            if "endpoint_url" not in s3_config:
-                s3_config["endpoint_url"] = "https://s3.amazonaws.com"
+            endpoint_url = config.get("endpoint_url") or os.environ.get("S3_ENDPOINT_URL") or "https://s3.amazonaws.com"
+            s3_config["endpoint_url"] = endpoint_url
 
             aws_access_key_id = config.get("aws_access_key_id") or os.environ.get("AWS_ACCESS_KEY_ID")
             aws_secret_access_key = config.get("aws_secret_access_key") or os.environ.get("AWS_SECRET_ACCESS_KEY")


### PR DESCRIPTION
…ariable fallback

The previous implementation added endpoint_url to valid_boto3_params but didn't properly handle the fallback chain when the config value was None or empty.

This fix removes endpoint_url from the boto3 params filter and explicitly handles the fallback: config -> S3_ENDPOINT_URL env var -> AWS default.