### PR TITLE
docs(DATAGO-114478): Agent builder documentation

### DIFF
--- a/docs/docs/documentation/enterprise/agent-builder.md
+++ b/docs/docs/documentation/enterprise/agent-builder.md
@@ -1,150 +1,98 @@
 ---
 title: Agent Builder
-sidebar_position: 10
+sidebar_position: 8
 ---
 
 # Agent Builder
 
-Agent Builder provides a visual, form-based interface for creating and managing agents without writing configuration files. This tool simplifies agent creation by offering optional AI assistance that suggests initial configuration values based on a description of the agent you want to build.
+Agent Builder provides a visual, form-based interface for creating and managing agents without writing configuration files. This tool offers optional AI assistance that suggests initial configuration values based on a description of the agent you want to build.
 
-## Overview
+When you click the "Create Agent" button from the Agents page, a dialog appears offering AI assistance. You can describe what you want the agent to do in natural language, and the AI generates initial configuration values for you to review and modify. Alternatively, you can skip AI assistance and manually enter all configuration details yourself.
 
-When you click the "Create Agent" button from the Agents page (which requires the `sam:agent_builder:create` capability), a dialog appears that offers optional AI assistance. You can describe what you want the agent to do in natural language (between 10 and 1000 characters), and the AI generates initial configuration values for you to review and modify. Alternatively, you can skip this step and manually enter all configuration details yourself.
+After you configure the agent in the form and save it, the agent appears in the Inactive tab with Not Deployed status. At this point, you can further edit the configuration, download it as a YAML file, or deploy it to make it available for use in Chat.
 
-After you configure the agent in the form and save it, the agent appears in the Inactive tab with `Not Deployed` status. At this point, you can further edit the configuration, download it as a YAML file, or deploy it to make it available for use in Chat.
+## Creating Your First Agent
 
-Use the "Refresh" button next to "Create Agent" to update the displayed agent list and sync deployment status information from the backend. For more information about access control, see Access Control.
+Agent Builder offers two paths for beginning your agent configuration.
 
-## Creating Agents
+### AI-Assisted Creation
 
-When you click "Create Agent" from the Agents page, the AI assistance dialog opens by default. This dialog provides two paths for beginning your agent configuration.
+You can provide a natural language description of what you want the agent to do. Explain the agent's purpose, the types of tasks it handles, and any specific capabilities it needs. For example, "An agent that helps users search company documentation and answer questions about internal policies" or "An agent that analyzes sales data and generates reports."
 
-### Using AI to Suggest Initial Values
+When you submit your description, the AI analyzes it and generates suggested values for several configuration fields. The AI creates a unique agent name, writes a description explaining the agent's purpose, drafts system instructions defining agent behavior, suggests appropriate toolsets, recommends connectors if applicable, and provides default settings for skills and communication modes.
 
-You can provide a natural language description of what you want the agent to do. This description should be between 10 and 1000 characters and should explain the agent's purpose, the types of tasks it handles, and any specific capabilities it needs. For example:
+These AI-generated values serve as suggestions only. You proceed to the configuration form where you can review, modify, or completely rewrite any of these values before saving the agent.
 
-- "An agent that helps users search company documentation and answer questions about internal policies"
-- "An agent that analyzes sales data and generates reports"
-- "An agent that assists with employee onboarding by answering HR-related questions"
+### Manual Creation
 
-When you submit your description, the AI analyzes it and generates suggested values for several configuration fields. The AI creates a unique agent name derived from your description, writes a detailed description field explaining the agent's purpose, and drafts system instructions that define how the agent should behave. The AI also suggests appropriate toolsets based on the capabilities mentioned in your description and recommends connectors if they match your needs. Finally, it provides default settings for skills and communication modes.
+You can skip AI assistance entirely by clicking the secondary button. The system prompts you to manually enter the agent's name and description in a simple dialog. After you provide these details and click continue, you proceed to the agent configuration form where the Agent Details section is pre-filled with your entered name and description. Other sections (instructions, toolsets, and connectors) remain empty for you to configure manually.
 
-These AI-generated values serve as suggestions only. After the AI generates them, you proceed to the configuration form where you can review, modify, or completely rewrite any of these values before saving the agent. The AI makes its best judgment based on your description, but you retain complete control over the final configuration.
-
-For more information about connectors, see [Connectors](#connectors).
-
-### Skipping AI Assistance
-
-You can click the secondary button to bypass AI assistance entirely. The system prompts you to manually enter the agent's name and description in a simple dialog. After you provide these details and click continue, you proceed to the agent configuration form where the Agent Details section is pre-filled with your entered name and description. Other sections (instructions, toolsets, connectors, and agent card) remain empty for you to configure manually. At minimum, you must complete the name, description, and instructions before your agent can be deployed.
-
-For more information about deployment requirements, see [Agent Lifecycle and Management](#agent-lifecycle-and-management).
-
-## Agent Configuration Form
+## Configuring the Agent
 
 The agent configuration form is where you configure all agent settings. You have complete control to manually configure or refine every setting, whether you work with AI-generated suggestions or enter values from scratch.
 
 ### Agent Details
 
-Agent details form the foundation of your agent configuration.
+The name field provides a unique identifier that describes the agent's purpose. Names must be unique across your deployment.
 
-The name field requires a unique identifier between 3 and 40 characters that describes the agent's purpose. Names must be unique across your deployment. If you used AI assistance, you should review the suggested name and modify it if needed.
-
-The description field requires text between 10 and 1000 characters that explains what the agent does and when users should interact with it. This description helps users understand the agent's purpose and capabilities.
+The description field explains what the agent does and when users should interact with it. This description helps users understand the agent's purpose and capabilities.
 
 ### Instructions
 
-Instructions define how the agent behaves during interactions. This field requires between 100 and 10,000 characters and forms the basis of the agent system prompt. Your instructions should explain the agent's role, communication style, and any specific rules or constraints it should follow.
+Instructions define how the agent behaves during interactions and form the basis of the agent system prompt. Your instructions should explain the agent's role, communication style, and any specific rules or constraints it should follow.
 
-For example, you might instruct an agent to always provide sources for information, maintain a formal or casual tone, follow specific steps when handling requests, or apply particular business rules or constraints.
-
-If you used AI assistance, the system generates initial instructions based on your description. You should review these carefully and modify them to match your exact requirements because the AI makes its best judgment but cannot know all your specific needs.
+For example, you can instruct an agent to always provide sources for information, maintain a formal or casual tone, follow specific steps when handling requests, or apply particular business rules or constraints.
 
 ### Toolsets
 
-Toolsets provide the agent with capabilities it can use to accomplish tasks. You can select from available toolsets such as Artifact Management to list, read, create, update and delete artifacts, Data Analysis to query, transform and visualize data from artifacts, and Web to perform internet searches.
+Toolsets provide the agent with capabilities it can use to accomplish tasks. Available toolsets include Artifact Management (list, read, create, update and delete artifacts), Data Analysis (query, transform and visualize data from artifacts), and Web (perform internet searches).
 
 You can assign multiple toolsets to a single agent, giving it access to diverse capabilities. If you select Data Analysis, you should also include Artifact Management because data analysis operations typically require artifact access.
 
-If you used AI assistance, the system suggests toolsets based on your description. You should review these selections and add or remove toolsets as needed to match your agent's actual requirements.
-
 ### Connectors
 
-Connectors link agents to external data sources like SQL databases. You can assign connectors that were previously created in the Connectors section. Each connector provides access to a specific database with configured credentials.
+Connectors link agents to external data sources such as databases and APIs. You assign connectors that were previously created in the Connectors section. All agents sharing a connector use the same credentials.
 
-All agents sharing a connector use the same database credentials. You should implement database-level access controls to restrict what each agent can access. The system supports MySQL, PostgreSQL, and MariaDB connectors.
+For detailed information about creating and configuring connectors, see [Connectors](connectors/connectors.md).
 
-Connectors must be created separately before they can be assigned to agents. For detailed information on creating and configuring database connectors, see [Working with SQL Connectors](#working-with-sql-connectors).
+## Deploying and Managing Agents
 
-### Agent Card
+### How Deployment Works
 
-Agent card configuration defines how the agent presents itself and communicates.
+When you deploy an agent through Agent Builder, the deployment process involves several components working together to create running agent instances.
 
-The skills field lets you specify what tasks the agent can perform. This information helps users and other agents understand your agent's capabilities.
+The Gateway receives your deployment request and validates the agent configuration. It creates a deployment record in the database and publishes a deployment message to the Solace broker. The Deployer component (a separate service) receives this message and creates a running agent instance using the configuration you provided. The Deployer sends status updates back to the Gateway through heartbeat messages, and the Gateway updates the deployment status you see in the UI.
 
-The communication modes field lets you select how the agent interacts, such as text-based interaction or voice capabilities. Choose the modes that match your agent's intended use cases.
-
-### Saving the Agent
-
-After you configure all settings, you can save the agent. It appears in the Inactive tab with `Not Deployed` status, where you can further edit the configuration, download it as a YAML file, or deploy it to make it available for use in Chat.
-
-## Working with SQL Connectors
-
-SQL connectors enable agents to query and analyze database information using natural language. These connectors convert user questions into SQL queries, execute them, and return results in a conversational format.
-
-Before you assign connectors to agents, you must create them in the Connectors section of the interface. Each connector configuration includes the database type (MySQL, PostgreSQL, or MariaDB), connection details (host, port, and database name), and authentication credentials (username and password).
-
-Once you create connectors, they become available for assignment to any agent. This reusability means you can connect multiple agents to the same database without duplicating connection configuration.
-
-### Security Considerations
-
-Security considerations are essential when using SQL connectors. The framework does not sandbox database access at the agent level. All agents assigned to a connector share the same database credentials and permissions. This design has several implications.
-
-Any agent with the connector can access all data the connector's credentials permit. Database-level access control is your primary security mechanism. You should create database users with minimal necessary privileges. Consider using database views or restricted schemas to limit what agents can access. You should also audit database queries to monitor what agents are accessing.
-
-The natural language to SQL conversion capability makes databases accessible through conversation, but this also means users can potentially request any data the connector can access. You should plan your database permissions accordingly and consider what information should be available through agent interactions.
-
-Each agent can be assigned a limited number of connectors. This limit helps manage complexity and prevents performance issues.
-
-## Agent Lifecycle and Management
-
-Agents move through distinct states as you create, edit, and deploy them.
+This architecture enables multiple Deployer instances to run for scalability and allows deployment operations to complete asynchronously without blocking the UI. You see status transitions (Deploying, Deployed, or Deployment Failed) as the Deployer works in the background.
 
 ### Agent States
+
+Agents move through distinct states as you create, edit, and deploy them.
 
 Not Deployed is the initial status for newly created agents. These agents appear in the Inactive tab where you can edit their configurations, download them as YAML files, or prepare them for deployment. Agents remain in this status until you explicitly deploy them.
 
 Deploying and Undeploying are the in-progress statuses that appear when an agent is being deployed or undeployed. You should not interact with an agent when it is in this transitory state.
 
-Running agents move to the Active tab and become available for user interactions. Once deployed, agents cannot be deleted—you must undeploy them first to remove them from the system.
+Deployed agents move to the Active tab and become available for user interactions. You cannot delete deployed agents—you must undeploy them first to remove them from the system.
 
 Deployment Failed displays if your agent failed to deploy for any reason. You should verify all agent configuration and try again, or contact an administrator if the problem persists.
 
-### Managing Configuration Changes
+### Managing Deployed Agents
 
-Sync status tracking helps you manage configuration drift for deployed agents. When you deploy an agent, the system records its configuration. If you later edit the agent's configuration in the UI, the system detects this mismatch. The system continues to display the Running agent in the active section and also displays the agent updates as Not Deployed in the inactive section. Both tiles show "Undeployed changes" to help you understand when deployed agents do not match their stored configurations. The specific synchronization mechanism depends on your deployment approach. The "Preview Updates" action in the agent side panel can help you compare the running agent with its undeployed configuration.
+When you deploy an agent, the system records its configuration. If you later edit the agent's configuration in the UI, the system detects this mismatch and displays "Undeployed changes" on both the Active and Inactive agent tiles. The "Preview Updates" action in the agent side panel compares the running agent with its undeployed configuration. Changes to deployed agents require the "Deploy Updates" action to take effect in the running agent.
 
-You can edit agent configurations (of agents built with agent builder) at any time, whether they are deployed or not. Changes to deployed agents require the "Deploy Updates" action to take effect in the Running agent.
+Downloading agents as YAML files provides portability and version control. These files support backing up agent configurations, sharing configurations between deployments, tracking configuration changes in version control systems, and deploying agents using infrastructure-as-code tools.
 
-### Downloading Agent Configurations
+## Access Control
 
-Downloading agents as YAML files provides portability and version control. You can use these files to back up agent configurations, share configurations between deployments, track configuration changes in version control systems, and deploy agents using infrastructure-as-code tools.
+Agent Builder operations require specific RBAC capabilities. The table below shows the capabilities and what they control:
 
-## Configuration Validation and Constraints
+| Capability | Purpose |
+|------------|---------|
+| `sam:agent_builder:create` | Create new agents through Agent Builder interface |
+| `sam:agent_builder:update` | Edit existing agent configurations |
+| `sam:agent_builder:delete` | Delete agents (must undeploy first) |
+| `sam:deployments:create` | Deploy agents to make them available in Chat |
+| `sam:deployments:read` | View deployment status and history |
 
-The system enforces several validation rules to ensure agent configurations remain functional.
-
-### Name Uniqueness
-
-Name uniqueness is enforced across all agents in your deployment. If you attempt to create an agent with a name that already exists, the system rejects it. This prevents confusion and ensures each agent has a distinct identifier.
-
-### Field Length Constraints
-
-Field length constraints ensure configurations remain manageable. Agent names must be between 3 and 40 characters. Agent descriptions must be between 10 and 1000 characters. System instructions must be between 100 and 10,000 characters (this field is optional during creation but required before deployment). AI-assisted descriptions must be between 10 and 1000 characters.
-
-### Deletion Restrictions
-
-Deletion restrictions prevent accidentally removing active agents. You cannot delete deployed agents directly. You must first undeploy them, which moves them back to Not Deployed status in the Inactive tab. After undeployment completes, you can delete them. This two-step process helps prevent service disruptions.
-
-### Connector Limits
-
-Each agent can have a limited number of connectors. This restriction helps manage complexity and prevents performance issues that could arise from agents attempting to connect to too many databases simultaneously.
+For information about connector-related capabilities, see [Connectors](connectors/connectors.md#access-control). For detailed information about configuring role-based access control and assigning capabilities to users, see [Setting Up RBAC](rbac-setup-guide.md). For Kubernetes-specific RBAC configuration, see the [Helm Chart RBAC documentation](https://solaceproducts.github.io/solace-agent-mesh-helm-quickstart/docs-site/#role-based-access-control-rbac).

--- a/docs/docs/documentation/enterprise/connectors/connectors.md
+++ b/docs/docs/documentation/enterprise/connectors/connectors.md
@@ -1,0 +1,96 @@
+---
+title: Connectors
+sidebar_position: 10
+---
+
+# Connectors
+
+Connectors link agents to external data sources and services. Each connector type provides access to different systems using configured credentials and connection details. Agents use connectors to retrieve information, execute queries, and interact with external platforms through natural language conversations.
+
+## SQL Connectors
+
+SQL connectors enable agents to query and analyze database information using natural language. These connectors convert user questions into SQL queries, execute them against configured databases, and return results in a conversational format. This capability makes database information accessible through agent interactions without requiring users to write SQL code.
+
+### Supported Databases
+
+SQL connectors support three database types:
+- MySQL
+- PostgreSQL
+- MariaDB
+
+Each database type follows the same configuration process but may have specific connection string requirements or authentication methods.
+
+### Creating SQL Connectors
+
+You create SQL connectors in the Connectors section of the Enterprise web interface. This process must be completed before you can assign connectors to agents.
+
+Each SQL connector configuration includes the database type selection, connection details (host address, port number, and database name), and authentication credentials (username and password). The connection configuration establishes a persistent connection pool that agents use to execute queries. You should verify that the database server allows connections from the Agent Mesh deployment and that any required firewall rules permit access.
+
+Once you create a connector, it becomes available for assignment to any agent in your deployment. This reusability means you can connect multiple agents to the same database without duplicating connection configuration. All agents assigned to a connector share the same database connection pool and credentials.
+
+### Security Considerations
+
+The framework implements a shared credential model that has significant implications for access control when planning your deployment architecture.
+
+#### Shared Credential Architecture
+
+The framework does not sandbox database access at the agent level. All agents assigned to a connector share the same database credentials and permissions. This design means that any agent with the connector can access all data the connector's credentials permit. Security boundaries exist at the database level, not between agents.
+
+#### Implementing Database-Level Security
+
+Database-level access control is your primary security mechanism. You should create database users with minimal necessary privileges, use database views or restricted schemas to limit what agents can access, and audit database queries to monitor what agents are accessing.
+
+For example, if you have agents that should only read customer data and other agents that need full database access, you must create separate connectors with different database users. Each database user has appropriate permissions configured at the database level. You cannot restrict access by assigning the same connector to different agents because all agents sharing a connector have identical database permissions.
+
+#### Natural Language Query Risks
+
+The natural language to SQL conversion capability makes databases accessible through conversation, but this also means users can potentially request any data the connector can access. You should plan your database permissions accordingly and consider what information should be available through agent interactions.
+
+Users might phrase questions in ways that expose data you intended to restrict, or they might discover table and column names through exploratory questions. Database views that present only approved data columns, user accounts with read-only permissions on specific tables, and query result size limits all help mitigate these risks.
+
+#### Best Practices
+
+Create separate connectors for different security boundaries. If agents require different levels of database access, configure multiple connectors with appropriately scoped database users rather than sharing a single connector across all agents.
+
+Use read-only database accounts whenever possible. Many agent use cases only require reading data, and read-only permissions prevent accidental or malicious data modification.
+
+Implement database views to present filtered data. Views can hide sensitive columns, join tables to present aggregated information, or implement row-level security logic at the database level.
+
+Enable query logging and monitoring to track what agents access. Database audit logs help you detect suspicious query patterns or unauthorized data access attempts.
+
+### Assigning Connectors to Agents
+
+You assign connectors to agents through Agent Builder. When creating or editing an agent, you select connectors from a list during agent configuration. You can assign connectors before or after deployment, and changes to connector assignments take effect when you deploy or update the agent.
+
+### Managing Connectors
+
+Connector management operations require specific RBAC capabilities and follow particular patterns to prevent service disruptions.
+
+#### Editing Connectors
+
+You can modify connector configurations at any time. Changes to connection details or credentials take effect immediately for new database connections. Existing connections in the pool may continue using previous credentials until they expire and reconnect.
+
+If agents are actively using a connector when you modify it, query failures may occur during the transition period. You should plan connector updates during maintenance windows or coordinate with agent users to minimize disruptions.
+
+#### Testing Connections
+
+The Connectors interface provides connection testing functionality that validates credentials and connectivity before you save the connector configuration. This testing helps identify configuration errors before agents attempt to use the connector.
+
+#### Deleting Connectors
+
+You can delete connectors, but the system enforces restrictions to prevent breaking deployed agents. If any agents are assigned to a connector, you must first remove the connector from those agents or undeploy them before deletion succeeds.
+
+The deletion process removes the connector configuration but does not affect the database itself. Database users and permissions remain in place, requiring separate cleanup if you no longer need them.
+
+## Access Control
+
+Connector operations require specific RBAC capabilities. The table below shows the capabilities and what they control:
+
+| Capability | Purpose |
+|------------|---------|
+| `sam:connectors:create` | Create new connectors in the Connectors section |
+| `sam:connectors:read` | View connector configurations and list available connectors |
+| `sam:connectors:update` | Modify connector configurations and credentials |
+| `sam:connectors:delete` | Remove connectors from the system |
+
+For detailed information about configuring role-based access control, see [Setting Up RBAC](../rbac-setup-guide.md).

--- a/docs/docs/documentation/enterprise/enterprise.md
+++ b/docs/docs/documentation/enterprise/enterprise.md
@@ -11,7 +11,7 @@ Enterprise is available as a self-managed container image that you can deploy in
 
 ## Enterprise Features
 
-The Enterprise version delivers several key capabilities that distinguish it from the Community edition.
+The Enterprise version delivers several capabilities that distinguish it from the Community edition.
 
 Authentication and authorization integrate with your existing identity systems through SSO, eliminating the need for separate credentials while maintaining security standards. You can configure role-based access control to implement granular authorization policies that determine which agents and resources each user can access through the Agent Mesh Gateways.
 
@@ -21,7 +21,7 @@ Observability tools provide complete visibility into your agent ecosystem. The b
 
 ## Getting Started with Enterprise
 
-Setting up Agent Mesh Enterprise involves three main areas: installation, security configuration, and authentication setup.
+Setting up Agent Mesh Enterprise involves installation, security configuration, and authentication setup.
 
 ### Installation
 
@@ -35,9 +35,13 @@ Role-based access control lets you define who can access which agents and featur
 
 SSO integration connects Agent Mesh Enterprise with your organization's identity provider, whether you use Azure, Google, Auth0, Okta, Keycloak, or another OAuth2-compliant system. The configuration process involves creating YAML files that define the authentication service and provider settings, then launching the container with the appropriate environment variables. For step-by-step configuration instructions, see [Enabling SSO](single-sign-on.md).
 
+### Connectors
+
+Connectors link agents to external data sources such as databases and APIs, enabling agents to retrieve and analyze information through natural language interactions. The Enterprise version supports SQL connectors for MySQL, PostgreSQL, and MariaDB databases. You create connectors in the Connectors section of the web interface, where they become available for assignment to any agent in your deployment. All agents assigned to a connector share the same credentials, requiring careful planning of data source permissions to maintain appropriate access control. For information about creating and managing connectors, see [Connectors](connectors/connectors.md).
+
 ### Agent Builder
 
-The Enterprise version includes Agent Builder, a visual interface for creating and managing agents without writing configuration files directly. Agent Builder supports both AI-assisted generation from natural language descriptions and manual configuration for precise control over agent capabilities. You can create agents, assign toolsets and SQL connectors, manage agent lifecycles, and download configurations as YAML files for version control or infrastructure-as-code deployments. For comprehensive information about creating and managing agents, see [Agent Builder](agent-builder.md).
+The Enterprise version includes Agent Builder, a visual interface for creating and managing agents without writing configuration files directly. Agent Builder supports both AI-assisted generation from natural language descriptions and manual configuration for precise control over agent capabilities. You can create agents, assign toolsets and connectors, and deploy them dynamically through the Deployer component without restarting services. The Deployer handles deployment operations asynchronously, enabling scalable agent creation through the web interface. You can also download agent configurations as YAML files for version control or infrastructure-as-code deployments. For comprehensive information about creating and managing agents, see [Agent Builder](agent-builder.md).
 
 ## What's Next
 


### PR DESCRIPTION
This pull request introduces comprehensive documentation for the new Agent Builder feature in Agent Mesh Enterprise, making agent creation and management more accessible through a visual interface. The changes include a dedicated guide covering all aspects of Agent Builder, as well as an update to the enterprise documentation to highlight this new capability.

**Agent Builder documentation and enterprise guide update:**

* Added a new `agent-builder.md` documentation file with detailed instructions on using Agent Builder, including AI-assisted agent creation, manual configuration, toolset and connector assignment, agent lifecycle management, validation rules, and troubleshooting tips.
* Updated `enterprise.md` to introduce Agent Builder as a visual interface for agent creation, describe its capabilities, and link to the new documentation for further details.