### PR TITLE
chore(DATAGO-116572): fixing agent display names

### DIFF
--- a/client/webui/frontend/src/lib/components/projects/DefaultAgentSection.tsx
+++ b/client/webui/frontend/src/lib/components/projects/DefaultAgentSection.tsx
@@ -3,7 +3,7 @@ import { Bot, Pencil } from "lucide-react";
 
 import { Button, Select, SelectContent, SelectItem, SelectTrigger, SelectValue, Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle } from "@/lib/components/ui";
 import type { Project } from "@/lib/types/projects";
-import { useChatContext } from "@/lib/hooks";
+import { useAgentCards, useChatContext } from "@/lib/hooks";
 
 interface DefaultAgentSectionProps {
     project: Project;
@@ -13,6 +13,7 @@ interface DefaultAgentSectionProps {
 
 export const DefaultAgentSection: React.FC<DefaultAgentSectionProps> = ({ project, onSave, isSaving }) => {
     const { agents, agentsLoading } = useChatContext();
+    const { agentNameMap } = useAgentCards();
     const [isEditing, setIsEditing] = useState(false);
     const [selectedAgentId, setSelectedAgentId] = useState<string | null>(project.defaultAgentId || null);
 
@@ -32,9 +33,6 @@ export const DefaultAgentSection: React.FC<DefaultAgentSectionProps> = ({ projec
         setIsEditing(false);
     };
 
-    const currentAgent = agents.find(agent => agent.name === project.defaultAgentId);
-    const displayName = currentAgent?.displayName || project.defaultAgentId || "None";
-
     return (
         <>
             <div className="mb-6">
@@ -50,7 +48,7 @@ export const DefaultAgentSection: React.FC<DefaultAgentSectionProps> = ({ projec
                         {project.defaultAgentId ? (
                             <div className="flex items-center gap-2">
                                 <Bot className="h-4 w-4" />
-                                <span>{displayName}</span>
+                                <span>{agentNameMap[project.defaultAgentId ?? ""] || "N/A"}</span>
                             </div>
                         ) : (
                             <span className="w-full text-center">No default agent set.</span>

--- a/client/webui/frontend/src/lib/hooks/useAgentCards.ts
+++ b/client/webui/frontend/src/lib/hooks/useAgentCards.ts
@@ -57,7 +57,6 @@ interface useAgentCardsReturn {
 export const useAgentCards = (): useAgentCardsReturn => {
     const { configServerUrl } = useConfigContext();
     const [agents, setAgents] = useState<AgentCardInfo[]>([]);
-    const [agentNameMap, setAgentNameMap] = useState<Record<string, string>>({});
     const [isLoading, setIsLoading] = useState<boolean>(false);
     const [error, setError] = useState<string | null>(null);
 
@@ -74,15 +73,6 @@ export const useAgentCards = (): useAgentCardsReturn => {
             const data: AgentCard[] = await response.json();
             const transformedAgents = data.map(transformAgentCard);
             setAgents(transformedAgents);
-
-            // Create a mapping of agent names to display names for easy lookup
-            const nameDisplayNameMap: Record<string, string> = {};
-            transformedAgents.forEach(agent => {
-                if (agent.name) {
-                    nameDisplayNameMap[agent.name] = agent.displayName || agent.name;
-                }
-            });
-            setAgentNameMap(nameDisplayNameMap);
         } catch (err: unknown) {
             console.error("Error fetching agents:", err);
             setError(err instanceof Error ? err.message : "Could not load agent information.");
@@ -95,6 +85,16 @@ export const useAgentCards = (): useAgentCardsReturn => {
     useEffect(() => {
         fetchAgents();
     }, [fetchAgents]);
+
+    const agentNameMap = useMemo(() => {
+        const nameDisplayNameMap: Record<string, string> = {};
+        agents.forEach(agent => {
+            if (agent.name) {
+                nameDisplayNameMap[agent.name] = agent.displayName || agent.name;
+            }
+        });
+        return nameDisplayNameMap;
+    }, [agents]);
 
     return useMemo(
         () => ({


### PR DESCRIPTION
This pull request updates how agent display names are managed and accessed in the project settings UI. The main change is moving the mapping of agent IDs to display names from a state variable to a memoized value, which simplifies state management and ensures the mapping is always up-to-date with the agents list.

**Agent display name mapping improvements:**

* Replaced the `agentNameMap` state in `useAgentCards` with a `useMemo`-based value, ensuring the mapping always reflects the current list of agents and reducing unnecessary state updates. [[1]](diffhunk://#diff-de60a6762cfa1494e6faf45eb5867461644a1ee86c18f804511e8d4d64883facL60) [[2]](diffhunk://#diff-de60a6762cfa1494e6faf45eb5867461644a1ee86c18f804511e8d4d64883facL77-L85) [[3]](diffhunk://#diff-de60a6762cfa1494e6faf45eb5867461644a1ee86c18f804511e8d4d64883facR89-R98)
* Updated `DefaultAgentSection` to use the new `agentNameMap` from `useAgentCards` for displaying the default agent's display name, improving reliability and consistency in the UI. [[1]](diffhunk://#diff-28e9e5bc4a3020e7932e7785d4dc74224f84f7e32d62755ebcfd6e7b98460f9eL6-R6) [[2]](diffhunk://#diff-28e9e5bc4a3020e7932e7785d4dc74224f84f7e32d62755ebcfd6e7b98460f9eR16) [[3]](diffhunk://#diff-28e9e5bc4a3020e7932e7785d4dc74224f84f7e32d62755ebcfd6e7b98460f9eL53-R51)

**Code cleanup:**

* Removed unused variables and logic related to the previous agent display name mapping approach in `DefaultAgentSection`.

--- 
Note: N/A could be "Not Found" - feel free to change this when adding the message banner.
<img width="1724" height="892" alt="image" src="https://github.com/user-attachments/assets/87e37265-ff30-4f9f-81ed-42bf7ad01c06" />
