### PR TITLE
ci(DATAGO-119418): fix release job

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,7 +49,10 @@ jobs:
   # Release to PyPI using Trusted Publishing
   release:
     name: Release to PyPI
-    # Run if security checks passed OR if security checks were skipped
+    # We need always() here because when security-checks is skipped (via skip_security_checks input),
+    # GitHub Actions would by default skip ALL dependent jobs. The always() forces evaluation of our
+    # condition, allowing the release to proceed when security-checks was either successful OR skipped.
+    # This enables emergency releases when security checks need to be bypassed.
     needs: security-checks
     if: |
       always() && 


### PR DESCRIPTION
- Added always() to the release job's if condition to ensure it evaluates even when security-checks is skipped
- Updated condition to allow release when security-checks is either `success` OR `skipped`
- Updated AWS secrets to use MANIFEST_READ_ONLY_* credentials