### PR TITLE
fix(DATAGO-116171): Add new state if the task is paused.

### DIFF
--- a/src/solace_agent_mesh/agent/adk/runner.py
+++ b/src/solace_agent_mesh/agent/adk/runner.py
@@ -124,6 +124,15 @@ async def run_adk_async_task_thread_wrapper(
             a2a_context,
         )
 
+        # Mark task as paused if it's waiting for peer response or user input
+        if task_context and is_paused:
+            task_context.set_paused(True)
+            log.debug(
+                "%s Task %s marked as paused, waiting for peer response or user input.",
+                component.log_identifier,
+                logical_task_id,
+            )
+
         log.debug(
             "%s ADK task %s awaited and completed (Paused: %s).",
             component.log_identifier,

--- a/src/solace_agent_mesh/agent/sac/component.py
+++ b/src/solace_agent_mesh/agent/sac/component.py
@@ -755,6 +755,14 @@ class SamAgentComponent(SamComponentBase):
         paused_invocation_id = correlation_data.get("invocation_id")
         log_retrigger = f"{self.log_identifier}[RetriggerManager:{logical_task_id}]"
 
+        # Clear paused state - task is resuming now
+        task_context.set_paused(False)
+        log.debug(
+            "%s Task %s resuming from paused state with peer responses.",
+            log_retrigger,
+            logical_task_id,
+        )
+
         try:
             effective_session_id = original_task_context.get("effective_session_id")
             user_id = original_task_context.get("user_id")

--- a/src/solace_agent_mesh/agent/sac/task_execution_context.py
+++ b/src/solace_agent_mesh/agent/sac/task_execution_context.py
@@ -36,6 +36,7 @@ class TaskExecutionContext:
         self.artifact_signals_to_return: List[Dict[str, Any]] = []
         self.event_loop: Optional[asyncio.AbstractEventLoop] = None
         self.lock: threading.Lock = threading.Lock()
+        self.is_paused: bool = False  # Track if task is paused waiting for peer/auth
 
         # Token usage tracking
         self.total_input_tokens: int = 0
@@ -58,6 +59,26 @@ class TaskExecutionContext:
     def is_cancelled(self) -> bool:
         """Checks if the cancellation event has been set."""
         return self.cancellation_event.is_set()
+
+    def set_paused(self, paused: bool) -> None:
+        """
+        Marks the task as paused (waiting for peer response or user input).
+
+        Args:
+            paused: True if task is paused, False if resuming.
+        """
+        with self.lock:
+            self.is_paused = paused
+
+    def get_is_paused(self) -> bool:
+        """
+        Checks if the task is currently paused.
+
+        Returns:
+            True if task is paused (waiting for peer/auth), False otherwise.
+        """
+        with self.lock:
+            return self.is_paused
 
     def append_to_streaming_buffer(self, text: str) -> None:
         """Appends a chunk of text to the main streaming buffer."""


### PR DESCRIPTION
Fix Paused Task Cancellation Bug

  **Problem**

  When a task is paused (waiting for peer response or authentication), the ADK runner has already exited. If a cancellation request arrives while the task is paused, task_context.cancel() sets the cancellation event but no active runner exists to detect it, leaving the task stuck forever without finalization.

 **Solution**

Added paused state tracking to TaskExecutionContext and immediate finalization for paused tasks with no peer sub-tasks when cancellation is requested.

Changes

  1. task_execution_context.py
  - Added is_paused: bool flag to track paused state
  - Added set_paused(paused: bool) and get_is_paused() methods

  2. runner.py
  - Mark task as paused when runner exits: task_context.set_paused(True)

  3. component.py
  - Clear paused state when retriggering with peer responses: task_context.set_paused(False)

  4. event_handlers.py
  - On cancellation, check if task is paused with no peer sub-tasks
  - If yes, immediately schedule finalization (no runner to detect cancellation)
  - If no, let the active runner handle cancellation normally

  5. input_required.py (enterprise)
  - Clear paused state when resuming after authentication

  Behavior

  - Active tasks: Runner detects cancellation via is_cancelled() checks (unchanged)
  - Paused tasks with peer sub-tasks: Peers will respond/timeout and trigger normal flow
  - Paused tasks without peers: Immediately finalize (fixes the bug)
