### PR TITLE
fix(DATAGO-116434): Ensuring messages don't get mixed when changing sessions on a slow network

### DIFF
--- a/client/webui/frontend/src/lib/types/index.ts
+++ b/client/webui/frontend/src/lib/types/index.ts
@@ -1,5 +1,6 @@
 export * from "./activities";
 export * from "./be";
 export * from "./fe";
+export * from "./projects";
 export * from "./prompts";
 export * from "./storage";


### PR DESCRIPTION
This pull request refactors the imports and improves session management in the `ChatProvider` component. The main changes include reorganizing type imports for clarity, improving session state handling to avoid race conditions, and making the code more maintainable and robust when switching sessions or loading tasks.

**Code organization improvements:**

* Moved type exports for `Project` and related types to a centralized `index.ts` barrel file for cleaner and more maintainable imports throughout the codebase.
* Consolidated and reordered imports in `ChatProvider.tsx` to import all types from the new barrel file, simplifying the import section and improving code clarity. [[1]](diffhunk://#diff-d33c8017d7b1273101dabad6b9fb45a9a00f0312bada8b8ec387b325a21bc2f7L7-R32) [[2]](diffhunk://#diff-d33c8017d7b1273101dabad6b9fb45a9a00f0312bada8b8ec387b325a21bc2f7L40-L73)

**Session and state management enhancements:**

* Added a `currentSessionIdRef` to track the active session and prevent race conditions when loading tasks, ensuring that only data for the current session is processed. [[1]](diffhunk://#diff-d33c8017d7b1273101dabad6b9fb45a9a00f0312bada8b8ec387b325a21bc2f7L93-R113) [[2]](diffhunk://#diff-d33c8017d7b1273101dabad6b9fb45a9a00f0312bada8b8ec387b325a21bc2f7L288-R302)
* Updated the `deserializeTaskToMessages` function to accept `sessionId` as a parameter, further ensuring correct session context when deserializing messages. [[1]](diffhunk://#diff-d33c8017d7b1273101dabad6b9fb45a9a00f0312bada8b8ec387b325a21bc2f7L229-R239) [[2]](diffhunk://#diff-d33c8017d7b1273101dabad6b9fb45a9a00f0312bada8b8ec387b325a21bc2f7L248-R256) [[3]](diffhunk://#diff-d33c8017d7b1273101dabad6b9fb45a9a00f0312bada8b8ec387b325a21bc2f7L303-R315)
* Improved session switching by resetting session-related state variables (e.g., message list, responding state, selected task) and ensuring session tasks are loaded only after the session state is updated. [[1]](diffhunk://#diff-d33c8017d7b1273101dabad6b9fb45a9a00f0312bada8b8ec387b325a21bc2f7L1326-L1329) [[2]](diffhunk://#diff-d33c8017d7b1273101dabad6b9fb45a9a00f0312bada8b8ec387b325a21bc2f7L1399-R1411) [[3]](diffhunk://#diff-d33c8017d7b1273101dabad6b9fb45a9a00f0312bada8b8ec387b325a21bc2f7L1409)

**Minor cleanup:**

* Cleaned up dependency arrays and removed unnecessary dependencies in React hooks to avoid potential performance issues or bugs.

___ 

Tested by throttling network traffic - the messages eventually catch up to the current session with no collision of messages.

https://github.com/user-attachments/assets/2a7882a0-2084-4a78-9631-db75f1e3b1c2

