### PR TITLE
feat(DATAGO-113298): Add component parameter to identity service and local file identity service initialization

### DIFF
--- a/src/solace_agent_mesh/common/services/identity_service.py
+++ b/src/solace_agent_mesh/common/services/identity_service.py
@@ -8,13 +8,14 @@ from typing import Any, Dict, List, Optional
 import importlib.metadata as metadata
 
 from solace_ai_connector.common.log import log
-from ...common.utils.in_memory_cache import InMemoryCache
+from ..utils.in_memory_cache import InMemoryCache
+from ..sac.sam_component_base import SamComponentBase
 
 
 class BaseIdentityService(ABC):
     """Abstract base class for all Identity Service providers."""
 
-    def __init__(self, config: Dict[str, Any]):
+    def __init__(self, config: Dict[str, Any], component: Optional[SamComponentBase] = None):
         """
         Initializes the service with its specific configuration block.
 
@@ -22,6 +23,7 @@ class BaseIdentityService(ABC):
             config: The dictionary of configuration parameters for this provider.
         """
         self.config = config
+        self.component = component
         self.log_identifier = f"[{self.__class__.__name__}]"
         self.cache_ttl = config.get("cache_ttl_seconds", 3600)
         self.cache = InMemoryCache() if self.cache_ttl > 0 else None
@@ -68,6 +70,7 @@ class BaseIdentityService(ABC):
 
 def create_identity_service(
     config: Optional[Dict[str, Any]],
+    component: Optional[SamComponentBase] = None,
 ) -> Optional[BaseIdentityService]:
     """
     Factory function to create an instance of an Identity Service provider
@@ -90,7 +93,7 @@ def create_identity_service(
     if provider_type == "local_file":
         from .providers.local_file_identity_service import LocalFileIdentityService
 
-        return LocalFileIdentityService(config)
+        return LocalFileIdentityService(config, component)
 
     else:
         try:
@@ -121,7 +124,7 @@ def create_identity_service(
                 )
 
             log.info(f"Successfully loaded identity provider plugin: {provider_type}")
-            return provider_class(config)
+            return provider_class(config, component)
         except (ImportError, AttributeError, TypeError, ValueError) as e:
             log.exception(
                 f"[IdentityFactory] Failed to load identity provider plugin '{provider_type}'. "

--- a/src/solace_agent_mesh/common/services/providers/local_file_identity_service.py
+++ b/src/solace_agent_mesh/common/services/providers/local_file_identity_service.py
@@ -8,6 +8,8 @@ from typing import Any, Dict, List, Optional
 
 from solace_ai_connector.common.log import log
 from ..identity_service import BaseIdentityService
+from ...sac.sam_component_base import SamComponentBase
+
 
 
 class LocalFileIdentityService(BaseIdentityService):
@@ -28,8 +30,8 @@ class LocalFileIdentityService(BaseIdentityService):
     ]
     """
 
-    def __init__(self, config: Dict[str, Any]):
-        super().__init__(config)
+    def __init__(self, config: Dict[str, Any], component: Optional[SamComponentBase] = None):
+        super().__init__(config, component)
         self.file_path = self.config.get("file_path")
         if not self.file_path:
             raise ValueError("LocalFileIdentityService config requires 'file_path'.")

--- a/src/solace_agent_mesh/gateway/base/component.py
+++ b/src/solace_agent_mesh/gateway/base/component.py
@@ -148,7 +148,7 @@ class BaseGatewayComponent(SamComponentBase):
 
         identity_service_config = self.get_config("identity_service")
         self.identity_service: Optional[BaseIdentityService] = create_identity_service(
-            identity_service_config
+            identity_service_config, self
         )
 
         self._config_resolver = MiddlewareRegistry.get_config_resolver()

--- a/tests/integration/scenarios_programmatic/test_services.py
+++ b/tests/integration/scenarios_programmatic/test_services.py
@@ -1,6 +1,7 @@
 import json
 import pytest
 import os
+from unittest.mock import Mock
 
 pytestmark = [
     pytest.mark.all,
@@ -43,9 +44,30 @@ def test_local_file_identity_service_initialization():
         service = LocalFileIdentityService(valid_config)
         assert service.file_path == valid_config["file_path"]
         assert service.lookup_key == valid_config["lookup_key"]
+        assert service.component is None, "Component should be None when not provided"
         print("LocalFileIdentityService initialized successfully.")
     except Exception as e:
         pytest.fail(f"Initialization failed with exception: {e}")
+
+def test_local_file_identity_service_initialization_with_component():
+    """
+    Tests that the LocalFileIdentityService initializes correctly with a component parameter.
+    """
+    from src.solace_agent_mesh.common.services.providers.local_file_identity_service import (
+        LocalFileIdentityService,
+    )
+    from unittest.mock import Mock
+
+    try:
+        # Create a mock component
+        mock_component = Mock()
+        service = LocalFileIdentityService(valid_config, component=mock_component)
+        assert service.file_path == valid_config["file_path"]
+        assert service.lookup_key == valid_config["lookup_key"]
+        assert service.component is mock_component, "Component should be set to the provided mock"
+        print("LocalFileIdentityService initialized successfully with component.")
+    except Exception as e:
+        pytest.fail(f"Initialization with component failed with exception: {e}")
 
 def test_local_file_identity_service_invalid_path():
     """
@@ -148,6 +170,7 @@ def test_identity_service_factory():
     service = create_identity_service(valid_config)
     assert service is not None, "Service should be created successfully with valid config."
     assert hasattr(service, 'get_user_profile'), "Service should have 'get_user_profile' method."
+    assert service.component is None, "Component should be None when not provided to factory"
 
     # Test with invalid configuration
     with pytest.raises(ValueError):
@@ -158,6 +181,30 @@ def test_identity_service_factory():
     assert service is None, "Service should be None when no config is provided."
 
     print("Identity service factory works correctly.")
+
+def test_identity_service_factory_with_component():
+    """
+    Tests the identity service factory function with a component parameter.
+    """
+    from src.solace_agent_mesh.common.services.identity_service import (
+        create_identity_service,
+    )
+    from unittest.mock import Mock
+
+    # Create a mock component
+    mock_component = Mock()
+
+    # Test with valid configuration and component
+    service = create_identity_service(valid_config, component=mock_component)
+    assert service is not None, "Service should be created successfully with valid config and component."
+    assert hasattr(service, 'get_user_profile'), "Service should have 'get_user_profile' method."
+    assert service.component is mock_component, "Component should be set to the provided mock"
+
+    # Test with no configuration but with component
+    service = create_identity_service(None, component=mock_component)
+    assert service is None, "Service should be None when no config is provided, regardless of component."
+
+    print("Identity service factory with component works correctly.")
 
 def test_employee_service_factory():
     """


### PR DESCRIPTION
## What is the purpose of this change?

This change adds the ability to pass a component parameter to identity service implementations, allowing identity service providers to access component resources and configuration when needed. This enhances the flexibility and integration capabilities of identity services within the agent mesh architecture.

## How is this accomplished?

- feat: add component parameter to identity service and local file identity service initialization
- Updated the BaseIdentityService class to accept an optional component parameter
- Modified the create_identity_service factory function to pass the component to service implementations
- Updated the LocalFileIdentityService implementation to support the component parameter
- Added test cases to verify the proper handling of the component parameter

## Anything reviews should focus on/be aware of?

Verify that existing identity service implementations will continue to function correctly with this change as the component parameter is optional.