### PR TITLE
chore(DATAGO-115251): Setting uvicorn log level to warning

### DIFF
--- a/src/solace_agent_mesh/gateway/http_sse/component.py
+++ b/src/solace_agent_mesh/gateway/http_sse/component.py
@@ -1222,7 +1222,7 @@ class WebUIBackendComponent(BaseGatewayComponent):
                 app=self.fastapi_app,
                 host=self.fastapi_host,
                 port=port,
-                log_level="info",
+                log_level="warning",
                 lifespan="on",
                 ssl_keyfile=self.ssl_keyfile,
                 ssl_certfile=self.ssl_certfile,


### PR DESCRIPTION
[Uvicorn configures formatters and handlers by default](https://github.com/Kludex/uvicorn/blob/main/uvicorn/config.py#L69) but these are not aligned with the main application log. Uvicorn uses its own formatting and handler logic.

Also, uvicorn logs request tokens at the INFO level which doesn't look like a good thing. 

Setting log level to warning works around the above two issues without impacting troubleshooting really. Warnings and errors will still be reported.