### PR TITLE
fix(DATAGO-114474): Avoid reconfiguring logging when Alembic migration takes place

### DIFF
--- a/src/solace_agent_mesh/gateway/http_sse/alembic.ini
+++ b/src/solace_agent_mesh/gateway/http_sse/alembic.ini
@@ -107,39 +107,3 @@ path_separator = os
 # ruff.type = exec
 # ruff.executable = ruff
 # ruff.options = check --fix REVISION_SCRIPT_FILENAME
-
-# Logging configuration.  This is also consumed by the user-maintained
-# env.py script only.
-[loggers]
-keys = root,sqlalchemy,alembic
-
-[handlers]
-keys = console
-
-[formatters]
-keys = generic
-
-[logger_root]
-level = WARNING
-handlers = console
-qualname =
-
-[logger_sqlalchemy]
-level = WARNING
-handlers =
-qualname = sqlalchemy.engine
-
-[logger_alembic]
-level = INFO
-handlers =
-qualname = alembic
-
-[handler_console]
-class = StreamHandler
-args = (sys.stderr,)
-level = NOTSET
-formatter = generic
-
-[formatter_generic]
-format = %(levelname)-5.5s [%(name)s] %(message)s
-datefmt = %H:%M:%S

--- a/src/solace_agent_mesh/gateway/http_sse/alembic/env.py
+++ b/src/solace_agent_mesh/gateway/http_sse/alembic/env.py
@@ -1,16 +1,9 @@
-from logging.config import fileConfig
-
 from alembic import context
 from sqlalchemy import engine_from_config, pool
 
 # this is the Alembic Config object, which provides
 # access to the values within the .ini file in use.
 config = context.config
-
-# Interpret the config file for Python logging.
-# This line sets up loggers basically.
-if config.config_file_name is not None:
-    fileConfig(config.config_file_name)
 
 # add your model's MetaData object here
 # for 'autogenerate' support


### PR DESCRIPTION
## Summary

Fixes logging reconfiguration issue during Alembic database migrations that was overriding the application's logging configuration.

## Changes

- Removed logging configuration from alembic.ini
- Updated env.py: Removed the fileConfig() call that was loading and applying the Alembic logging configuration from the config file

## Problem

When Alembic migrations execute, they would reconfigure the Python logging system using their own configuration from alembic.ini. This would override the application's existing logging setup, causing unexpected loss of properly configured loggers and changes in log formatting.

## Related

This fix mirrors the changes made in SolaceDev/solace-agent-mesh-enterprise#208 which addressed the same issue in the enterprise repository.