### PR TITLE
fix: add _DB_URL to env variables

### DIFF
--- a/cli/commands/add_cmd/agent_cmd.py
+++ b/cli/commands/add_cmd/agent_cmd.py
@@ -66,7 +66,7 @@ def _write_agent_yaml_from_data(
 
             if type_val == "sql":
                 database_url_placeholder = (
-                    f"${{{formatted_names['SNAKE_UPPER_CASE_NAME']}, sqlite:///{file_name_snake}.db}}"
+                    f"${{{formatted_names['SNAKE_UPPER_CASE_NAME']}_DATABASE_URL, sqlite:///{file_name_snake}.db}}"
                 )
                 session_service_lines.append(
                     f'database_url: "{database_url_placeholder}"'
@@ -294,7 +294,7 @@ def _write_agent_yaml_from_data(
         for placeholder, value in replacements.items():
             modified_content = modified_content.replace(placeholder, str(value))
         if config_options.get(DATABASE_URL_KEY):
-            env_key = f"{formatted_names['SNAKE_UPPER_CASE_NAME']}"
+            env_key = f"{formatted_names['SNAKE_UPPER_CASE_NAME']}_DATABASE_URL"
             if config_options[DATABASE_URL_KEY] == "default_agent_db":
                 db_file = project_root / "data" / f"{formatted_names['SNAKE_CASE_NAME']}.db"
                 config_options[DATABASE_URL_KEY] = f"sqlite:///{db_file.resolve()}"

--- a/tests/unit/cli/test_add_agent_cmd.py
+++ b/tests/unit/cli/test_add_agent_cmd.py
@@ -60,7 +60,7 @@ def test_add_agent_default_db_generation(project_dir):
     assert agent_config_path.exists(), "Agent config file was not created."
     with open(agent_config_path) as f:
         content = f.read()
-        assert 'database_url: "${NEW_AGENT, sqlite:///new_agent.db}"' in content
+        assert 'database_url: "${NEW_AGENT_DATABASE_URL, sqlite:///new_agent.db}"' in content
 
 
 @pytest.mark.xfail(reason="This test needs to be reviewed and fixed.")


### PR DESCRIPTION
- ~Add `_DB_URL` to env variable for new agents~
- ~change `_DATABASE_URL` to `_DB_URL` for orchestrator and webui env variables~
- Added `_DATABASE_URL` to env variable for created agents