### PR TITLE
DATAGO-115023 - Consolidate OAuth 2.0 Client implementations all into one class

### DIFF
--- a/src/solace_agent_mesh/agent/adk/models/oauth2_token_manager.py
+++ b/src/solace_agent_mesh/agent/adk/models/oauth2_token_manager.py
@@ -6,12 +6,9 @@ It handles token acquisition, caching, and automatic refresh with proper error h
 
 import asyncio
 import logging
-import random
-import time
-from typing import Any, Dict, Optional
+from typing import Optional
 
-import httpx
-
+from solace_agent_mesh.common.oauth import OAuth2RetryClient, is_token_expired
 from solace_agent_mesh.common.utils.in_memory_cache import InMemoryCache
 
 logger = logging.getLogger(__name__)
@@ -72,17 +69,19 @@ class OAuth2ClientCredentialsTokenManager:
         self.scope = scope
         self.ca_cert_path = ca_cert_path
         self.refresh_buffer_seconds = refresh_buffer_seconds
-        self.max_retries = max_retries
-        
+
         # Thread-safe token access
         self._lock = asyncio.Lock()
-        
+
         # Token cache using existing InMemoryCache singleton
         self._cache = InMemoryCache()
-        
+
         # Cache key for this token manager instance
         self._cache_key = f"oauth_token_{hash((token_url, client_id))}"
-        
+
+        # OAuth client with retry logic
+        self._oauth_client = OAuth2RetryClient(max_retries=max_retries)
+
         logger.info(
             "OAuth2ClientCredentialsTokenManager initialized for endpoint: %s",
             token_url
@@ -104,14 +103,24 @@ class OAuth2ClientCredentialsTokenManager:
         async with self._lock:
             # Check if we have a cached token
             cached_token_data = self._cache.get(self._cache_key)
-            
-            if cached_token_data and not self._is_token_expired(cached_token_data):
+
+            if cached_token_data and not is_token_expired(
+                cached_token_data["expires_at"], buffer_seconds=self.refresh_buffer_seconds
+            ):
                 logger.debug("Using cached OAuth token")
                 return cached_token_data["access_token"]
-            
-            # Fetch new token
+
+            # Fetch new token using common OAuth client
             logger.info("Fetching new OAuth token from %s", self.token_url)
-            token_data = await self._fetch_token()
+            verify = self.ca_cert_path if self.ca_cert_path else True
+            token_data = await self._oauth_client.fetch_client_credentials_token(
+                token_url=self.token_url,
+                client_id=self.client_id,
+                client_secret=self.client_secret,
+                scope=self.scope,
+                verify=verify,
+                timeout=30.0,
+            )
             
             # Cache the token with TTL
             expires_in = token_data.get("expires_in", 3600)  # Default 1 hour
@@ -121,125 +130,3 @@ class OAuth2ClientCredentialsTokenManager:
             
             logger.info("OAuth token cached with TTL: %d seconds", cache_ttl)
             return token_data["access_token"]
-
-    def _is_token_expired(self, token_data: Dict[str, Any]) -> bool:
-        """Check if a token is expired or near expiry.
-        
-        Args:
-            token_data: Token data dictionary with 'expires_at' timestamp
-            
-        Returns:
-            True if token is expired or near expiry, False otherwise
-        """
-        if "expires_at" not in token_data:
-            return True
-            
-        current_time = time.time()
-        expires_at = token_data["expires_at"]
-        
-        # Consider token expired if it expires within the buffer time
-        return current_time >= (expires_at - self.refresh_buffer_seconds)
-
-    async def _fetch_token(self) -> Dict[str, Any]:
-        """Fetch a new OAuth 2.0 access token from the token endpoint.
-
-        Implements retry logic with exponential backoff for transient failures.
-
-        Returns:
-            Token data dictionary containing access_token, expires_in, etc.
-
-        Raises:
-            httpx.HTTPError: If HTTP request fails after all retries
-            ValueError: If response is invalid or missing required fields
-        """
-        # Prepare request payload
-        payload = {
-            "grant_type": "client_credentials",
-            "client_id": self.client_id,
-            "client_secret": self.client_secret,
-        }
-        
-        if self.scope:
-            payload["scope"] = self.scope
-        
-        # Configure HTTP client with SSL settings
-        verify = True
-        if self.ca_cert_path:
-            verify = self.ca_cert_path
-            
-        headers = {
-            "Content-Type": "application/x-www-form-urlencoded",
-            "Accept": "application/json",
-        }
-        
-        last_exception = None
-
-        for attempt in range(self.max_retries + 1):
-            try:
-                async with httpx.AsyncClient(verify=verify) as client:
-                    response = await client.post(
-                        self.token_url,
-                        data=payload,
-                        headers=headers,
-                        timeout=30.0,
-                    )
-                    response.raise_for_status()
-
-                    token_data = response.json()
-
-                    # Validate response
-                    if "access_token" not in token_data:
-                        raise ValueError("Token response missing 'access_token' field")
-
-                    # Add expiration timestamp for cache management
-                    expires_in = token_data.get("expires_in", 3600)
-                    token_data["expires_at"] = time.time() + expires_in
-
-                    logger.info("Successfully fetched OAuth token, expires in %d seconds", expires_in)
-                    return token_data
-
-            except httpx.HTTPStatusError as e:
-                last_exception = e
-                # Don't retry on 4xx errors (client errors)
-                if 400 <= e.response.status_code < 500:
-                    logger.error(
-                        "OAuth token request failed with client error %d: %s",
-                        e.response.status_code,
-                        e.response.text
-                    )
-                    raise
-
-                logger.warning(
-                    "OAuth token request failed with status %d (attempt %d/%d): %s",
-                    e.response.status_code,
-                    attempt + 1,
-                    self.max_retries + 1,
-                    e.response.text
-                )
-
-            except httpx.RequestError as e:
-                last_exception = e
-                logger.warning(
-                    "OAuth token request failed (attempt %d/%d): %s",
-                    attempt + 1,
-                    self.max_retries + 1,
-                    str(e)
-                )
-
-            except Exception as e:
-                last_exception = e
-                logger.error("Unexpected error during OAuth token fetch: %s", str(e))
-                raise
-
-            # Exponential backoff with jitter for retries
-            if attempt < self.max_retries:
-                delay = (2 ** attempt) + random.uniform(0, 1)
-                logger.info("Retrying OAuth token request in %.2f seconds", delay)
-                await asyncio.sleep(delay)
-
-        # All retries exhausted
-        logger.error("OAuth token request failed after %d attempts", self.max_retries + 1)
-        if last_exception:
-            raise last_exception
-        else:
-            raise RuntimeError("OAuth token request failed after all retries")

--- a/src/solace_agent_mesh/common/oauth/__init__.py
+++ b/src/solace_agent_mesh/common/oauth/__init__.py
@@ -1,0 +1,17 @@
+"""Common OAuth 2.0 components for Solace Agent Mesh.
+
+This module provides pure OAuth 2.0 protocol implementations that can be
+used across different components (LLM providers, A2A proxies, etc.) without
+domain-specific logic.
+"""
+
+from .oauth_client import OAuth2Client, OAuth2RetryClient
+from .utils import calculate_expires_at, is_token_expired, validate_https_url
+
+__all__ = [
+    "OAuth2Client",
+    "OAuth2RetryClient",
+    "calculate_expires_at",
+    "is_token_expired",
+    "validate_https_url",
+]

--- a/src/solace_agent_mesh/common/oauth/oauth_client.py
+++ b/src/solace_agent_mesh/common/oauth/oauth_client.py
@@ -1,0 +1,408 @@
+"""Pure OAuth 2.0 protocol implementation.
+
+This module provides stateless OAuth 2.0 flow implementations without any
+caching, retry logic, or domain-specific behavior. It implements the core
+OAuth 2.0 flows as defined in RFC 6749.
+"""
+
+import asyncio
+import logging
+import random
+from typing import Any, Dict, Optional, Union
+
+import httpx
+
+from .utils import calculate_expires_at
+
+logger = logging.getLogger(__name__)
+
+
+class OAuth2Client:
+    """Pure OAuth 2.0 protocol implementation.
+
+    This class provides stateless OAuth 2.0 flow implementations without any
+    caching, retry logic, or domain-specific behavior. Each method makes a
+    single HTTP request to the token endpoint and returns the parsed response.
+
+    All OAuth 2.0 flows follow RFC 6749 specification.
+    """
+
+    async def fetch_client_credentials_token(
+        self,
+        token_url: str,
+        client_id: str,
+        client_secret: str,
+        scope: Optional[str] = None,
+        verify: Union[bool, str] = True,
+        timeout: float = 30.0,
+    ) -> Dict[str, Any]:
+        """Execute OAuth 2.0 Client Credentials flow (RFC 6749 Section 4.4).
+
+        This flow is used for server-to-server authentication where the client
+        acts on its own behalf rather than on behalf of a user.
+
+        Args:
+            token_url: OAuth 2.0 token endpoint URL
+            client_id: OAuth 2.0 client identifier
+            client_secret: OAuth 2.0 client secret
+            scope: Optional space-separated list of scopes
+            verify: SSL certificate verification (True, False, or path to CA bundle)
+            timeout: Request timeout in seconds
+
+        Returns:
+            Token response dictionary containing:
+                - access_token: The access token string
+                - expires_in: Token lifetime in seconds
+                - token_type: Token type (usually "Bearer")
+                - scope: Granted scopes (optional)
+                - expires_at: Unix timestamp when token expires (added by this method)
+
+        Raises:
+            httpx.HTTPStatusError: If the token request fails
+            ValueError: If the response is missing required fields
+        """
+        payload = {
+            "grant_type": "client_credentials",
+            "client_id": client_id,
+            "client_secret": client_secret,
+        }
+
+        if scope:
+            payload["scope"] = scope
+
+        return await self._execute_token_request(
+            token_url=token_url,
+            payload=payload,
+            verify=verify,
+            timeout=timeout,
+        )
+
+    async def fetch_authorization_code_token(
+        self,
+        token_url: str,
+        client_id: str,
+        client_secret: str,
+        code: str,
+        redirect_uri: str,
+        verify: Union[bool, str] = True,
+        timeout: float = 30.0,
+    ) -> Dict[str, Any]:
+        """Execute OAuth 2.0 Authorization Code flow (RFC 6749 Section 4.1).
+
+        This flow is used for user-delegated authentication where the application
+        acts on behalf of a user who has granted permission.
+
+        Args:
+            token_url: OAuth 2.0 token endpoint URL
+            client_id: OAuth 2.0 client identifier
+            client_secret: OAuth 2.0 client secret
+            code: Authorization code received from authorization server
+            redirect_uri: Redirect URI used in authorization request (must match)
+            verify: SSL certificate verification (True, False, or path to CA bundle)
+            timeout: Request timeout in seconds
+
+        Returns:
+            Token response dictionary containing:
+                - access_token: The access token string
+                - expires_in: Token lifetime in seconds
+                - refresh_token: Refresh token for obtaining new access tokens (optional)
+                - token_type: Token type (usually "Bearer")
+                - scope: Granted scopes (optional)
+                - expires_at: Unix timestamp when token expires (added by this method)
+
+        Raises:
+            httpx.HTTPStatusError: If the token request fails
+            ValueError: If the response is missing required fields
+        """
+        payload = {
+            "grant_type": "authorization_code",
+            "code": code,
+            "redirect_uri": redirect_uri,
+            "client_id": client_id,
+            "client_secret": client_secret,
+        }
+
+        return await self._execute_token_request(
+            token_url=token_url,
+            payload=payload,
+            verify=verify,
+            timeout=timeout,
+        )
+
+    async def fetch_refresh_token(
+        self,
+        token_url: str,
+        client_id: str,
+        client_secret: str,
+        refresh_token: str,
+        scope: Optional[str] = None,
+        verify: Union[bool, str] = True,
+        timeout: float = 30.0,
+    ) -> Dict[str, Any]:
+        """Execute OAuth 2.0 Refresh Token flow (RFC 6749 Section 6).
+
+        This flow is used to obtain a new access token using a refresh token,
+        without requiring user interaction.
+
+        Args:
+            token_url: OAuth 2.0 token endpoint URL
+            client_id: OAuth 2.0 client identifier
+            client_secret: OAuth 2.0 client secret
+            refresh_token: The refresh token
+            scope: Optional space-separated list of scopes (must not exceed original grant)
+            verify: SSL certificate verification (True, False, or path to CA bundle)
+            timeout: Request timeout in seconds
+
+        Returns:
+            Token response dictionary containing:
+                - access_token: The new access token string
+                - expires_in: Token lifetime in seconds
+                - refresh_token: New refresh token (optional, may be same as input)
+                - token_type: Token type (usually "Bearer")
+                - scope: Granted scopes (optional)
+                - expires_at: Unix timestamp when token expires (added by this method)
+
+        Raises:
+            httpx.HTTPStatusError: If the token request fails
+            ValueError: If the response is missing required fields
+        """
+        payload = {
+            "grant_type": "refresh_token",
+            "refresh_token": refresh_token,
+            "client_id": client_id,
+            "client_secret": client_secret,
+        }
+
+        if scope:
+            payload["scope"] = scope
+
+        return await self._execute_token_request(
+            token_url=token_url,
+            payload=payload,
+            verify=verify,
+            timeout=timeout,
+        )
+
+    async def _execute_token_request(
+        self,
+        token_url: str,
+        payload: Dict[str, str],
+        verify: Union[bool, str],
+        timeout: float,
+    ) -> Dict[str, Any]:
+        """Execute a token request to the OAuth 2.0 token endpoint.
+
+        This is the core HTTP operation shared by all OAuth flows.
+
+        Args:
+            token_url: OAuth 2.0 token endpoint URL
+            payload: Request payload (grant-specific parameters)
+            verify: SSL certificate verification
+            timeout: Request timeout in seconds
+
+        Returns:
+            Token response dictionary with added expires_at field
+
+        Raises:
+            httpx.HTTPStatusError: If the token request fails
+            ValueError: If the response is missing required fields
+        """
+        headers = {
+            "Content-Type": "application/x-www-form-urlencoded",
+            "Accept": "application/json",
+        }
+
+        async with httpx.AsyncClient(verify=verify) as client:
+            response = await client.post(
+                token_url,
+                data=payload,
+                headers=headers,
+                timeout=timeout,
+            )
+            response.raise_for_status()
+
+            token_data = response.json()
+
+            # Validate response contains required fields
+            if "access_token" not in token_data:
+                raise ValueError(
+                    f"Token response missing 'access_token' field. "
+                    f"Response keys: {list(token_data.keys())}"
+                )
+
+            # Add expiration timestamp for convenience
+            expires_in = token_data.get("expires_in", 3600)  # Default 1 hour
+            token_data["expires_at"] = calculate_expires_at(expires_in)
+
+            return token_data
+
+
+class OAuth2RetryClient:
+    """OAuth 2.0 client with configurable retry logic.
+
+    This class wraps OAuth2Client and adds retry logic with exponential backoff
+    for handling transient failures. Retry behavior:
+    - 4xx errors (client errors): No retry - fail immediately
+    - 5xx errors (server errors): Retry with exponential backoff
+    - Network errors: Retry with exponential backoff
+    """
+
+    def __init__(
+        self,
+        max_retries: int = 0,
+        backoff_base: float = 2.0,
+        backoff_jitter: bool = True,
+    ):
+        """Initialize the retry client.
+
+        Args:
+            max_retries: Maximum number of retry attempts (0 = no retries)
+            backoff_base: Base for exponential backoff (delay = base^attempt)
+            backoff_jitter: Whether to add random jitter to backoff delay
+        """
+        self._base_client = OAuth2Client()
+        self._max_retries = max_retries
+        self._backoff_base = backoff_base
+        self._backoff_jitter = backoff_jitter
+
+    async def fetch_client_credentials_token(
+        self,
+        token_url: str,
+        client_id: str,
+        client_secret: str,
+        scope: Optional[str] = None,
+        verify: Union[bool, str] = True,
+        timeout: float = 30.0,
+    ) -> Dict[str, Any]:
+        """Execute Client Credentials flow with retry logic.
+
+        See OAuth2Client.fetch_client_credentials_token for parameter details.
+        """
+        return await self._execute_with_retry(
+            self._base_client.fetch_client_credentials_token,
+            token_url=token_url,
+            client_id=client_id,
+            client_secret=client_secret,
+            scope=scope,
+            verify=verify,
+            timeout=timeout,
+        )
+
+    async def fetch_authorization_code_token(
+        self,
+        token_url: str,
+        client_id: str,
+        client_secret: str,
+        code: str,
+        redirect_uri: str,
+        verify: Union[bool, str] = True,
+        timeout: float = 30.0,
+    ) -> Dict[str, Any]:
+        """Execute Authorization Code flow with retry logic.
+
+        See OAuth2Client.fetch_authorization_code_token for parameter details.
+        """
+        return await self._execute_with_retry(
+            self._base_client.fetch_authorization_code_token,
+            token_url=token_url,
+            client_id=client_id,
+            client_secret=client_secret,
+            code=code,
+            redirect_uri=redirect_uri,
+            verify=verify,
+            timeout=timeout,
+        )
+
+    async def fetch_refresh_token(
+        self,
+        token_url: str,
+        client_id: str,
+        client_secret: str,
+        refresh_token: str,
+        scope: Optional[str] = None,
+        verify: Union[bool, str] = True,
+        timeout: float = 30.0,
+    ) -> Dict[str, Any]:
+        """Execute Refresh Token flow with retry logic.
+
+        See OAuth2Client.fetch_refresh_token for parameter details.
+        """
+        return await self._execute_with_retry(
+            self._base_client.fetch_refresh_token,
+            token_url=token_url,
+            client_id=client_id,
+            client_secret=client_secret,
+            refresh_token=refresh_token,
+            scope=scope,
+            verify=verify,
+            timeout=timeout,
+        )
+
+    async def _execute_with_retry(self, func, **kwargs) -> Dict[str, Any]:
+        """Execute a function with retry logic.
+
+        Args:
+            func: Async function to execute
+            **kwargs: Arguments to pass to the function
+
+        Returns:
+            Result from the function
+
+        Raises:
+            Exception: Last exception if all retries are exhausted
+        """
+        last_exception = None
+
+        for attempt in range(self._max_retries + 1):
+            try:
+                return await func(**kwargs)
+
+            except httpx.HTTPStatusError as e:
+                last_exception = e
+                # Don't retry on 4xx errors (client errors)
+                if 400 <= e.response.status_code < 500:
+                    logger.error(
+                        "OAuth token request failed with client error %d: %s",
+                        e.response.status_code,
+                        e.response.text,
+                    )
+                    raise
+
+                logger.warning(
+                    "OAuth token request failed with status %d (attempt %d/%d): %s",
+                    e.response.status_code,
+                    attempt + 1,
+                    self._max_retries + 1,
+                    e.response.text,
+                )
+
+            except httpx.RequestError as e:
+                last_exception = e
+                logger.warning(
+                    "OAuth token request failed (attempt %d/%d): %s",
+                    attempt + 1,
+                    self._max_retries + 1,
+                    str(e),
+                )
+
+            except Exception as e:
+                last_exception = e
+                logger.error("Unexpected error during OAuth token fetch: %s", str(e))
+                raise
+
+            # Exponential backoff with optional jitter
+            if attempt < self._max_retries:
+                delay = self._backoff_base**attempt
+                if self._backoff_jitter:
+                    delay += random.uniform(0, 1)
+                logger.info("Retrying OAuth token request in %.2f seconds", delay)
+                await asyncio.sleep(delay)
+
+        # All retries exhausted
+        logger.error(
+            "OAuth token request failed after %d attempts", self._max_retries + 1
+        )
+        if last_exception:
+            raise last_exception
+        else:
+            raise RuntimeError("OAuth token request failed after all retries")

--- a/src/solace_agent_mesh/common/oauth/utils.py
+++ b/src/solace_agent_mesh/common/oauth/utils.py
@@ -1,0 +1,50 @@
+"""Utility functions for OAuth 2.0 operations."""
+
+import time
+from urllib.parse import urlparse
+
+
+def validate_https_url(url: str) -> None:
+    """Validate that a URL uses HTTPS scheme.
+
+    OAuth 2.0 requires HTTPS for security when transmitting credentials.
+
+    Args:
+        url: The URL to validate
+
+    Raises:
+        ValueError: If the URL does not use HTTPS scheme
+    """
+    parsed_url = urlparse(url)
+    if parsed_url.scheme != "https":
+        raise ValueError(
+            f"OAuth 2.0 URLs must use HTTPS for security. "
+            f"Got scheme: {parsed_url.scheme}"
+        )
+
+
+def calculate_expires_at(expires_in: int) -> float:
+    """Calculate expiration timestamp from expires_in seconds.
+
+    Args:
+        expires_in: Number of seconds until token expires
+
+    Returns:
+        Unix timestamp (float) when the token will expire
+    """
+    return time.time() + expires_in
+
+
+def is_token_expired(expires_at: float, buffer_seconds: int = 0) -> bool:
+    """Check if a token is expired or will expire within buffer time.
+
+    Args:
+        expires_at: Unix timestamp when token expires
+        buffer_seconds: Optional buffer to consider token expired early
+                       (useful for proactive refresh)
+
+    Returns:
+        True if token is expired or within buffer time of expiring
+    """
+    current_time = time.time()
+    return current_time >= (expires_at - buffer_seconds)

--- a/tests/unit/agent/sac/test_oauth_llm_integration.py
+++ b/tests/unit/agent/sac/test_oauth_llm_integration.py
@@ -102,7 +102,7 @@ class TestOAuthLLMIntegration:
         """Test that OAuth tokens are properly injected into LLM requests."""
         llm = LiteLlm(**oauth_config)
 
-        with patch("solace_agent_mesh.agent.adk.models.oauth2_token_manager.httpx.AsyncClient") as mock_oauth_client, \
+        with patch("solace_agent_mesh.common.oauth.oauth_client.httpx.AsyncClient") as mock_oauth_client, \
              patch.object(llm.llm_client, "acompletion") as mock_completion:
 
             # Mock OAuth token response
@@ -156,7 +156,7 @@ class TestOAuthLLMIntegration:
 
         llm = LiteLlm(**config)
 
-        with patch("solace_agent_mesh.agent.adk.models.oauth2_token_manager.httpx.AsyncClient") as mock_oauth_client, \
+        with patch("solace_agent_mesh.common.oauth.oauth_client.httpx.AsyncClient") as mock_oauth_client, \
              patch.object(llm.llm_client, "acompletion") as mock_completion:
 
             # Mock OAuth failure
@@ -196,7 +196,7 @@ class TestOAuthLLMIntegration:
         """Test that multiple LLM requests reuse cached OAuth tokens."""
         llm = LiteLlm(**oauth_config)
 
-        with patch("solace_agent_mesh.agent.adk.models.oauth2_token_manager.httpx.AsyncClient") as mock_oauth_client, \
+        with patch("solace_agent_mesh.common.oauth.oauth_client.httpx.AsyncClient") as mock_oauth_client, \
              patch.object(llm.llm_client, "acompletion") as mock_completion:
 
             # Mock OAuth token response
@@ -250,7 +250,7 @@ class TestOAuthLLMIntegration:
 
         llm = LiteLlm(**config)
 
-        with patch("solace_agent_mesh.agent.adk.models.oauth2_token_manager.httpx.AsyncClient") as mock_oauth_client:
+        with patch("solace_agent_mesh.common.oauth.oauth_client.httpx.AsyncClient") as mock_oauth_client:
             # Mock OAuth failure
             mock_oauth_client.return_value.__aenter__.return_value.post = AsyncMock(
                 side_effect=Exception("OAuth server unavailable")
@@ -288,7 +288,7 @@ class TestOAuthLLMIntegration:
         """Test thread safety with concurrent OAuth-authenticated LLM requests."""
         llm = LiteLlm(**oauth_config)
 
-        with patch("solace_agent_mesh.agent.adk.models.oauth2_token_manager.httpx.AsyncClient") as mock_oauth_client, \
+        with patch("solace_agent_mesh.common.oauth.oauth_client.httpx.AsyncClient") as mock_oauth_client, \
              patch.object(llm.llm_client, "acompletion") as mock_completion:
 
             # Mock OAuth token response


### PR DESCRIPTION
problem: 
  Three separate OAuth 2.0 client implementations exist in SAM:
  1. LLM Provider OAuth (oauth2_token_manager.py)
  2. A2A Proxy OAuth (component.py)
  3. User Allocated Access OAuth (enterprise package)

refactor:
 - each component above keeps domain specific logic which must stay separate, decision was to extract and reuse only common logic and avoid creating yet another uber-component with if/else branching for each separate case.

what stays:
  Each component kept its domain-specific logic:
  - LLM: Refresh buffer strategy (300s), retry count (3), cache key hashing, fallback to API key
  - A2A: No retries, agent-name caching, 401 handling with client invalidation, session-based cache keys
  - Enterprise: Authorization Code flow, multi-tenant storage, trust manager integration (unchanged - uses Google ADK)

