### PR TITLE
feat(DATAGO-116474): enhance agent selection priority to include URL parameter

### DIFF
--- a/client/webui/frontend/src/lib/providers/ChatProvider.tsx
+++ b/client/webui/frontend/src/lib/providers/ChatProvider.tsx
@@ -59,6 +59,7 @@ import type {
     TaskStatusUpdateEvent,
     TextPart,
     ArtifactPart,
+    AgentCardInfo,
 } from "@/lib/types";
 
 interface ChatProviderProps {
@@ -1855,9 +1856,10 @@ export const ChatProvider: React.FC<ChatProviderProps> = ({ children }) => {
             // Check URL parameter first
             const urlParams = new URLSearchParams(window.location.search);
             const urlAgentName = urlParams.get('agent');
+            let urlAgent: AgentCardInfo | undefined;
             
             if (urlAgentName) {
-                const urlAgent = agents.find(agent => agent.name === urlAgentName);
+                urlAgent = agents.find(agent => agent.name === urlAgentName);
                 if (urlAgent) {
                     selectedAgent = urlAgent;
                     console.log(`Using URL parameter agent: ${selectedAgent.name}`);
@@ -1867,7 +1869,7 @@ export const ChatProvider: React.FC<ChatProviderProps> = ({ children }) => {
             }
 
             // If no URL agent found, follow existing priority order
-            if (!urlAgentName || !agents.find(agent => agent.name === urlAgentName)) {
+            if (!urlAgent) {
                 if (activeProject?.defaultAgentId) {
                     const projectDefaultAgent = agents.find(agent => agent.name === activeProject.defaultAgentId);
                     if (projectDefaultAgent) {


### PR DESCRIPTION
## What is the purpose of this change?

This change enhances the agent selection priority logic to include a URL parameter option, allowing users to specify an agent directly in the URL using the "agent" query parameter (e.g., ?agent=AgentName).

## How is this accomplished?

- feat(DATAGO-116474): enhance agent selection priority to include URL parameter
- Modified the agent selection priority order to first check for the presence of an agent parameter in the URL
- Added validation to fall back to the existing priority logic if the specified agent isn't found
- Updated the selection priority to follow this order:
  1. URL parameter agent
  2. Project's default agent
  3. OrchestratorAgent
  4. First available agent

## Anything reviews should focus on/be aware of?

The URL parameter validation handling includes appropriate fallback mechanisms and logging to ensure a smooth user experience even when an invalid agent name is provided.