### PR TITLE
chore(DATAGO-117179): Downgrade log level for AuthMiddleware

### DIFF
--- a/src/solace_agent_mesh/gateway/http_sse/main.py
+++ b/src/solace_agent_mesh/gateway/http_sse/main.py
@@ -166,7 +166,7 @@ async def _create_user_state_without_identity_service(
             user_identifier,
         )
 
-    log.error(
+    log.debug(
         "AuthMiddleware: Internal IdentityService not configured on component. Using user ID: %s",
         final_user_id,
     )


### PR DESCRIPTION
- Downgraded a log from error to debug
- The log was misleading as the internal IdentityService is not always used in deployments
- Chose `debug` since this log is written numerous times and details internal behaviour