### PR TITLE
DATAGO-112515 fix user identity if email is missing

### DIFF
--- a/src/solace_agent_mesh/gateway/http_sse/main.py
+++ b/src/solace_agent_mesh/gateway/http_sse/main.py
@@ -97,7 +97,8 @@ async def _get_user_info(
 
 def _extract_user_identifier(user_info: dict) -> str:
     user_identifier = (
-        user_info.get("sub")
+        user_info.get("user_id") # internal /user_info endpoint format maps identifier to user_id
+        or user_info.get("sub")
         or user_info.get("client_id")
         or user_info.get("username")
         or user_info.get("oid")


### PR DESCRIPTION
The internal user_info endpoint format strips most of the external idp user info and only keeps a few things like `email` and `name`. In cases where the user doesn't have an email from the identify provider, this prevents the user from being correctly authenticated.

This change defaults the identifier to the internally chosen user_id (which will always be the `sub` claim in oidc compliant idps).