### PR TITLE
feat: Add platform database configuration to preset

### DIFF
--- a/docs/docs/documentation/installing-and-configuring/session-storage.md
+++ b/docs/docs/documentation/installing-and-configuring/session-storage.md
@@ -177,6 +177,20 @@ The database connection string specifying where to store session data.
 export WEB_UI_GATEWAY_DATABASE_URL="postgresql://user:pass@host:5432/webui_db"
 ```
 
+`PLATFORM_DATABASE_URL` (Optional, required for enterprise features)
+
+The database connection string for platform features such as agents, connectors, and deployments. If not configured, platform endpoints return 501 (Not Implemented).
+
+```bash
+export PLATFORM_DATABASE_URL="postgresql://user:pass@host:5432/platform_db"
+```
+
+For development, you can use SQLite:
+
+```bash
+export PLATFORM_DATABASE_URL="sqlite:///platform.db"
+```
+
 ### Gateway Configuration File
 
 Update your WebUI Gateway configuration to use the database:
@@ -185,6 +199,9 @@ Update your WebUI Gateway configuration to use the database:
 session_service:
   type: "sql"
   database_url: "${WEB_UI_GATEWAY_DATABASE_URL}"
+
+platform_service:
+  database_url: "${PLATFORM_DATABASE_URL, sqlite:///platform.db}"
 ```
 
 ### Database Backend Options

--- a/preset/agents/basic/webui.yaml
+++ b/preset/agents/basic/webui.yaml
@@ -25,6 +25,9 @@ apps:
         database_url: "${WEB_UI_GATEWAY_DATABASE_URL, sqlite:///webui-gateway.db}"
         default_behavior: "PERSISTENT"
 
+      platform_service:
+        database_url: "${PLATFORM_DATABASE_URL, sqlite:///platform.db}"
+
       artifact_service: *default_artifact_service
 
       model: *general_model


### PR DESCRIPTION
## Summary

Add platform database configuration to the WebUI gateway preset, enabling enterprise platform features (agents, connectors, deployments) with persistent storage by default.

This PR builds on #462 (platform database support) by configuring the platform database in the preset files.

## Changes

### Configuration (`preset/agents/basic/webui.yaml`)
- Added `platform_service.database_url` configuration
- Uses `PLATFORM_DATABASE_URL` environment variable
- Defaults to `sqlite:///platform.db` for local development

### Documentation (`session-storage.md`)
- Added `PLATFORM_DATABASE_URL` environment variable documentation
- Included examples for both SQLite and PostgreSQL
- Updated gateway configuration examples to show platform_service

## Benefits

### For Local Development
- Platform features work out-of-the-box with SQLite
- No external database setup required
- Platform data persists across restarts

### For Production Deployments
- Easy PostgreSQL configuration via environment variable
- Separate database for platform vs runtime data
- Supports database split architecture for service separation

## Behavior

### With PLATFORM_DATABASE_URL Set
```bash
export PLATFORM_DATABASE_URL="postgresql://user:pass@host:5432/platform_db"
```
→ Platform migrations run, enterprise features available

### Without Environment Variable (Default)
Uses SQLite: `sqlite:///platform.db`
→ Platform features work locally with file-based storage

### To Disable Platform Features
Unset or leave empty:
```bash
export PLATFORM_DATABASE_URL=""
```
→ Platform migrations skipped, endpoints return 501

## Configuration Example

```yaml
app_config:
  session_service:
    type: "sql"
    database_url: "${WEB_UI_GATEWAY_DATABASE_URL, sqlite:///webui-gateway.db}"

  platform_service:
    database_url: "${PLATFORM_DATABASE_URL, sqlite:///platform.db}"
```

## Testing

- [x] Verify default SQLite configuration works locally
- [x] Verify PLATFORM_DATABASE_URL environment variable override works
- [x] Confirm documentation is clear and accurate
- [x] Ensure backward compatibility (empty value disables platform features)

## Related

- Depends on: #462 (platform database configuration support)
- Related to: #479 (default SQL persistence with SQLite)