### PR TITLE
DATAGO-119010: Try to load static files anyways in case enterprise is enabled

### DIFF
--- a/src/solace_agent_mesh/gateway/http_sse/main.py
+++ b/src/solace_agent_mesh/gateway/http_sse/main.py
@@ -674,7 +674,7 @@ def _setup_static_files() -> None:
         )
         log.info("Mounted static files directory '%s' at '/'", static_files_dir)
     except Exception as static_mount_err:
-        log.warning(
+        log.error(
             "Failed to mount static files directory '%s': %s",
             static_files_dir,
             static_mount_err,


### PR DESCRIPTION
## Summary

  Attempt to mount static files directory even when it doesn't exist for enterprise environments

## Changes

  - Modified static files mounting logic in src/solace_agent_mesh/gateway/http_sse/main.py to attempt mounting even when the directory is not found
  - Changed error logging from error to warning level for mount failures
  - This allows the application to continue attempting to serve static files in enterprise environments where the directory structure may differ

## Motivation

Allow enterprise to choose where it loads static files from, so that it can be run without a build. 