### PR TITLE
chore(DATAGO-115570): Remove LiteLLM log handlers to prevent logging conflicts

### DIFF
--- a/src/solace_agent_mesh/agent/adk/models/lite_llm.py
+++ b/src/solace_agent_mesh/agent/adk/models/lite_llm.py
@@ -699,6 +699,11 @@ class LiteLlm(BaseLlm):
         super().__init__(model=model, **kwargs)
         self._additional_args = kwargs.copy()
 
+        # Remove handlers added by LiteLLM as they produce duplicate and misformatted logs.
+        # Logging is an application concern and libraries should not set handlers/formatters.
+        for logger_name in ["LiteLLM", "LiteLLM Proxy", "LiteLLM Router", "litellm"]:
+            logging.getLogger(logger_name).handlers.clear()
+
         # Validate and store cache strategy
         valid_strategies = ["none", "5m", "1h"]
         if cache_strategy not in valid_strategies:

--- a/tests/unit/agent/adk/models/test_lite_llm_logging.py
+++ b/tests/unit/agent/adk/models/test_lite_llm_logging.py
@@ -1,0 +1,48 @@
+"""
+When imported, LiteLLM configures custom logging handler and formatter.
+This is bad practice for libraries since logging is an application concern and libraries that set handlers/formatters is likely to conflict with the application's logging configuration.
+
+At initialization, we remove litellm's handlers but keep propagate=True on litellm's loggers so that litellm logs still flow to the main application's log handlers/formatters.
+"""
+
+import logging
+
+from solace_agent_mesh.agent.adk.models.lite_llm import LiteLlm
+
+
+class TestLiteLlmLoggingHandlerCleanup:
+    """Test that LiteLlm properly cleans up litellm's logging handlers after initialization."""
+
+    def test_litellm_loggers_cleaned_after_init(self):
+        """
+        Test that after LiteLlm initialization, all litellm loggers have:
+        - propagate=True (to pass logs to parent handlers)
+        - No handlers (handlers list is empty)
+
+        This prevents duplicate logs and ensures litellm uses the main application's log handlers & formatters.
+        """
+        # The 4 litellm loggers we expect to be cleaned
+        # There is a risk that these logger names change in future litellm versions
+        litellm_logger_names = [
+            "LiteLLM",
+            "LiteLLM Proxy",
+            "LiteLLM Router",
+            "litellm"
+        ]
+
+        # Initialize LiteLlm - we expect litellm handler to be cleared
+        LiteLlm(model="test-model")
+
+        # Verify each litellm logger is properly configured
+        for logger_name in litellm_logger_names:
+            logger = logging.getLogger(logger_name)
+
+            assert logger.propagate is True, (
+                f"{logger_name} should have propagate=True so that logs flow to parent handlers"
+            )
+
+            # Assert no handlers are set (preventing duplicate logs)
+            assert len(logger.handlers) == 0, (
+                f"{logger_name} should have no handlers after init, but has {len(logger.handlers)}: "
+                f"{[type(h).__name__ for h in logger.handlers]}"
+            )


### PR DESCRIPTION
## Summary

This PR fixes logging conflicts caused by LiteLLM's custom log handlers by removing them during initialization while preserving log propagation.

## Problem

LiteLLM configures custom logging handlers and formatters when imported, which is problematic because:
- Libraries should not configure logging handlers/formatters (this is an application concern)
- LiteLLM's handlers conflict with the application's logging configuration
- This causes duplicate and misformatted log entries

## Solution

- Clear all handlers from LiteLLM's loggers (LiteLLM, LiteLLM Proxy, LiteLLM Router, litellm) during LiteLlm initialization
- Keep propagate=True on these loggers so logs still flow to the application's handlers
- This ensures LiteLLM logs are formatted consistently with the rest of the application
