### PR TITLE
fix(DATAGO-115411): move timestamp to next line if model name is too long

### DIFF
--- a/client/webui/frontend/src/lib/components/activities/VisualizerStepCard.tsx
+++ b/client/webui/frontend/src/lib/components/activities/VisualizerStepCard.tsx
@@ -207,13 +207,13 @@ const VisualizerStepCard: React.FC<VisualizerStepCardProps> = ({ step, isHighlig
 
     return (
         <div className={cardClasses} style={indentationStyle} onClick={onClick}>
-            <div className="mb-1.5 flex items-center">
+            <div className="mb-1.5 flex w-full items-center gap-1">
                 {getStepIcon()}
-                <div className="flex w-full flex-wrap justify-between gap-2">
-                    <h4 className="text-sm font-semibold" title={step.title}>
+                <div className="flex min-w-0 flex-1 flex-wrap items-center justify-between gap-2">
+                    <h4 className="flex-1 truncate text-sm font-semibold" title={step.title}>
                         {step.title}
                     </h4>
-                    <span className="text-muted-foreground font-mono text-xs">{displayTimestamp}</span>
+                    <span className="text-muted-foreground shrink-0 font-mono text-xs">{displayTimestamp}</span>
                 </div>
             </div>
             {step.delegationInfo && step.delegationInfo.length > 0 && (


### PR DESCRIPTION
# With enough space
<img width="446" height="231" alt="Screenshot 2025-10-24 at 3 23 05 PM" src="https://github.com/user-attachments/assets/5662d544-986e-443d-805c-a969f433aa9b" />

# Without enough space
<img width="519" height="189" alt="Screenshot 2025-10-24 at 5 08 02 PM" src="https://github.com/user-attachments/assets/17e195d7-b301-427d-b5c8-07d1e55a789a" />
