### PR TITLE
fix(DATAGO-116584): long project name

### DIFF
--- a/client/webui/frontend/src/lib/components/header/Header.tsx
+++ b/client/webui/frontend/src/lib/components/header/Header.tsx
@@ -51,7 +51,7 @@ export const Header: React.FC<HeaderProps> = ({ title, breadcrumbs, tabs, button
             {leadingAction && <div className="mr-4 flex items-center pt-[35px]">{leadingAction}</div>}
 
             {/* Title */}
-            <div className="flex items-center pt-[35px] text-xl">{title}</div>
+            <div className="max-w-lg truncate pt-[35px] text-xl">{title}</div>
 
             {/* Tabs */}
             {tabs && tabs.length > 0 && (


### PR DESCRIPTION
# Screenshot
<img width="1728" height="992" alt="Screenshot 2025-11-05 at 2 21 50 PM" src="https://github.com/user-attachments/assets/774d8443-1ec8-41f2-93dc-4ecbed3be171" />
