### PR TITLE
DATAGO-113744: Update SSO Documentation- Clarify OAuth2 Flow and Environment Variable Usage

### DIFF
--- a/docs/docs/documentation/enterprise/single-sign-on.md
+++ b/docs/docs/documentation/enterprise/single-sign-on.md
@@ -490,7 +490,9 @@ When using SSO, it’s important to understand how the authentication flow works
 
 ### How the OAuth2 Flow Works
 
-1. A user visits the `FRONTEND_AUTH_LOGIN_URL` (for example, `http://localhost:8000/api/v1/auth/login`).
+1. A user opens the frontend application (for example, `http://localhost:8000`).  
+   - The frontend checks whether a valid access token exists (e.g., in local storage or cookies).  
+   - If no valid token is found or the token has expired, the frontend automatically calls the backend endpoint defined by `FRONTEND_AUTH_LOGIN_URL` (for example, `http://localhost:8000/api/v1/auth/login`) to start the authentication process.  
 2. The WebUI Gateway calls the `EXTERNAL_AUTH_SERVICE_URL` (typically `http://localhost:9000`) and passes the `EXTERNAL_AUTH_PROVIDER` value (such as `azure` or `keycloak` or `auth0`, or `google`).
 3. The OAuth2 service looks up the provider in `oauth2_config.yaml` and automatically constructs the correct authorization request using the provider’s `issuer`, `client_id`, `redirect_uri`, and `scope`.
 4. The user is redirected to the IdP (e.g., Azure AD, Auth0, or Keycloak) for login.


### PR DESCRIPTION
This PR updates the Single Sign-On (SSO) documentation to clarify how the OAuth2 authentication flow works in the Solace Agent Mesh and to better explain key environment variables.

**Changes Introduced**
	•	Added a step-by-step explanation of the OAuth2 authentication flow between the frontend, gateway, OAuth service, and IdP.
	•	Clarified that users should not manually append client_id, scope, or redirect_uri to the FRONTEND_AUTH_LOGIN_URL — these are automatically handled by the OAuth2 service.
	•	Documented common environment variables:
	•	FRONTEND_AUTH_LOGIN_URL
	•	EXTERNAL_AUTH_SERVICE_URL
	•	EXTERNAL_AUTH_PROVIDER
	•	EXTERNAL_AUTH_CALLBACK
	•	FRONTEND_REDIRECT_URL
	•	Added examples for supported identity providers (azure, keycloak, auth0, google).
	•	Improved examples and formatting for better readability.