### PR TITLE
fix(DATAGO-116603): Update remote MCP with auth to not use parallel tool calls.

### DIFF
--- a/examples/agents/remote-mcp/mcp_canva.yaml
+++ b/examples/agents/remote-mcp/mcp_canva.yaml
@@ -695,8 +695,6 @@ apps:
         type: "filesystem"
         base_path: "/tmp/samv2"
         artifact_scope: namespace
-      credential_service:
-        type: "memory"
       enable_embed_resolution: true
       enable_artifact_content_instruction: true
       trust_manager:

--- a/examples/agents/remote-mcp/mcp_cloudflare.yaml
+++ b/examples/agents/remote-mcp/mcp_cloudflare.yaml
@@ -338,8 +338,6 @@ apps:
         type: "filesystem"
         base_path: "/tmp/samv2"
         artifact_scope: namespace
-      credential_service:
-        type: "memory"
       enable_embed_resolution: true
       enable_artifact_content_instruction: true
       trust_manager:

--- a/examples/agents/remote-mcp/mcp_jira_sse_example.yaml
+++ b/examples/agents/remote-mcp/mcp_jira_sse_example.yaml
@@ -1142,8 +1142,6 @@ apps:
         type: "filesystem"
         base_path: "/tmp/samv2"
         artifact_scope: namespace
-      credential_service:
-        type: "memory"
       enable_embed_resolution: true
       enable_artifact_content_instruction: true
   

--- a/examples/agents/remote-mcp/mcp_stripe.yaml
+++ b/examples/agents/remote-mcp/mcp_stripe.yaml
@@ -906,8 +906,6 @@ apps:
         type: "filesystem"
         base_path: "/tmp/samv2"
         artifact_scope: namespace
-      credential_service:
-        type: "memory"
       enable_embed_resolution: true
       enable_artifact_content_instruction: true
       trust_manager:


### PR DESCRIPTION
Update the instruction of the remote MCP examples with auth to not use parallel tool calls.