### PR TITLE
fix: add deployment field to SamAgentAppConfig schema

### DIFF
--- a/src/solace_agent_mesh/agent/sac/app.py
+++ b/src/solace_agent_mesh/agent/sac/app.py
@@ -257,6 +257,10 @@ class SamAgentAppConfig(SamConfigBase):
         default=None,
         description="Human-friendly display name for this ADK agent instance.",
     )
+    deployment: Optional[Dict[str, Any]] = Field(
+        default=None,
+        description="Deployment tracking information for rolling updates and version control.",
+    )
     model: Union[str, Dict[str, Any]] = Field(
         ..., description="ADK model name (string) or BaseLlm config dict."
     )


### PR DESCRIPTION
## Summary
Fixes deployment ID extension not appearing in published AgentCards due to Pydantic validation stripping the field.

## Problem
The `deployment` configuration (containing `deployment.id`) was being silently dropped during Pydantic validation because `SamAgentAppConfig` schema didn't include this field. This prevented:
- Deployment ID from being accessible via `component.get_config("deployment")`
- Deployment extension from being added to AgentCards
- Backend from verifying deployment IDs during rolling updates

## Solution
Added `deployment` field to `SamAgentAppConfig` schema with:
- Type: `Optional[Dict[str, Any]]`
- Default: `None`
- Description: Deployment tracking for rolling updates

## Impact
- ✅ Deployment ID now preserved through validation
- ✅ AgentCards published with deployment extension
- ✅ Backend can verify deployment IDs for update validation
- ✅ Enables proper rolling update detection

## Testing
- Verified deployment.id appears in YAML config
- Checked Pydantic validation preserves deployment field
- Confirmed deployment extension added to AgentCards

## Related
- Depends on PR #424 (deployment extension in event_handlers.py)
- Required for enterprise deployment tracking and drift detection