### PR TITLE
chore(DATAGO-118624): removing npm install references from docs and logs

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -30,7 +30,7 @@
 - **Install Node.js dependencies**:
   ```bash
   cd client/webui/frontend
-  npm install
+  npm ci
   ```
   - **TIMING**: ~15 seconds. Set timeout to 2+ minutes.
 - **Build frontend**:

--- a/.github/helper_scripts/build_frontend.py
+++ b/.github/helper_scripts/build_frontend.py
@@ -64,7 +64,7 @@ class CustomBuildHook(BuildHookInterface):
         log(">>> Building Solace Agent Mesh Config Portal\n")
         os.chdir("config_portal/frontend")
         try:
-            log("### npm install")
+            log("### npm ci")
             subprocess.run(
                 [npm, "ci"], check=True, stdout=log_file, stderr=subprocess.STDOUT
             )
@@ -83,7 +83,7 @@ class CustomBuildHook(BuildHookInterface):
         log(">>> Building Solace Agent Mesh Web UI\n")
         os.chdir("client/webui/frontend")
         try:
-            log("### npm install")
+            log("### npm ci")
             subprocess.run(
                 [npm, "ci"], check=True, stdout=log_file, stderr=subprocess.STDOUT
             )
@@ -104,7 +104,7 @@ class CustomBuildHook(BuildHookInterface):
         log(">>> Building Solace Agent Mesh Documentation\n")
         os.chdir("docs")
         try:
-            log("### npm install")
+            log("### npm ci")
             subprocess.run(
                 [npm, "ci"], check=True, stdout=log_file, stderr=subprocess.STDOUT
             )

--- a/client/webui/frontend/cypress/README.md
+++ b/client/webui/frontend/cypress/README.md
@@ -165,7 +165,7 @@ Ensure the following are installed:
 
 - Node.js (>=20.8.10)
 - npm or yarn
-- Cypress dependencies (`npm install`)
+- Cypress dependencies (`npm ci`)
 
 ### Development Server
 

--- a/client/webui/frontend/frontend_llm.txt
+++ b/client/webui/frontend/frontend_llm.txt
@@ -133,7 +133,7 @@ import { useAuthContext, useBeforeUnload } from "./src/lib/hooks"
 ```bash
 # Install dependencies
 cd frontend
-npm install
+npm ci
 
 # Start development server
 npm run dev

--- a/client/webui/llm.txt
+++ b/client/webui/llm.txt
@@ -40,7 +40,7 @@ import { r as React, j as jsx, e as ReactDOM } from "./webui/frontend/static/ass
 cd webui/frontend
 
 # Install dependencies
-npm install
+npm ci
 
 # Start development server
 npm run dev

--- a/client/webui/llm_detail.txt
+++ b/client/webui/llm_detail.txt
@@ -143,7 +143,7 @@ import { useAuthContext, useBeforeUnload } from "./src/lib/hooks"
 ```bash
 # Install dependencies
 cd frontend
-npm install
+npm ci
 
 # Start development server
 npm run dev
@@ -6331,7 +6331,7 @@ import { r as React, j as jsx, e as ReactDOM } from "./webui/frontend/static/ass
 cd webui/frontend
 
 # Install dependencies
-npm install
+npm ci
 
 # Start development server
 npm run dev

--- a/docs/README.md
+++ b/docs/README.md
@@ -6,7 +6,7 @@ To run Solace Agent Mesh locally, follow these steps:
 
 ```sh
 cd docs
-npm install
+npm ci
 npm start
 ```
 
@@ -16,6 +16,6 @@ To build Solace Agent Mesh documentation pages, follow these steps:
 
 ```sh
 cd docs
-npm install
+npm ci
 npm run build
 ```


### PR DESCRIPTION
This pull request standardizes the usage of `npm ci` instead of `npm install` across documentation and build scripts. The change ensures consistent and reproducible dependency installations for all Node.js-based components, which improves build reliability and speeds up CI/CD workflows.

**Documentation updates:**

* Updated all relevant documentation files (e.g., `.github/copilot-instructions.md`, `client/webui/frontend/cypress/README.md`, `docs/README.md`, and various `llm*.txt` files) to instruct users to use `npm ci` instead of `npm install` for installing dependencies. [[1]](diffhunk://#diff-227c2c26cb2ee0ce0f46a320fc48fbcbdf21801a57f59161b1d0861e8aad55f5L33-R33) [[2]](diffhunk://#diff-458433ec91dbc49ec20e7247de1d79632d05a389b41ca2733a95930f5331032dL168-R168) [[3]](diffhunk://#diff-f81150625175c3ce814ab60713e94a2dbe68585c085ae6c9ab13f17cdd48a619L136-R136) [[4]](diffhunk://#diff-41ceff046f4d0f4d04a6c9622c5c2243595651aaa0a2bfa66ebf9dda8b48b785L43-R43) [[5]](diffhunk://#diff-16b273a08eea1395c8d85902bb0089a32fb32d103c94f4d9e9d6d2d87831c034L146-R146) [[6]](diffhunk://#diff-16b273a08eea1395c8d85902bb0089a32fb32d103c94f4d9e9d6d2d87831c034L6334-R6334) [[7]](diffhunk://#diff-0b5ca119d2be595aa307d34512d9679e49186307ef94201e4b3dfa079aa89938L9-R9) [[8]](diffhunk://#diff-0b5ca119d2be595aa307d34512d9679e49186307ef94201e4b3dfa079aa89938L19-R19)

**Build script improvements:**

* Modified the `build_frontend.py` helper script to use `npm ci` instead of `npm install` for all build steps, ensuring clean and predictable installs in CI environments. [[1]](diffhunk://#diff-77e026a3e0abf12653d4f3403b87cc1f3421eb77ce33fc5a8e61ef2013ee3a18L67-R67) [[2]](diffhunk://#diff-77e026a3e0abf12653d4f3403b87cc1f3421eb77ce33fc5a8e61ef2013ee3a18L86-R86) [[3]](diffhunk://#diff-77e026a3e0abf12653d4f3403b87cc1f3421eb77ce33fc5a8e61ef2013ee3a18L107-R107)