### PR TITLE
fix(DATAGO-116792): remove UUID from gateway queue names to prevent queue leaks

### DIFF
--- a/src/solace_agent_mesh/gateway/http_sse/component.py
+++ b/src/solace_agent_mesh/gateway/http_sse/component.py
@@ -388,7 +388,7 @@ class WebUIBackendComponent(BaseGatewayComponent):
             broker_input_cfg = {
                 "component_module": "broker_input",
                 "component_name": f"{self.gateway_id}_viz_broker_input",
-                "broker_queue_name": f"{self.namespace.strip('/')}/q/gdk/viz/{self.gateway_id}/{uuid.uuid4().hex}",
+                "broker_queue_name": f"{self.namespace.strip('/')}/q/gdk/viz/{self.gateway_id}",
                 "create_queue_on_start": True,
                 "component_config": {
                     "broker_url": main_broker_config.get("broker_url"),
@@ -522,7 +522,7 @@ class WebUIBackendComponent(BaseGatewayComponent):
             broker_input_cfg = {
                 "component_module": "broker_input",
                 "component_name": f"{self.gateway_id}_task_log_broker_input",
-                "broker_queue_name": f"{self.namespace.strip('/')}/q/gdk/task_log/{self.gateway_id}/{uuid.uuid4().hex}",
+                "broker_queue_name": f"{self.namespace.strip('/')}/q/gdk/task_log/{self.gateway_id}",
                 "create_queue_on_start": True,
                 "component_config": {
                     "broker_url": main_broker_config.get("broker_url"),


### PR DESCRIPTION
## Summary
Fixes a critical issue where visualization and task_log queues were creating new orphaned queues on every gateway restart, causing resource leaks and message accumulation.

## Problem
The visualization and task_log internal flows were using `uuid.uuid4().hex` in their queue names:
- `{namespace}/q/gdk/viz/{gateway_id}/{uuid}`
- `{namespace}/q/gdk/task_log/{gateway_id}/{uuid}`

This caused a new queue to be created every time the gateway started, leaving orphaned queues with:
- 0 consumers
- Accumulated messages (up to quota limit)
- Wasted broker resources

## Root Cause
Every time `_ensure_visualization_flow_is_running()` or `_ensure_task_logger_flow_is_running()` executed, a new random UUID was generated, creating a new durable queue and abandoning the previous one.

## Solution
Removed the UUID suffix from both queue names:
- `{namespace}/q/gdk/viz/{gateway_id}`
- `{namespace}/q/gdk/task_log/{gateway_id}`

This ensures:
- Queue names are stable across gateway restarts
- Messages are preserved when gateway reconnects
- No orphaned queues accumulating resources
- Consistent with other queue patterns in the codebase (e.g., `q/a2a/OrchestratorAgent`, `q/gdk/gateway/{gateway_id}`)

## Impact
**Before**: Gateway restarts left 82+ orphaned queues consuming broker resources
**After**: Gateway reuses the same queues, preserving messages and preventing leaks

## Testing Recommendations
1. Manually delete all existing orphaned viz and task_log queues
2. Restart gateway and verify only one queue per type is created
3. Restart gateway again and verify the same queues are reused
4. Verify visualization streams continue working after restart

## Related
Queue naming pattern should match other durable queues in the system which do not use random UUIDs.