### PR TITLE
feat(DATAGO-117572): Add react compiler to webui frontend

### DIFF
--- a/client/webui/frontend/package-lock.json
+++ b/client/webui/frontend/package-lock.json
@@ -58,6 +58,7 @@
                 "@types/react": "19.0.0",
                 "@types/react-dom": "19.0.0",
                 "@vitejs/plugin-react": "^4.4.1",
+                "babel-plugin-react-compiler": "^1.0.0",
                 "cypress": "^14.5.4",
                 "eslint": "^9.25.0",
                 "eslint-plugin-react-hooks": "^5.2.0",
@@ -3383,6 +3384,16 @@
             "version": "1.13.2",
             "dev": true,
             "license": "MIT"
+        },
+        "node_modules/babel-plugin-react-compiler": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/babel-plugin-react-compiler/-/babel-plugin-react-compiler-1.0.0.tgz",
+            "integrity": "sha512-Ixm8tFfoKKIPYdCCKYTsqv+Fd4IJ0DQqMyEimo+pxUOMUR9cVPlwTrFt9Avu+3cb6Zp3mAzl+t1MrG2fxxKsxw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@babel/types": "^7.26.0"
+            }
         },
         "node_modules/balanced-match": {
             "version": "1.0.2",

--- a/client/webui/frontend/package.json
+++ b/client/webui/frontend/package.json
@@ -119,6 +119,7 @@
         "@types/react": "19.0.0",
         "@types/react-dom": "19.0.0",
         "@vitejs/plugin-react": "^4.4.1",
+        "babel-plugin-react-compiler": "^1.0.0",
         "cypress": "^14.5.4",
         "eslint": "^9.25.0",
         "eslint-plugin-react-hooks": "^5.2.0",

--- a/client/webui/frontend/vite.config.ts
+++ b/client/webui/frontend/vite.config.ts
@@ -10,7 +10,14 @@ export default defineConfig(({ mode }) => {
     const backendTarget = `http://localhost:${backendPort}`;
 
     return {
-        plugins: [react(), tailwindcss()],
+        plugins: [
+            react({
+                babel: {
+                    plugins: [["babel-plugin-react-compiler", {}]],
+                },
+            }),
+            tailwindcss(),
+        ],
         resolve: {
             alias: {
                 "@": path.resolve(__dirname, "./src"),


### PR DESCRIPTION
## What is the purpose of this change?

This change aims to enhance React compilation in the frontend application by introducing a new Babel plugin specifically designed for React.

## How is this accomplished?

- feat: add babel-plugin-react-compiler to enhance React compilation

The change is implemented by:
- Adding the 'babel-plugin-react-compiler' package as a dev dependency
- Configuring the Vite build process to use this new Babel plugin within the React plugin settings

## Anything reviews should focus on/be aware of?

Reviewers should verify that the new Babel plugin is correctly configured and doesn't introduce any unintended side effects on the existing React components or build process.