### PR TITLE
fix(DATAGO-114587): auth dialog layout

### DIFF
--- a/client/webui/frontend/src/lib/components/chat/authentication/AuthenticationMessage.tsx
+++ b/client/webui/frontend/src/lib/components/chat/authentication/AuthenticationMessage.tsx
@@ -36,10 +36,10 @@ export const AuthenticationMessage: React.FC<{ message: MessageFE }> = ({ messag
         const targetAgent = message.authenticationLink.targetAgent || "Agent";
 
         return (
-            <div className="w-1/2 rounded-lg border p-4">
+            <div className="w-max rounded-lg border p-4">
                 <div className="font-semibold">Action Needed</div>
                 <div className="py-4">The "{targetAgent}" agent requires authentication.</div>
-                <div className="flex flex-row justify-end gap-2">
+                <div className="flex flex-row flex-wrap justify-end gap-2">
                     <Button variant="ghost" onClick={handleRejectClick} disabled={authenticationAttempted || rejected}>
                         Reject
                     </Button>
@@ -47,7 +47,7 @@ export const AuthenticationMessage: React.FC<{ message: MessageFE }> = ({ messag
                         {message.authenticationLink.text}
                     </Button>
                 </div>
-                <div className="text-muted-foreground w-full text-center text-xs">
+                <div className="text-muted-foreground text-center text-xs">
                     {rejected && <div className="mt-4">Authentication request rejected.</div>}
                     {authenticationAttempted && <div className="mt-4">Authentication window has been opened. Complete the process in the new window.</div>}
                 </div>


### PR DESCRIPTION
# Before
<img width="959" height="921" alt="Screenshot 2025-10-29 at 10 43 40 AM" src="https://github.com/user-attachments/assets/ffb7c43b-d6bb-47d5-a88b-d730e47fbcfa" />

# After
<img width="1728" height="957" alt="Screenshot 2025-10-29 at 10 52 18 AM" src="https://github.com/user-attachments/assets/0deabed8-3998-4f2a-b82f-d098720dfa26" />