### PR TITLE
ci(DATAGO-113736): use changelog formatter for github release notes g

### DIFF
--- a/.github/workflows/changelog.yaml
+++ b/.github/workflows/changelog.yaml
@@ -1,0 +1,54 @@
+name: Generate Github Release Notes Changelog
+run-name: "Generate Github Release Notes Changelog from ${{ inputs.from_ref }} to ${{ inputs.to_ref }}"
+
+on:
+    workflow_dispatch:
+        inputs:
+            from_ref:
+                description: "Tag or github reference (e.g., 1.3.3)"
+                type: string
+                required: true
+            to_ref:
+                description: "Tag or github reference (e.g., 1.4.11)"
+                type: string
+                required: true
+            output_file:
+                description: "Output file path for release notes"
+                type: string
+                required: false
+                default: "RELEASE_NOTES.md"
+
+permissions:
+    contents: read
+    pull-requests: read
+
+jobs:
+    generate-changelog:
+        runs-on: ubuntu-latest
+        steps:
+            - name: Checkout repository
+              uses: actions/checkout@v5
+              with:
+                  fetch-depth: 0
+            - name: Generate Changelog
+              id: generate_changelog
+              uses: SolaceDev/solace-public-workflows/generate-github-release-notes@gen-log
+              with:
+                  from-ref: ${{ inputs.from_ref }}
+                  to-ref: ${{ inputs.to_ref }}
+                  output-file: ${{ inputs.output_file }}
+                  github-token: ${{ secrets.GITHUB_TOKEN }}
+
+            - name: Print Outputs
+              run: |
+                  echo "RELEASE_NOTES_PATH: ${{ steps.generate_changelog.outputs.release-notes-path }}"
+                  echo "TOTAL_COMMITS: ${{ steps.generate_changelog.outputs.total-commits }}"
+
+            - name: Output Changelog
+              run: |
+                  if [ -f RELEASE_NOTES.md ]; then
+                      echo "RELEASE_NOTES.md exists."
+                  else
+                      echo "RELEASE_NOTES.md does not exist."
+                  fi
+                  cat RELEASE_NOTES.md >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/changelog.yaml
+++ b/.github/workflows/changelog.yaml
@@ -2,16 +2,21 @@ name: Generate Github Release Notes Changelog
 run-name: "Generate Github Release Notes Changelog from ${{ inputs.from_ref }} to ${{ inputs.to_ref }}"
 
 on:
+    push:
+        branches:
+            - test-changelog
     workflow_dispatch:
         inputs:
             from_ref:
                 description: "Tag or github reference (e.g., 1.3.3)"
                 type: string
                 required: true
+                default: "1.3.3"
             to_ref:
                 description: "Tag or github reference (e.g., 1.4.11)"
                 type: string
                 required: true
+                default: "1.4.11"
             output_file:
                 description: "Output file path for release notes"
                 type: string

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,6 +16,7 @@ permissions:
   checks: write
   contents: write
   packages: write
+  pull-requests: read
 
 jobs:
   release:

--- a/.versionrc.json
+++ b/.versionrc.json
@@ -1,0 +1,21 @@
+{
+  "types": [
+    { "type": "feat", "section": "Features" },
+    { "type": "fix", "section": "Bug Fixes" },
+    { "type": "ci", "section": "Continuous Integration" },
+    { "type": "deps", "section": "Dependencies" },
+    { "type": "chore", "section": "Chores" },
+    { "type": "build", "section": "Build" },
+    { "type": "docs", "section": "Documentation" },
+    { "type": "style", "section": "Style" },
+    { "type": "refactor", "section": "Refactoring" },
+    { "type": "perf", "section": "Performance" },
+    { "type": "test", "section": "Tests" }
+  ],
+  "uiChanges": {
+    "enabled": true,
+    "tagPrefix": "ui-v",
+    "pathPatterns": ["client/webui/frontend/**"],
+    "bumpCommitPattern": ".*bump version to ui-v.*\\[skip ci\\]"
+  }
+}


### PR DESCRIPTION
- Use custom release note generation workflow 
- Example [Run](https://github.com/SolaceLabs/solace-agent-mesh/actions/runs/18322983067) 