### PR TITLE
feat(DATAGO-118068): Add timestamp to user_properties in publish_a2a_message

### DIFF
--- a/src/solace_agent_mesh/common/sac/sam_component_base.py
+++ b/src/solace_agent_mesh/common/sac/sam_component_base.py
@@ -8,6 +8,7 @@ import asyncio
 import concurrent.futures
 import threading
 import functools
+import time
 from typing import Any, Optional
 
 from solace_ai_connector.components.component_base import ComponentBase
@@ -401,6 +402,12 @@ class SamComponentBase(ComponentBase, abc.ABC):
                 topic,
                 list(payload.keys()) if isinstance(payload, dict) else "not_dict"
             )
+
+            # Create user_properties if it doesn't exist
+            if user_properties is None:
+                user_properties = {}
+            
+            user_properties["timestamp"] = int(time.time() * 1000)
 
             # Validate message size
             is_valid, actual_size = validate_message_size(


### PR DESCRIPTION
## What is the purpose of this change?

Add a timestamp to every A2A message to help with debugging and tracking message flow through the system.

## How is this accomplished?

- chore: Add timestamp to user_properties in publish_a2a_message
  - Added a timestamp (in milliseconds) to the user_properties of each A2A message
  - Created user_properties dictionary if it doesn't exist

## Anything reviews should focus on/be aware of?
The timestamp is added in milliseconds since the epoch to maintain precision for high-throughput scenarios.