### PR TITLE
fix(DATAGO-117335): fixing session id for large file upload on first message

### DIFF
--- a/client/webui/frontend/src/lib/providers/ChatProvider.tsx
+++ b/client/webui/frontend/src/lib/providers/ChatProvider.tsx
@@ -1698,13 +1698,13 @@ export const ChatProvider: React.FC<ChatProviderProps> = ({ children }) => {
                             },
                         });
                     } else {
-                        // Large file: upload and get URI
-                        const result = await uploadArtifactFile(file);
+                        // Large file: upload and get URI, pass effectiveSessionId to ensure all files go to the same session
+                        const result = await uploadArtifactFile(file, effectiveSessionId);
 
                         // Check for success FIRST - must have both uri and sessionId
                         if (result && "uri" in result && result.uri && result.sessionId) {
-                            // Update effective session ID if backend created a new one during upload
-                            if (result.sessionId !== sessionId) {
+                            // Update effective session ID once if backend has created a new session
+                            if (!effectiveSessionId) {
                                 effectiveSessionId = result.sessionId;
                             }
 


### PR DESCRIPTION
This pull request improves how chat sessions handle file uploads and session naming in the `ChatProvider` component. The main focus is on ensuring the correct session ID is used when large files trigger the backend to create a new session, and on generating more meaningful session names when messages contain only files.

**Session management improvements:**

* The code now tracks an `effectiveSessionId` that updates if the backend creates a new session during a file upload, ensuring all subsequent messages and context use the correct session ID. [[1]](diffhunk://#diff-d33c8017d7b1273101dabad6b9fb45a9a00f0312bada8b8ec387b325a21bc2f7R1683-R1685) [[2]](diffhunk://#diff-d33c8017d7b1273101dabad6b9fb45a9a00f0312bada8b8ec387b325a21bc2f7L1703-R1714) [[3]](diffhunk://#diff-d33c8017d7b1273101dabad6b9fb45a9a00f0312bada8b8ec387b325a21bc2f7L1748-R1760)

**Session naming enhancements:**

* When a new session is created, if the initial message contains only files (no text), the session name is derived from the file name(s)—using the single file name or a summary if multiple files are uploaded.

**Minor cleanup:**

* Removed unnecessary comments and slightly simplified the early return logic after file upload errors.