### PR TITLE
fix(DATAGO-115562): Store the original Solace message in the task execution context rather than in the a2a_context

### DIFF
--- a/src/solace_agent_mesh/agent/adk/runner.py
+++ b/src/solace_agent_mesh/agent/adk/runner.py
@@ -75,7 +75,6 @@ async def run_adk_async_task_thread_wrapper(
 
         if adk_session and component.session_service:
             context_setting_invocation_id = logical_task_id
-            original_message = a2a_context.pop("original_solace_message", None)
             try:
                 context_setting_event = ADKEvent(
                     invocation_id=context_setting_invocation_id,
@@ -107,9 +106,6 @@ async def run_adk_async_task_thread_wrapper(
                     e_append,
                     exc_info=True,
                 )
-            finally:
-                if original_message:
-                    a2a_context["original_solace_message"] = original_message
         else:
             log.warning(
                 "%s Could not inject a2a_context into ADK session state via event for task %s (session or session_service invalid). Tool scope filtering might not work.",
@@ -198,7 +194,7 @@ async def run_adk_async_task_thread_wrapper(
             "%s Bad Request for task %s: %s.",
             component.log_identifier,
             logical_task_id,
-            e.message
+            e.message,
         )
         raise
     except Exception as e:
@@ -345,7 +341,7 @@ async def run_adk_async_task(
             "%s Bad Request for task %s: %s.",
             component.log_identifier,
             logical_task_id,
-            e.message
+            e.message,
         )
         raise
     except Exception as e:

--- a/src/solace_agent_mesh/agent/protocol/event_handlers.py
+++ b/src/solace_agent_mesh/agent/protocol/event_handlers.py
@@ -632,7 +632,6 @@ async def handle_a2a_request(component, message: SolaceMessage):
                 "is_streaming": is_streaming_request,
                 "statusTopic": status_topic_from_peer,
                 "replyToTopic": reply_topic_from_peer,
-                "original_solace_message": message,
                 "a2a_user_config": a2a_user_config,
                 "effective_session_id": effective_session_id,
                 "is_run_based_session": is_run_based_session,
@@ -664,6 +663,10 @@ async def handle_a2a_request(component, message: SolaceMessage):
             task_context = TaskExecutionContext(
                 task_id=logical_task_id, a2a_context=a2a_context
             )
+
+            # Store the original Solace message in TaskExecutionContext instead of a2a_context
+            # This avoids serialization issues when a2a_context is stored in ADK session state
+            task_context.set_original_solace_message(message)
 
             # Store auth token for peer delegation using generic security storage
             if hasattr(component, "trust_manager") and component.trust_manager:

--- a/src/solace_agent_mesh/agent/sac/component.py
+++ b/src/solace_agent_mesh/agent/sac/component.py
@@ -1997,9 +1997,14 @@ class SamAgentComponent(SamComponentBase):
         For STREAMING tasks, it uses the content of the last ADK event.
         """
         logical_task_id = a2a_context.get("logical_task_id")
-        original_message: Optional[SolaceMessage] = a2a_context.get(
-            "original_solace_message"
-        )
+
+        # Retrieve the original Solace message from TaskExecutionContext
+        original_message: Optional[SolaceMessage] = None
+        with self.active_tasks_lock:
+            task_context = self.active_tasks.get(logical_task_id)
+            if task_context:
+                original_message = task_context.get_original_solace_message()
+
         log.info(
             "%s Finalizing task %s successfully.", self.log_identifier, logical_task_id
         )
@@ -2193,9 +2198,14 @@ class SamAgentComponent(SamComponentBase):
         Called by the background ADK thread wrapper when a task is cancelled.
         """
         logical_task_id = a2a_context.get("logical_task_id")
-        original_message: Optional[SolaceMessage] = a2a_context.get(
-            "original_solace_message"
-        )
+
+        # Retrieve the original Solace message from TaskExecutionContext
+        original_message: Optional[SolaceMessage] = None
+        with self.active_tasks_lock:
+            task_context = self.active_tasks.get(logical_task_id)
+            if task_context:
+                original_message = task_context.get_original_solace_message()
+
         log.info(
             "%s Finalizing task %s as CANCELED.", self.log_identifier, logical_task_id
         )
@@ -2397,9 +2407,14 @@ class SamAgentComponent(SamComponentBase):
         Sends a COMPLETED status with an informative message.
         """
         logical_task_id = a2a_context.get("logical_task_id")
-        original_message: Optional[SolaceMessage] = a2a_context.get(
-            "original_solace_message"
-        )
+
+        # Retrieve the original Solace message from TaskExecutionContext
+        original_message: Optional[SolaceMessage] = None
+        with self.active_tasks_lock:
+            task_context = self.active_tasks.get(logical_task_id)
+            if task_context:
+                original_message = task_context.get_original_solace_message()
+
         log.info(
             "%s Finalizing task %s as COMPLETED (LLM call limit reached).",
             self.log_identifier,
@@ -2476,9 +2491,14 @@ class SamAgentComponent(SamComponentBase):
         Called by the background ADK thread wrapper.
         """
         logical_task_id = a2a_context.get("logical_task_id")
-        original_message: Optional[SolaceMessage] = a2a_context.get(
-            "original_solace_message"
-        )
+
+        # Retrieve the original Solace message from TaskExecutionContext
+        original_message: Optional[SolaceMessage] = None
+        with self.active_tasks_lock:
+            task_context = self.active_tasks.get(logical_task_id)
+            if task_context:
+                original_message = task_context.get_original_solace_message()
+
         log.error(
             "%s Finalizing task %s with error: %s",
             self.log_identifier,
@@ -2621,9 +2641,13 @@ class SamAgentComponent(SamComponentBase):
                         log_id,
                         e,
                     )
-                    original_message: Optional[SolaceMessage] = a2a_context.get(
-                        "original_solace_message"
-                    )
+                    # Retrieve the original Solace message from TaskExecutionContext for fallback NACK
+                    original_message: Optional[SolaceMessage] = None
+                    with self.active_tasks_lock:
+                        task_context = self.active_tasks.get(logical_task_id)
+                        if task_context:
+                            original_message = task_context.get_original_solace_message()
+
                     if original_message:
                         try:
                             original_message.call_negative_acknowledgements()

--- a/src/solace_agent_mesh/agent/sac/task_execution_context.py
+++ b/src/solace_agent_mesh/agent/sac/task_execution_context.py
@@ -4,7 +4,10 @@ Encapsulates the runtime state for a single, in-flight agent task.
 
 import asyncio
 import threading
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from solace_ai_connector.common.message import Message as SolaceMessage
 
 
 class TaskExecutionContext:
@@ -33,16 +36,20 @@ class TaskExecutionContext:
         self.artifact_signals_to_return: List[Dict[str, Any]] = []
         self.event_loop: Optional[asyncio.AbstractEventLoop] = None
         self.lock: threading.Lock = threading.Lock()
-        
+
         # Token usage tracking
         self.total_input_tokens: int = 0
         self.total_output_tokens: int = 0
         self.total_cached_input_tokens: int = 0
         self.token_usage_by_model: Dict[str, Dict[str, int]] = {}
         self.token_usage_by_source: Dict[str, Dict[str, int]] = {}
-        
+
         # Generic security storage (enterprise use only)
         self._security_context: Dict[str, Any] = {}
+
+        # Original Solace message for ACK/NACK operations
+        # Stored here instead of a2a_context to avoid serialization issues
+        self._original_solace_message: Optional["SolaceMessage"] = None
 
     def cancel(self) -> None:
         """Signals that the task should be cancelled."""
@@ -295,10 +302,34 @@ class TaskExecutionContext:
     def clear_security_data(self) -> None:
         """
         Clear all security data.
-        
+
         This method is provided for completeness but is not explicitly called.
         Security data is automatically cleaned up when the TaskExecutionContext
         is removed from active_tasks and garbage collected.
         """
         with self.lock:
             self._security_context.clear()
+
+    def set_original_solace_message(self, message: Optional["SolaceMessage"]) -> None:
+        """
+        Store the original Solace message for this task.
+
+        This message is used for ACK/NACK operations when the task completes.
+        Stored separately from a2a_context to avoid serialization issues when
+        the context is persisted to the ADK session state.
+
+        Args:
+            message: The Solace message that initiated this task, or None
+        """
+        with self.lock:
+            self._original_solace_message = message
+
+    def get_original_solace_message(self) -> Optional["SolaceMessage"]:
+        """
+        Retrieve the original Solace message for this task.
+
+        Returns:
+            The Solace message that initiated this task, or None if not available
+        """
+        with self.lock:
+            return self._original_solace_message


### PR DESCRIPTION
## Summary

This PR addresses a serialization issue by moving the storage of the original Solace message from `a2a_context` to `TaskExecutionContext`.

## Problem

Previously, the `original_solace_message` was stored in `a2a_context`, which gets serialized and persisted to ADK session state. This caused issues because Solace message objects are not serializable.

## Solution

- Added `_original_solace_message` field to `TaskExecutionContext` with getter/setter methods
- Store the original Solace message in `TaskExecutionContext` immediately after creating it (in `event_handlers.py:667`)
- Updated all locations that retrieve the original message to use the new getter method:
  - `finalize_task_success`
  - `finalize_task_cancelled`
  - `finalize_task_with_llm_call_limit`
  - `finalize_task_with_error`
  - Exception handling for fallback NACK operations
- Removed the temporary pop/restore logic in ADK runner that was attempting to work around this issue
- Added documentation explaining why this separation is necessary

## Benefits

- Eliminates serialization errors when `a2a_context` is stored in session state
- Cleaner separation of concerns: serializable context vs runtime objects
- More maintainable code with proper encapsulation in `TaskExecutionContext`
