### PR TITLE
feat: Add deployment ID extension to AgentCard for rolling update tracking

### DIFF
--- a/src/solace_agent_mesh/agent/protocol/event_handlers.py
+++ b/src/solace_agent_mesh/agent/protocol/event_handlers.py
@@ -1458,6 +1458,7 @@ def publish_agent_card(component):
         dynamic_url = f"solace:{agent_request_topic}"
 
         # Define unique URIs for our custom extensions.
+        DEPLOYMENT_EXTENSION_URI = "https://solace.com/a2a/extensions/sam/deployment"
         PEER_TOPOLOGY_EXTENSION_URI = (
             "https://solace.com/a2a/extensions/peer-agent-topology"
         )
@@ -1465,6 +1466,24 @@ def publish_agent_card(component):
         TOOLS_EXTENSION_URI = "https://solace.com/a2a/extensions/sam/tools"
 
         extensions_list = []
+
+        # Create the extension object for deployment tracking.
+        deployment_config = component.get_config("deployment", {})
+        deployment_id = deployment_config.get("id")
+
+        if deployment_id:
+            deployment_extension = AgentExtension(
+                uri=DEPLOYMENT_EXTENSION_URI,
+                description="SAM deployment tracking for rolling updates",
+                required=False,
+                params={"id": deployment_id}
+            )
+            extensions_list.append(deployment_extension)
+            log.debug(
+                "%s Added deployment extension with ID: %s",
+                component.log_identifier,
+                deployment_id
+            )
 
         # Create the extension object for peer agents.
         if peer_agents:

--- a/tests/agent/protocol/test_deployment_extension.py
+++ b/tests/agent/protocol/test_deployment_extension.py
@@ -1,0 +1,159 @@
+"""Tests for deployment ID extension in AgentCard publishing."""
+
+import pytest
+from unittest.mock import Mock, MagicMock
+from a2a.types import AgentCard, AgentExtension
+from solace_agent_mesh.agent.protocol.event_handlers import publish_agent_card
+
+DEPLOYMENT_EXTENSION_URI = "https://solace.com/a2a/extensions/sam/deployment"
+
+
+class TestDeploymentExtension:
+    """Test deployment extension is added to AgentCard."""
+
+    def test_publish_agent_card_with_deployment_id(self):
+        """Test agent card includes deployment extension when deployment.id present."""
+        component = Mock()
+        component.get_config = Mock(side_effect=lambda key, default={}: {
+            "agent_card": {
+                "description": "Test agent",
+                "skills": []
+            },
+            "agent_name": "TestAgent",
+            "namespace": "test",
+            "supports_streaming": True,
+            "deployment": {"id": "test-deployment-123"}
+        }.get(key, default))
+        component.peer_agents = {}
+        component.agent_card_tool_manifest = []
+        component.log_identifier = "[TestAgent]"
+        component.HOST_COMPONENT_VERSION = "1.0.0"
+
+        published_card = None
+        def capture_publish(card_dict, topic):
+            nonlocal published_card
+            published_card = card_dict
+
+        component.publish_a2a_message = capture_publish
+
+        publish_agent_card(component)
+
+        assert published_card is not None
+        assert "capabilities" in published_card
+        assert "extensions" in published_card["capabilities"]
+
+        extensions = published_card["capabilities"]["extensions"]
+        deployment_ext = next(
+            (ext for ext in extensions if ext["uri"] == DEPLOYMENT_EXTENSION_URI),
+            None
+        )
+
+        assert deployment_ext is not None
+        assert deployment_ext["params"]["id"] == "test-deployment-123"
+        assert deployment_ext["required"] is False
+
+    def test_publish_agent_card_without_deployment_id(self):
+        """Test agent card works without deployment section (backward compat)."""
+        component = Mock()
+        component.get_config = Mock(side_effect=lambda key, default={}: {
+            "agent_card": {
+                "description": "Test agent",
+                "skills": []
+            },
+            "agent_name": "TestAgent",
+            "namespace": "test",
+            "supports_streaming": False
+        }.get(key, default))
+        component.peer_agents = {}
+        component.agent_card_tool_manifest = []
+        component.log_identifier = "[TestAgent]"
+        component.HOST_COMPONENT_VERSION = "1.0.0"
+
+        published_card = None
+        def capture_publish(card_dict, topic):
+            nonlocal published_card
+            published_card = card_dict
+
+        component.publish_a2a_message = capture_publish
+
+        publish_agent_card(component)
+
+        assert published_card is not None
+
+        extensions = published_card.get("capabilities", {}).get("extensions")
+        if extensions:
+            deployment_ext = next(
+                (ext for ext in extensions if ext["uri"] == DEPLOYMENT_EXTENSION_URI),
+                None
+            )
+            assert deployment_ext is None
+
+    def test_deployment_extension_with_other_extensions(self):
+        """Test deployment extension coexists with other extensions."""
+        component = Mock()
+        component.get_config = Mock(side_effect=lambda key, default={}: {
+            "agent_card": {
+                "description": "Test agent",
+                "skills": []
+            },
+            "agent_name": "TestAgent",
+            "display_name": "Test Display Name",
+            "namespace": "test",
+            "supports_streaming": True,
+            "deployment": {"id": "deploy-456"}
+        }.get(key, default))
+
+        peer_agent_card = Mock()
+        peer_agent_card.name = "PeerAgent"
+        component.peer_agents = {"PeerAgent": peer_agent_card}
+        component.agent_card_tool_manifest = []
+        component.log_identifier = "[TestAgent]"
+        component.HOST_COMPONENT_VERSION = "1.0.0"
+
+        published_card = None
+        def capture_publish(card_dict, topic):
+            nonlocal published_card
+            published_card = card_dict
+
+        component.publish_a2a_message = capture_publish
+
+        publish_agent_card(component)
+
+        extensions = published_card["capabilities"]["extensions"]
+        assert len(extensions) >= 3
+
+        uris = [ext["uri"] for ext in extensions]
+        assert DEPLOYMENT_EXTENSION_URI in uris
+        assert "https://solace.com/a2a/extensions/display-name" in uris
+        assert "https://solace.com/a2a/extensions/peer-agent-topology" in uris
+
+    def test_deployment_extension_ordering(self):
+        """Test deployment extension is added first in the list."""
+        component = Mock()
+        component.get_config = Mock(side_effect=lambda key, default={}: {
+            "agent_card": {
+                "description": "Test agent",
+                "skills": []
+            },
+            "agent_name": "TestAgent",
+            "display_name": "Test Display",
+            "namespace": "test",
+            "supports_streaming": False,
+            "deployment": {"id": "deploy-789"}
+        }.get(key, default))
+        component.peer_agents = {}
+        component.agent_card_tool_manifest = []
+        component.log_identifier = "[TestAgent]"
+        component.HOST_COMPONENT_VERSION = "1.0.0"
+
+        published_card = None
+        def capture_publish(card_dict, topic):
+            nonlocal published_card
+            published_card = card_dict
+
+        component.publish_a2a_message = capture_publish
+
+        publish_agent_card(component)
+
+        extensions = published_card["capabilities"]["extensions"]
+        assert extensions[0]["uri"] == DEPLOYMENT_EXTENSION_URI


### PR DESCRIPTION
## Summary
Adds deployment ID extension to AgentCard to enable precise tracking of which deployment version is running during rolling updates.

## Problem
During rolling updates, both old and new pods publish AgentCards with the same agent name. The enterprise status checker cannot distinguish which pod (old vs new) is actually running, leading to premature success marking when the old pod is still active.

## Solution
Add `deployment.id` as an AgentCard extension that gets published with the heartbeat:

1. Enterprise generates YAML with `deployment.id` field
2. Agent reads `deployment.id` from config on startup
3. Agent adds deployment extension to AgentCard capabilities
4. Extension published automatically with heartbeat (every 10s)
5. Enterprise status checker compares deployment IDs before marking success

## Changes

### event_handlers.py
- Added `DEPLOYMENT_EXTENSION_URI` constant
- Read `deployment.id` from `component.get_config("deployment", {}).get("id")`
- Create `AgentExtension` with deployment ID in params
- Add to extensions list (first position, before peer_topology)

### Extension Structure
```json
{
  "uri": "https://solace.com/a2a/extensions/sam/deployment",
  "description": "SAM deployment tracking for rolling updates",
  "required": false,
  "params": {"id": "7f3a9b2c-4d1e-4a8b-9c7d-2e5f8a1b3c6d"}
}
```

### YAML Config Format
```yaml
app_config:
  deployment:
    id: "7f3a9b2c-4d1e-4a8b-9c7d-2e5f8a1b3c6d"
```

## Behavior

**When deployment.id Present:**
- Extension added to AgentCard
- Published with heartbeat
- Available for enterprise tracking

**When deployment.id Absent:**
- Extension not added
- AgentCard published normally
- Backward compatible with existing configs

## Testing

### Unit Tests (4 tests - All Pass ✅)
- ✅ Extension added when deployment.id present
- ✅ Extension omitted when deployment.id absent  
- ✅ Extension coexists with other extensions (display_name, peer_topology, tools)
- ✅ Extension ordering (deployment first)

### Test Coverage
- New test file: `tests/agent/protocol/test_deployment_extension.py`
- Comprehensive coverage of extension logic
- Mock-based, no external dependencies

## Backward Compatibility

✅ **Fully backward compatible**
- Extension only added if `deployment.id` in config
- Existing agents without this field work unchanged
- No breaking changes to AgentCard structure
- Optional extension (required: false)

## Integration

**Requires enterprise changes to utilize:**
- Enterprise must generate YAML with deployment.id
- Enterprise status checker must extract and compare deployment IDs
- See companion PR: solace-agent-mesh-enterprise#XXX (to be created)

## Impact

**No user-facing changes:**
- Extension not displayed in UI
- Purely backend tracking mechanism
- No performance impact (extension ~40 bytes)

## Related

Part of rolling update verification feature to prevent premature deployment success marking.