### PR TITLE
fix(DATAGO-114141): Change some prompting to stop triple ticks around save_artifacts

### DIFF
--- a/src/solace_agent_mesh/agent/adk/callbacks.py
+++ b/src/solace_agent_mesh/agent/adk/callbacks.py
@@ -168,11 +168,6 @@ async def process_artifact_blocks_callback(
                         )
                         filename = event.params.get("filename", "unknown_artifact")
                         if a2a_context:
-                            status_text = f"Receiving artifact `{filename}`..."
-                            if description:
-                                status_text = (
-                                    f"Receiving artifact `{filename}`: {description}"
-                                )
                             progress_data = AgentProgressUpdateData(
                                 status_text=f"Receiving artifact `{filename}`..."
                             )
@@ -790,7 +785,7 @@ It can span multiple lines.
   - All parameter values **MUST** be enclosed in double quotes.
   - You **MUST NOT** use double quotes `"` inside the parameter values (e.g., within the description string). Use single quotes or rephrase instead.
   - Do not surround a save_artifact block with '```' (triple backticks). This will create rendering issues.
-  
+
 The system will automatically save the content and give you a confirmation in the next turn."""
 
 


### PR DESCRIPTION
This was a small change in the agent prompting that fixes output generation errors that were showing up often with Claude-4-5-Sonnet