### PR TITLE
feat (DATAGO-118799): docs for prompt caching

### DIFF
--- a/docs/docs/documentation/components/context-management/prompt-caching.md
+++ b/docs/docs/documentation/components/context-management/prompt-caching.md
@@ -1,0 +1,131 @@
+---
+title: Prompt Caching
+sidebar_position: 4
+---
+
+# Prompt Caching
+
+Prompt caching reduces latency and costs by storing frequently used prompt content at the LLM provider level. When you send requests with identical cached content, the provider can serve responses faster and often at reduced token charges.
+
+## How Prompt Caching Works
+
+LLM providers like Anthropic and OpenAI support caching mechanisms that store prompt prefixes for reuse across requests. Agent Mesh integrates with these mechanisms through the LiteLLM wrapper, which adds cache control headers to system instructions and tool definitions.
+
+When caching is enabled:
+
+1. The LiteLLM wrapper adds `cache_control` metadata to cacheable content
+2. The LLM provider stores the cached content for the configured duration
+3. Subsequent requests with identical cached content benefit from faster processing
+4. The provider may charge reduced rates for cached tokens
+
+## Configuring Cache Strategy
+
+You can configure the cache strategy at the model level using the `cache_strategy` parameter:
+
+```yaml
+# In shared_config.yaml or agent config
+llm_config:
+  model: claude-sonnet-4-5
+  api_base: ${LLM_SERVICE_ENDPOINT}
+  api_key: ${LLM_SERVICE_API_KEY}
+  cache_strategy: "5m"
+```
+
+### Available Strategies
+
+| Strategy | Description | Use Case |
+|----------|-------------|----------|
+| `"none"` | Caching disabled | When you need fresh processing for every request |
+| `"5m"` | 5-minute ephemeral cache (default) | Standard interactive sessions |
+| `"1h"` | 1-hour extended cache | Long-running sessions or batch processing |
+
+The default strategy is `"5m"`, which provides a balance between cache benefits and freshness for typical interactive use cases.
+
+## What Gets Cached
+
+Agent Mesh applies cache control to two types of content:
+
+### System Instructions
+
+System instructions define the agent's behavior and are typically identical across requests within a session. The cache control is applied to the entire system instruction block:
+
+```yaml
+# Example system instruction caching
+system_instruction: "You are a helpful assistant with access to tools."
+# With cache_strategy: "5m", this becomes:
+# {
+#   "type": "text",
+#   "text": "You are a helpful assistant...",
+#   "cache_control": {"type": "ephemeral"}
+# }
+```
+
+### Tool Definitions
+
+Tool definitions describe the available functions an agent can call. Because Agent Mesh sorts peer agents alphabetically, tool definitions remain stable across requests, making them good candidates for caching.
+
+Cache control is applied to the last tool in the list, which signals to the provider that all preceding tools should also be cached:
+
+```yaml
+# With multiple tools, cache_control is added to the last one
+tools:
+  - tool1  # No cache_control
+  - tool2  # No cache_control
+  - tool3  # cache_control: {"type": "ephemeral"}
+```
+
+## Provider Support
+
+Prompt caching support varies by LLM provider:
+
+| Provider | Caching Support | Notes |
+|----------|-----------------|-------|
+| Anthropic (Claude) | Full support | Native ephemeral caching with `cache_control` markers |
+| OpenAI | Automatic | Prompts over 1,024 tokens cached automatically |
+| Vertex AI (Gemini) | Full support | Supports `cache_control` markers like Anthropic |
+| Bedrock | Supported | LiteLLM translates cache markers for Bedrock-hosted models |
+
+LiteLLM handles the translation of cache control headers to provider-specific formats, so you can use the same configuration across different providers.
+
+## Best Practices
+
+### Stable System Instructions
+
+Design system instructions that remain constant across requests. Avoid including dynamic content like timestamps or session-specific data in the system instruction, as this prevents effective caching.
+
+### Consistent Tool Ordering
+
+Agent Mesh automatically sorts peer agents alphabetically to ensure consistent tool ordering. If you define custom tools, maintain a consistent order to maximize cache hits.
+
+### Appropriate Cache Duration
+
+Choose a cache strategy that matches your usage pattern:
+
+- Use `"5m"` for interactive sessions where users may switch contexts frequently
+- Use `"1h"` for batch processing or long-running automated tasks
+- Use `"none"` when you need to ensure fresh processing for every request
+
+## Troubleshooting
+
+### Cached Tokens Always Zero
+
+If cached tokens are always reported as zero:
+
+1. Verify that `cache_strategy` is not set to `"none"`
+2. Check that your LLM provider supports prompt caching
+3. Ensure your prompts meet the provider's minimum length requirements for caching
+
+### Cache Not Reducing Costs
+
+If you do not see cost reductions from caching:
+
+1. Verify that your provider charges reduced rates for cached tokens
+2. Check that requests are being made within the cache duration window
+3. Ensure system instructions and tools are identical across requests
+
+### Invalid Cache Strategy Warning
+
+If you see a warning about invalid cache strategy:
+
+1. Check that `cache_strategy` is set to one of: `"none"`, `"5m"`, or `"1h"`
+2. The system defaults to `"5m"` when an invalid strategy is specified

--- a/docs/docs/documentation/installing-and-configuring/token-usage-breakdown.md
+++ b/docs/docs/documentation/installing-and-configuring/token-usage-breakdown.md
@@ -1,0 +1,368 @@
+---
+title: Token Usage Breakdown
+sidebar_position: 345
+---
+
+# Token Usage Breakdown
+
+Understanding token usage in Agent Mesh helps you estimate costs and optimize your LLM configurations. This page provides a breakdown of what gets sent to the LLM on each request and explains how prompt caching can reduce costs.
+
+:::info Approximate Token Counts
+The token counts in this document are approximate estimates based on a typical Orchestrator Agent configuration. Actual token counts vary based on your specific configuration, the LLM provider's tokenizer, custom instructions, the number of peer agents discovered, and the tools enabled. You can run `python scripts/calculate_token_usage.py` to calculate token counts for your specific setup.
+:::
+
+## Components Sent to the LLM
+
+Each LLM request in Agent Mesh consists of several components that contribute to the total token count. The system instruction and tool definitions are cacheable, while conversation history and user messages are sent fresh with each request.
+
+### System Instruction
+
+The system instruction is the largest component and consists of multiple parts. The following table shows approximate token counts for a typical Orchestrator Agent configuration:
+
+| Component | Approximate Tokens | Description |
+|-----------|-------------------|-------------|
+| Base Agent Instruction | ~250-300 | Your custom agent instruction from YAML config |
+| Planning Instruction | ~500 | Parallel tool calling and response formatting rules |
+| Artifact Instructions | ~600-700 | Instructions for creating text-based artifacts |
+| Inline Template Instruction | ~400-450 | Liquid template syntax for data rendering |
+| Fenced Block Syntax Rules | ~400 | Syntax rules for artifact blocks |
+| Embed Instruction | ~1,100-1,200 | Dynamic embeds including math, datetime, and artifact_content |
+| Conversation Flow Instruction | ~400-450 | Response formatting and status update guidelines |
+| Examples Instruction | ~800-900 | Usage examples for artifacts and templates |
+| Peer Agent Instructions | ~50-100 per agent | Instructions for discovered peer agents |
+
+The total system instruction typically uses 4,000-5,000 tokens depending on your configuration.
+
+### Tool Definitions
+
+Tool definitions are converted to OpenAPI-style function declarations. The built-in tools consume approximately 500-600 tokens across 8 tools:
+
+| Tool | Approximate Tokens | Description |
+|------|-------------------|-------------|
+| `create_artifact` | ~120-130 | Creates a new artifact with content |
+| `list_artifacts` | ~40-50 | Lists all artifacts in session |
+| `load_artifact` | ~75-85 | Loads artifact content |
+| `signal_artifact_for_return` | ~80-90 | Signals artifact for user return |
+| `delete_artifact` | ~55-65 | Deletes an artifact |
+| `jq_query` | ~75-85 | Executes jq query on JSON |
+| `sql_query` | ~80-90 | Executes SQL on tabular data |
+| `get_current_time` | ~40-50 | Gets current date and time |
+
+Peer agent tools add approximately 80-130 tokens per agent depending on the agent's description and capabilities. With 3 peer agents, the tool definitions consume approximately 250-350 additional tokens.
+
+The total tool definitions typically use 800-1,000 tokens depending on the number of tools and peer agents.
+
+### Conversation History
+
+Conversation history grows with each turn and is not currently cached. The token usage varies based on message content:
+
+| Message Type | Typical Tokens | Notes |
+|--------------|---------------|-------|
+| User Message | 50-500 | Depends on user input length |
+| Assistant Response | 100-2,000 | Depends on response complexity |
+| Tool Call | 30-100 | Function name and arguments |
+| Tool Response | 50-5,000 | Depends on tool output size |
+
+### User Message
+
+The current user message is always sent fresh and cannot be cached because it is unique for each request.
+
+## Prompt Caching
+
+LLM prompt caching stores content that appears at the beginning of the prompt and remains identical across requests. Agent Mesh marks the system instruction and tool definitions for caching, which reduces costs on subsequent requests.
+
+The following table shows what gets cached in Agent Mesh:
+
+| Component | Cached | Reason |
+|-----------|--------|--------|
+| System Instruction | Yes | Marked with `cache_control` and stable across requests |
+| Tool Definitions | Yes | Last tool marked with `cache_control` and stable across requests |
+| Conversation History | No | Not currently marked for caching |
+| Current User Message | No | Always unique and cannot be cached |
+
+:::info Conversation History Caching
+The conversation history up to but not including the latest turn is identical to what was sent in the previous request. This means it could be cached using incremental cache breakpoints.
+
+Agent Mesh currently adds `cache_control` to the system instruction and the last tool, which caches approximately 5,000-6,000 tokens. LiteLLM supports automatic cache control injection via `cache_control_injection_points`. You could configure this in your LiteLLM config:
+
+```yaml
+# In litellm config.yaml
+model_list:
+  - model_name: claude-with-history-caching
+    litellm_params:
+      model: anthropic/claude-sonnet-4-5-20250929
+      cache_control_injection_points:
+        - location: message
+          role: system
+        - location: message
+          index: -2  # Second-to-last message (history prefix)
+```
+
+This configuration caches the conversation history prefix automatically. Anthropic allows a maximum of 4 cache breakpoints per request. For more information, see [LiteLLM Auto-Inject Prompt Caching documentation](https://docs.litellm.ai/docs/completion/prompt_caching#auto-inject-prompt-caching-checkpoints).
+:::
+
+### How Caching Works
+
+The LLM provider caches content from the start of the prompt. For Anthropic, content must be marked with `cache_control`, while OpenAI caches automatically when prompts exceed 1,024 tokens. The cache is invalidated if any content before a cache breakpoint changes. Multiple cache breakpoints can be used for incremental caching.
+
+Agent Mesh sends requests in this order: system instruction (cached), tool definitions (cached), conversation history (not cached), and user message (not cached).
+
+:::note Provider-Specific Behavior
+LiteLLM supports prompt caching for these providers using the OpenAI-compatible usage format:
+
+| Provider | Model Prefix | Caching Type | Notes |
+|----------|--------------|--------------|-------|
+| OpenAI | `openai/` | Automatic | Prompts over 1,024 tokens cached automatically |
+| Anthropic | `anthropic/` | Explicit | Requires `cache_control: {"type": "ephemeral"}` markers |
+| AWS Bedrock | `bedrock/`, `bedrock/converse/` | Explicit | All models Bedrock supports prompt caching on |
+| Vertex AI (Gemini) | `vertex_ai/` | Explicit | Supports `cache_control: {"type": "ephemeral"}` markers like Anthropic |
+
+:::
+
+## Token Usage Summary
+
+The following summary shows approximate token usage for a typical Orchestrator Agent:
+
+| Component | Approximate Tokens |
+|-----------|-------------------|
+| System Instruction (all components) | ~4,500 |
+| Built-in Tool Definitions (8 tools) | ~600 |
+| Peer Agent Tool Definitions (3 agents) | ~300 |
+| Total Cacheable | ~5,400 |
+
+Non-cacheable components vary based on usage:
+
+| Component | Typical Tokens |
+|-----------|---------------|
+| User Message | 50-500 |
+| Conversation History (per turn) | 100-2,000 |
+| Tool Responses | 50-5,000 |
+
+## Cost Estimation
+
+This section uses Claude Sonnet 4.5 pricing as of late 2025 for illustration. Input tokens cost $3 per million tokens ($0.003/1K), cached input tokens cost $0.30 per million tokens ($0.0003/1K) representing a 90% discount, and output tokens cost $15 per million tokens ($0.015/1K).
+
+### First Request
+
+On the first request, a cache miss occurs and the content is stored for future requests:
+
+| Component | Approximate Tokens | Rate | Approximate Cost |
+|-----------|-------------------|------|------------------|
+| System Instruction | ~4,500 | $0.003/1K | ~$0.014 |
+| Tool Definitions | ~900 | $0.003/1K | ~$0.003 |
+| User Message | ~100 | $0.003/1K | ~$0.000 |
+| Total Input | ~5,500 | — | ~$0.017 |
+| Output (typical response) | ~500 | $0.015/1K | ~$0.008 |
+| Total Cost | — | — | ~$0.025 |
+
+### Subsequent Requests
+
+On subsequent requests, cached content is served at the discounted rate:
+
+| Component | Approximate Tokens | Rate | Approximate Cost |
+|-----------|-------------------|------|------------------|
+| Cached Content (system + tools) | ~5,400 | $0.0003/1K | ~$0.002 |
+| Conversation History | ~500 | $0.003/1K | ~$0.002 |
+| User Message | ~100 | $0.003/1K | ~$0.000 |
+| Total Input | ~6,000 | — | ~$0.004 |
+| Output (typical response) | ~500 | $0.015/1K | ~$0.008 |
+| Total Cost | — | — | ~$0.012 |
+
+The savings compared to the first request is approximately 50-55%.
+
+### Cost Comparison
+
+| Scenario | Approximate Input Cost | Output Cost | Approximate Total | Savings |
+|----------|----------------------|-------------|-------------------|---------|
+| First request (cache miss) | ~$0.017 | ~$0.008 | ~$0.025 | — |
+| Subsequent request (cache hit) | ~$0.004 | ~$0.008 | ~$0.012 | ~50% |
+| 10 requests (1 miss + 9 hits) | ~$0.053 | ~$0.080 | ~$0.133 | ~45% vs no cache |
+
+:::tip Cost Optimization
+For high-frequency agents, prompt caching can reduce input token costs by up to 90% on cache hits. The system instruction and tool definitions (approximately 5,000-6,000 tokens representing 85-90% of base input) are cached, while only conversation history and user messages are charged at full rate. Pricing varies by provider and model, so check your provider's current pricing for accurate cost estimates.
+:::
+
+## Token Usage by Agent Type
+
+Different agent configurations have different token overhead. The following examples show typical usage patterns.
+
+An Orchestrator Agent with full features uses approximately 4,500 tokens for the system instruction and 900 tokens for tool definitions (8 built-in tools plus 3 peer agents), resulting in a base overhead of approximately 5,400 tokens per request.
+
+A specialized agent with minimal features uses approximately 2,000-2,500 tokens for the system instruction (with fewer instructions enabled) and 200-400 tokens for tool definitions (2-3 specific tools), resulting in a base overhead of approximately 2,500-3,000 tokens per request.
+
+An agent with MCP tools uses approximately 4,500 tokens for the system instruction and 1,500-3,000 tokens for tool definitions (MCP tools can be verbose), resulting in a base overhead of approximately 6,000-7,500 tokens per request.
+
+## Factors Affecting Token Usage
+
+Several configuration options affect token usage. The following options increase token consumption:
+
+| Configuration | Approximate Impact | Recommendation |
+|--------------|-------------------|----------------|
+| `enable_embed_resolution: true` | +800-1,000 tokens | Keep enabled for artifact support |
+| `enable_artifact_content_instruction: true` | +300-500 tokens | Disable if not using artifact_content embeds |
+| `agent_discovery: enabled: true` | +150-250 tokens per peer | Limit peer agents via allow_list |
+| Large custom instruction | Variable | Keep instructions concise |
+
+The following options reduce token consumption:
+
+| Configuration | Approximate Impact | Recommendation |
+|--------------|-------------------|----------------|
+| `enable_embed_resolution: false` | -800-1,000 tokens | Only if not using embeds |
+| `agent_discovery: enabled: false` | Removes peer overhead | For isolated agents |
+| Minimal tool configuration | -50-150 per tool | Only include needed tools |
+
+## Monitoring Token Usage
+
+Agent Mesh tracks token usage per task and reports it in the final task metadata:
+
+```json
+{
+  "token_usage": {
+    "total_tokens": 6150,
+    "total_input_tokens": 5650,
+    "total_output_tokens": 500,
+    "total_cached_input_tokens": 5600,
+    "llm_calls": 1
+  }
+}
+```
+
+Token usage is available in LLM response callbacks where each LLM call reports individual usage.
+
+## Optimizing Token Usage
+
+You can optimize token usage by configuring appropriate cache strategies based on usage patterns. Use `cache_strategy: "5m"` for high-frequency agents that make 10 or more calls per hour, `cache_strategy: "1h"` for burst patterns with 3-10 calls per hour, or `cache_strategy: "none"` for rarely-used agents with fewer than 2 calls per hour:
+
+```yaml
+model:
+  cache_strategy: "5m"  # For high-frequency agents (10+ calls/hour)
+  # cache_strategy: "1h"  # For burst patterns (3-10 calls/hour)
+  # cache_strategy: "none"  # For rarely-used agents (<2 calls/hour)
+```
+
+Keep custom instructions focused and concise. A good instruction is direct and specific:
+
+```yaml
+# Good: Focused instruction
+instruction: |
+  You are a data analysis agent. Analyze CSV and JSON files using the provided tools.
+  Save results as artifacts when requested.
+
+# Avoid: Verbose instruction with redundant information
+instruction: |
+  You are a helpful AI assistant that specializes in data analysis...
+  [500+ words of detailed instructions that duplicate system capabilities]
+```
+
+Use allow_list to control which peer agents are visible:
+
+```yaml
+inter_agent_communication:
+  allow_list: ["DataAgent", "ReportAgent"]  # Only specific agents
+  # allow_list: ["*"]  # All agents (higher token usage)
+```
+
+Only include tools the agent actually needs:
+
+```yaml
+tools:
+  - tool_type: builtin-group
+    group_name: "artifact_management"  # Include if agent creates files
+  # Avoid including unused tool groups
+```
+
+## Illustrative Example
+
+:::note Rough Illustration
+This example is for rough illustration purposes only. Actual token counts vary based on your specific configuration, the LLM provider's tokenizer, and the tools and agents available in your deployment.
+:::
+
+### Scenario: User asks "What is the weather in Toronto?"
+
+The following breakdown shows approximately what gets sent to the LLM for this simple question:
+
+```
+┌─────────────────────────────────────────────────────────────────────────────────┐
+│                         REQUEST TO LLM                                           │
+├─────────────────────────────────────────────────────────────────────────────────┤
+│                                                                                  │
+│  ┌─────────────────────────────────────────────────────────────────────────┐    │
+│  │ 1. SYSTEM INSTRUCTION (role: "developer")                   ~4,500 tokens │    │
+│  │    ┌─────────────────────────────────────────────────────────────────┐  │    │
+│  │    │ • Base Agent Instruction                          ~250 tokens   │  │    │
+│  │    │ • Planning Instruction                            ~500 tokens   │  │    │
+│  │    │ • Artifact Instructions                           ~650 tokens   │  │    │
+│  │    │ • Inline Template Instruction                     ~450 tokens   │  │    │
+│  │    │ • Fenced Block Syntax Rules                       ~400 tokens   │  │    │
+│  │    │ • Embed Instruction                             ~1,150 tokens   │  │    │
+│  │    │ • Conversation Flow Instruction                   ~450 tokens   │  │    │
+│  │    │ • Examples Instruction                            ~850 tokens   │  │    │
+│  │    │ • Peer Agent Instructions (varies by agents)      ~250 tokens   │  │    │
+│  │    └─────────────────────────────────────────────────────────────────┘  │    │
+│  │    [cache_control: {"type": "ephemeral"}]  ← CACHED                     │    │
+│  └─────────────────────────────────────────────────────────────────────────┘    │
+│                                                                                  │
+│  ┌─────────────────────────────────────────────────────────────────────────┐    │
+│  │ 2. TOOL DEFINITIONS                                        ~900 tokens │    │
+│  │    ┌─────────────────────────────────────────────────────────────────┐  │    │
+│  │    │ Built-in Tools (8):                                  ~600 tokens │  │    │
+│  │    │   • create_artifact, list_artifacts, load_artifact              │  │    │
+│  │    │   • signal_artifact_for_return, delete_artifact                 │  │    │
+│  │    │   • jq_query, sql_query, get_current_time                       │  │    │
+│  │    │                                                                 │  │    │
+│  │    │ Peer Agent Tools (varies):                           ~300 tokens │  │    │
+│  │    │   • peer_MarkitdownAgent, peer_WebAgent, peer_MermaidAgent      │  │    │
+│  │    └─────────────────────────────────────────────────────────────────┘  │    │
+│  │    [cache_control: {"type": "ephemeral"}] on last tool  ← CACHED        │    │
+│  └─────────────────────────────────────────────────────────────────────────┘    │
+│                                                                                  │
+│  ┌─────────────────────────────────────────────────────────────────────────┐    │
+│  │ 3. USER MESSAGE (role: "user")                               ~10 tokens │    │
+│  │    "What is the weather in Toronto?"                                    │    │
+│  │    [NOT CACHED - unique each request]                                   │    │
+│  └─────────────────────────────────────────────────────────────────────────┘    │
+│                                                                                  │
+├─────────────────────────────────────────────────────────────────────────────────┤
+│ TOTAL INPUT TOKENS:                                           ~5,400 tokens     │
+│   • Cached (system + tools):                                  ~5,400 tokens     │
+│   • Non-cached (user message):                                   ~10 tokens     │
+└─────────────────────────────────────────────────────────────────────────────────┘
+```
+
+### Cost Calculation
+
+Using Claude Sonnet 4.5 pricing as of late 2025:
+
+| Component | Approximate Tokens | Rate | Approximate Cost |
+|-----------|-------------------|------|------------------|
+| Cached input | ~5,400 | $0.30/1M | ~$0.0016 |
+| Non-cached input | ~10 | $3.00/1M | ~$0.00003 |
+| Output | ~150 | $15.00/1M | ~$0.0023 |
+| Total | — | — | ~$0.004 |
+
+Without caching, the same request would cost approximately $0.016 for input plus $0.002 for output, totaling approximately $0.018. The savings from caching is approximately 75-80%.
+
+### Multi-Turn Conversation Example
+
+As the conversation continues, history accumulates:
+
+Turn 1 with the question "What is the weather in Toronto?" uses approximately 5,400 input tokens (5,400 cached plus 10 new) and generates approximately 150 output tokens.
+
+Turn 2 with the question "What about tomorrow?" uses approximately 5,600 input tokens (5,400 cached plus 160 history plus 10 new) and generates approximately 120 output tokens.
+
+Turn 3 with the question "Should I bring an umbrella?" uses approximately 5,700 input tokens (5,400 cached plus 290 history plus 10 new) and generates approximately 80 output tokens.
+
+Currently, conversation history is not cached. Only the system instruction and tool definitions benefit from caching. This means the history portion is charged at full rate.
+
+### Provider-Specific Caching Behavior
+
+| Provider | Model Prefix | Caching Type | How It Works |
+|----------|--------------|--------------|--------------|
+| OpenAI | `openai/` | Automatic | Caches prompts over 1,024 tokens automatically with no markers needed |
+| Anthropic | `anthropic/` | Explicit | Requires `cache_control: {"type": "ephemeral"}` markers which Agent Mesh adds automatically; Anthropic charges for cache writes via `cache_creation_input_tokens` |
+| AWS Bedrock | `bedrock/`, `bedrock/converse/` | Explicit | LiteLLM translates cache markers for Bedrock-hosted Anthropic models |
+| Vertex AI (Gemini) | `vertex_ai/` | Explicit | Supports `cache_control: {"type": "ephemeral"}` markers like Anthropic; Agent Mesh cache markers work automatically |
+
+## Related Documentation
+
+For more information about LLM provider configuration and prompt caching, see [Configuring LLMs](./large_language_models.md). For agent-specific settings, see [Agent Configuration](./agent-configuration.md). For overall configuration structure, see [Configurations](./configurations.md).

--- a/scripts/calculate_token_usage.py
+++ b/scripts/calculate_token_usage.py
@@ -1,0 +1,698 @@
+#!/usr/bin/env python3
+"""
+Script to calculate actual token counts for Agent Mesh system prompts.
+Uses tiktoken for accurate token counting with Claude/GPT tokenizers.
+
+Usage:
+    python scripts/calculate_token_usage.py
+"""
+
+import sys
+import os
+
+# Add the src directory to the path
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', 'src'))
+
+try:
+    import tiktoken
+except ImportError:
+    print("Installing tiktoken...")
+    import subprocess
+    subprocess.check_call([sys.executable, "-m", "pip", "install", "tiktoken"])
+    import tiktoken
+
+
+def count_tokens(text: str, model: str = "cl100k_base") -> int:
+    """Count tokens using tiktoken encoder.
+    
+    cl100k_base is used by:
+    - GPT-4, GPT-4-turbo, GPT-4o
+    - GPT-3.5-turbo
+    - Claude models (approximate)
+    """
+    try:
+        encoding = tiktoken.get_encoding(model)
+        return len(encoding.encode(text))
+    except Exception as e:
+        print(f"Error counting tokens: {e}")
+        # Fallback: rough estimate of 4 chars per token
+        return len(text) // 4
+
+
+def generate_planning_instruction() -> str:
+    """Generate the planning instruction text."""
+    return """\
+Parallel Tool Calling:
+The system is capable of calling multiple tools in parallel to speed up processing. Please try to run tools in parallel when they don't depend on each other. This saves money and time, providing faster results to the user.
+
+**Response Formatting - CRITICAL**:
+In most cases when calling tools, you should produce NO visible text at all - only status_update embeds and the tool calls themselves.
+The user can see your tool calls and status updates, so narrating your actions is redundant and creates noise.
+
+If you do include visible text:
+- It must contain actual results, insights, or answers - NOT process narration
+- Do NOT end with a colon (":") before tool calls, as this leaves it hanging
+- Prefer ending with a period (".") if you must include visible text
+
+Examples:
+ - BEST: "{{status_update:Searching database...}}" [then calls tool, NO visible text]
+ - BAD: "Let me search for that information." [then calls tool]
+ - BAD: "Searching for information..." [then calls tool]
+
+Embeds in responses from agents:
+To be efficient, peer agents may respond with artifact_content in their responses. These will not be resolved until they are sent back to a gateway. If it makes
+sense, just carry that embed forward to your response to the user. For example, if you ask for an org chart from another agent and its response contains an embed like
+`{{artifact_content:org_chart.md}}`, you can just include that embed in your response to the user. The gateway will resolve it and display the org chart.
+
+Similarly, template_liquid blocks in peer agent responses can be carried forward to your response to the user for resolution by the gateway.
+
+When faced with a complex goal or request that involves multiple steps, data retrieval, or artifact summarization to produce a new report or document, you MUST first create a plan.
+Simple, direct requests like 'create an image of a dog' or 'write an email to thank my boss' do not require a plan.
+
+If a plan is created:
+1. It should be a terse, hierarchical list describing the steps needed, with each checkbox item on its own line.
+2. Use '⬜' for pending items, '✅' for completed items, and '❌' for cancelled items.
+3. If the plan changes significantly during execution, restate the updated plan.
+4. As items are completed, update the plan to check them off.
+
+"""
+
+
+def generate_fenced_artifact_instruction() -> str:
+    """Generate the fenced artifact instruction text."""
+    open_delim = "«««"
+    return f"""\
+**Creating Text-Based Artifacts (`{open_delim}save_artifact: ...`):**
+
+When to Create Artifacts:
+Create an artifact when the content provides value as a standalone file, such as:
+- Content with special formatting (HTML, Markdown, CSS).
+- Documents intended for use outside the conversation (reports, emails).
+- Structured reference content (schedules, guides, templates).
+- Substantial text documents or technical documentation.
+
+When NOT to Create Artifacts:
+- Simple answers, explanations, or conversational responses.
+- Brief advice, opinions, or short lists.
+
+Behavior of Created Artifacts:
+- They are sent to the user as an interactive file component.
+- The user can see the content, so there is no need to return or embed it again.
+
+Parameters for `{open_delim}save_artifact: ...`:
+- `filename="your_filename.ext"` (REQUIRED)
+- `mime_type="text/plain"` (optional, defaults to text/plain)
+- `description="A brief description."` (optional)
+
+The system will automatically save the content and confirm it in the next turn.
+"""
+
+
+def generate_inline_template_instruction() -> str:
+    """Generate the inline template instruction text."""
+    open_delim = "«««"
+    close_delim = "»»»"
+    return f"""\
+**Inline Liquid Templates (`{open_delim}template_liquid: ...`):**
+
+Use inline Liquid templates to dynamically render data from artifacts for user-friendly display. This is faster and more accurate than reading the artifact and reformatting it yourself.
+
+IMPORTANT: Template Format
+- Templates use Liquid template syntax (same as Shopify templates - NOTE that Jekyll extensions are NOT supported).
+
+When to Use Inline Templates:
+- Formatting CSV, JSON, or YAML data into tables or lists.
+- Applying simple transformations (filtering, limiting rows).
+
+Parameters for `{open_delim}template_liquid: ...`:
+- `data="filename.ext"` (REQUIRED): The data artifact to render. Can include version: `data="file.csv:2"`.
+- `jsonpath="$.expression"` (optional): JSONPath to extract a subset of JSON/YAML data.
+- `limit="N"` (optional): Limit to the first N rows (CSV) or items (JSON/YAML arrays).
+
+Data Context for Liquid Templates:
+- CSV data: Available as `headers` (array of column names) and `data_rows` (array of row arrays).
+- JSON/YAML arrays: Available as `items`.
+- JSON/YAML objects: Keys are directly available (e.g., `name`, `email`).
+
+Example - CSV Table:
+{open_delim}template_liquid: data="sales_data.csv" limit="5"
+| {{% for h in headers %}}{{{{ h }}}} | {{% endfor %}}
+|{{% for h in headers %}}---|{{% endfor %}}
+{{% for row in data_rows %}}| {{% for cell in row %}}{{{{ cell }}}} | {{% endfor %}}{{% endfor %}}
+{close_delim}
+
+Negative Examples
+Use {{{{ issues.size }}}} instead of {{{{ issues|length }}}}
+Use {{{{ forloop.index }}}} instead of {{{{ loop.index }}}} (Liquid uses forloop not loop)
+Use {{{{ issue.fields.description | truncate: 200 }}}} instead of slicing with [:200]
+Do not use Jekyll-specific tags or filters (e.g., `{{% assign %}}`, `{{% capture %}}`, `where`, `sort`, `where_exp`, etc.)
+
+The rendered output will appear inline in your response automatically.
+"""
+
+
+def generate_fenced_block_syntax_rules() -> str:
+    """Generate the fenced block syntax rules."""
+    open_delim = "«««"
+    close_delim = "»»»"
+    return f"""
+**Fenced Block Syntax Rules (Applies to `save_artifact` and `template_liquid`):**
+To create content blocks, you MUST use the EXACT syntax shown below.
+
+**EXACT SYNTAX (copy this pattern exactly):**
+{open_delim}keyword: parameter="value" ...
+The content for the block goes here.
+It can span multiple lines.
+{close_delim}
+
+**CRITICAL FORMATTING RULES:**
+  1. The opening delimiter MUST be EXACTLY `{open_delim}`.
+  2. Immediately after the delimiter, write the keyword (`save_artifact` or `template_liquid`) followed by a colon, with NO space before the colon (e.g., `{open_delim}save_artifact:`).
+  3. All parameters (like `filename`, `data`, `mime_type`) must be on the SAME line as the opening delimiter.
+  4. All parameter values **MUST** be enclosed in double quotes (e.g., `filename="example.txt"`).
+  5. You **MUST NOT** use double quotes `"` inside parameter values. Use single quotes or rephrase instead.
+  6. The block's content begins on the line immediately following the parameters.
+  7. Close the block with EXACTLY `{close_delim}` (three angle brackets) on its own line.
+  8. Do NOT surround the block with triple backticks (```). The `{open_delim}` and `{close_delim}` delimiters are sufficient.
+
+**COMMON ERRORS TO AVOID:**
+  ❌ WRONG: `{open_delim[0:1]}template_liquid:` (only 1 angle brackets)
+  ❌ WRONG: `{open_delim[0:2]}save_artifact:` (only 2 angle brackets)
+  ❌ WRONG: `{open_delim}save_artifact` (missing colon)
+  ✅ CORRECT: `{open_delim}save_artifact: filename="test.txt" mime_type="text/plain"`
+"""
+
+
+def generate_embed_instruction(include_artifact_content: bool = True) -> str:
+    """Generate the embed instruction text."""
+    open_delim = "{{"
+    close_delim = "}}"
+    chain_delim = ">>>"
+    
+    base_instruction = f"""\
+**Using Dynamic Embeds in Responses:**
+
+You can use dynamic embeds in your text responses and tool parameters using the syntax {open_delim}type:expression {chain_delim} format{close_delim}. NOTE that this differs from 'save_artifact', which has  different delimiters. This allows you to
+always have correct information in your output. Specifically, make sure you always use embeds for math, even if it is simple. You will make mistakes if you try to do math yourself.
+Use HTML entities to escape the delimiters.
+This host resolves the following embed types *early* (before sending to the LLM or tool): `math`, `datetime`, `uuid`, `artifact_meta`. This means the embed is replaced with its resolved value.
+- `{open_delim}math:expression | .2f{close_delim}`: Evaluates the math expression using asteval - this must just be plain math (plus random(), randint() and uniform()), don't import anything. Optional format specifier follows Python's format(). Use this for all math calculations rather than doing it yourself. Don't give approximations.
+- `{open_delim}datetime:format_or_keyword{close_delim}`: Inserts current date/time. Use Python strftime format (e.g., `%Y-%m-%d`) or keywords (`iso`, `timestamp`, `date`, `time`, `now`).
+- `{open_delim}uuid:{close_delim}`: Inserts a random UUID.
+- `{open_delim}artifact_meta:filename[:version]{close_delim}`: Inserts a summary of the artifact's metadata (latest version if unspecified).
+- `{open_delim}status_update:Your message here{close_delim}`: Generates an immediate, distinct status message event that is displayed to the user (e.g., 'Thinking...', 'Searching database...'). This message appears in a status area, not as part of the main chat conversation. Use this to provide interim feedback during processing.
+
+Examples:
+- `{open_delim}status_update:Analyzing data...{close_delim}` (Shows 'Analyzing data...' as a status update)
+- `The result of 23.5 * 4.2 is {open_delim}math:23.5 * 4.2 | .2f{close_delim}` (Embeds calculated result with 2 decimal places)
+
+The following embeds are resolved *late* (by the gateway before final display):
+- `{open_delim}artifact_return:filename[:version]{close_delim}`: This is the primary way to return an artifact to the user. It attaches the specified artifact to the message. The embed itself is removed from the text. Use this instead of describing a file and expecting the user to download it. Note: artifact_return is not necessary if the artifact was just created by you in this same response, since newly created artifacts are automatically attached to your message.
+"""
+
+    artifact_content_instruction = f"""
+- `{open_delim}artifact_content:filename[:version] {chain_delim} modifier1:value1 {chain_delim} ... {chain_delim} format:output_format{close_delim}`: Embeds artifact content after applying a chain of modifiers. This is resolved *late* (typically by a gateway before final display).
+    - If this embed resolves to binary content (like an image), it will be automatically converted into an attached file, similar to `artifact_return`.
+    - Use `{chain_delim}` to separate the artifact identifier from the modifier steps and the final format step.
+    - Available modifiers: `jsonpath`, `grep`, `head`, `tail`, `slice_lines`, `select_fields`, `sort_by`, `filter_by`, `unique`, `count`, `sum`, `avg`, `min`, `max`.
+    - The `format:output_format` step *must* be the last step in the chain. Supported formats include `text`, `datauri`, `json`, `json_pretty`, `csv`. Formatting as datauri, will include the data URI prefix, so do not add it yourself.
+    - Use `artifact_meta` first to check size; embedding large files may fail.
+    - Efficient workflows for large artifacts:
+        - To extract specific line ranges: `load_artifact(filename, version, include_line_numbers=True)` to identify lines, then use `slice_lines:start:end` modifier to extract that range.
+        - To fill templates with many placeholders: use `artifact_search_and_replace_regex` with `replacements` array (single atomic operation instead of multiple calls).
+        - Line numbers are display-only; `slice_lines` always operates on original content.
+    - Examples:
+        - `<img src="{open_delim}artifact_content:image.png {chain_delim} format:datauri{close_delim}`"> (Embed image as data URI - NOTE that this includes the datauri prefix. Do not add it yourself.)
+        - `{open_delim}artifact_content:data.json {chain_delim} jsonpath:$.items[*] {chain_delim} select_fields:name,status {chain_delim} format:json_pretty{close_delim}` (Extract and format JSON fields)
+        - `{open_delim}artifact_content:logs.txt {chain_delim} grep:ERROR {chain_delim} head:10 {chain_delim} format:text{close_delim}` (Get first 10 error lines)
+        - `{open_delim}artifact_content:config.json {chain_delim} jsonpath:$.userPreferences.theme {chain_delim} format:text{close_delim}` (Extract a single value from a JSON artifact)
+        - `{open_delim}artifact_content:server.log {chain_delim} tail:100 {chain_delim} grep:WARN {chain_delim} format:text{close_delim}` (Get warning lines from the last 100 lines of a log file)
+        - `{open_delim}artifact_content:template.html {chain_delim} slice_lines:10:50 {chain_delim} format:text{close_delim}` (Extract lines 10-50 from a large file)
+        - `<img src="{open_delim}artifact_content:diagram.png {chain_delim} format:datauri{close_delim}`"> (Embed an PNG diagram as a data URI)`
+"""
+
+    final_instruction = base_instruction
+    if include_artifact_content:
+        final_instruction += artifact_content_instruction
+
+    final_instruction += f"""
+Ensure the syntax is exactly `{open_delim}type:expression{close_delim}` or `{open_delim}type:expression {chain_delim} ... {chain_delim} format:output_format{close_delim}` with no extra spaces around delimiters (`{open_delim}`, `{close_delim}`, `{chain_delim}`, `:`, `|`). Malformed directives will be ignored."""
+
+    return final_instruction
+
+
+def generate_conversation_flow_instruction() -> str:
+    """Generate the conversation flow instruction text."""
+    open_delim = "{{"
+    close_delim = "}}"
+    return f"""\
+**Conversation Flow and Response Formatting:**
+
+**CRITICAL: Minimize Narration - Maximize Results**
+
+You do NOT need to produce visible text on every turn. Many turns should contain ONLY status updates and tool calls, with NO visible text at all.
+Only produce visible text when you have actual results, answers, or insights to share with the user.
+
+Response Content Rules:
+1. Visible responses should contain ONLY:
+   - Direct answers to the user's question
+   - Analysis and insights derived from tool results
+   - Final results and data
+   - Follow-up questions when needed
+   - Plans for complex multi-step tasks
+
+2. DO NOT include visible text for:
+   - Process narration ("Let me...", "I'll...", "Now I will...")
+   - Acknowledgments of tool calls ("I'm calling...", "Searching...")
+   - Descriptions of what you're about to do
+   - Play-by-play commentary on your actions
+   - Transitional phrases between tool calls
+
+3. Use invisible status_update embeds for ALL process updates:
+   - "Searching for..."
+   - "Analyzing..."
+   - "Creating..."
+   - "Querying..."
+   - "Calling agent X..."
+
+4. NEVER mix process narration with status updates - if you use a status_update embed, do NOT repeat that information in visible text.
+
+Examples:
+
+**Excellent (no visible text, just status and tools):**
+"{open_delim}status_update:Retrieving sales data...{close_delim}" [then calls tool, no visible text]
+
+**Good (visible text only contains results):**
+"{open_delim}status_update:Analyzing Q4 sales...{close_delim}" [calls tool]
+"Sales increased 23% in Q4, driven primarily by enterprise accounts."
+
+**Bad (unnecessary narration):**
+"Let me retrieve the sales data for you." [then calls tool]
+
+**Bad (narration mixed with results):**
+"I've analyzed the data and found that sales increased 23% in Q4."
+
+**Bad (play-by-play commentary):**
+"Now I'll search for the information. After that I'll analyze it."
+
+Remember: The user can see status updates and tool calls. You don't need to announce them in visible text.
+"""
+
+
+def generate_examples_instruction() -> str:
+    """Generate the examples instruction text."""
+    open_delim = "«««"
+    close_delim = "»»»"
+    embed_open_delim = "{{"
+    embed_close_delim = "}}"
+
+    return f"""\
+    Example 1:
+    - User: "Create a markdown file with your two csv files as tables."
+    <note>There are two csv files already uploaded: data1.csv and data2.csv</note>
+    - OrchestratorAgent:
+    {embed_open_delim}status_update:Creating Markdown tables from CSV files...{embed_close_delim}
+    {open_delim}save_artifact: filename="data_tables.md" mime_type="text/markdown" description="Markdown tables from CSV files"
+    # Data Tables
+    ## Data 1
+    {open_delim}template_liquid: data="data1.csv"
+    | {{% for h in headers %}}{{{{ h }}}} | {{% endfor %}}
+    |{{% for h in headers %}}---|{{% endfor %}}
+    {{% for row in data_rows %}}| {{% for cell in row %}}{{{{ cell }}}} | {{% endfor %}}{{% endfor %}}
+    {close_delim}
+    ## Data 2
+    {open_delim}template_liquid: data="data2.csv"
+    | {{% for h in headers %}}{{{{ h }}}} | {{% endfor %}}
+    |{{% for h in headers %}}---|{{% endfor %}}
+    {{% for row in data_rows %}}| {{% for cell in row %}}{{{{ cell }}}} | {{% endfor %}}{{% endfor %}}
+    {close_delim}
+    {close_delim}
+    Example 2:
+    - User: "Create a text file with the result of sqrt(12345) + sqrt(67890) + sqrt(13579) + sqrt(24680)."
+    - OrchestratorAgent:
+    {embed_open_delim}status_update:Calculating and creating text file...{embed_close_delim}
+    {open_delim}save_artifact: filename="math.txt" mime_type="text/plain" description="Result of sqrt(12345) + sqrt(67890) + sqrt(13579) + sqrt(24680)"
+    result = {embed_open_delim}math: sqrt(12345) + sqrt(67890) + sqrt(13579) + sqrt(24680) | .2f{embed_close_delim}
+    {close_delim}
+    
+    Example 3:
+    - User: "Show me the first 10 entries from data1.csv"
+    - OrchestratorAgent:
+    {embed_open_delim}status_update:Loading CSV data...{embed_close_delim}
+    {open_delim}template_liquid: data="data1.csv" limit="10"
+    | {{% for h in headers %}}{{{{ h }}}} | {{% endfor %}}
+    |{{% for h in headers %}}---|{{% endfor %}}
+    {{% for row in data_rows %}}| {{% for cell in row %}}{{{{ cell }}}} | {{% endfor %}}{{% endfor %}}
+    {close_delim}
+
+    Example 4:
+    - User: "Search the database for all orders from last month"
+    - OrchestratorAgent:
+    {embed_open_delim}status_update:Querying order database...{embed_close_delim}
+    [calls search_database tool with no visible text]
+    [After getting results:]
+    Found 247 orders from last month totaling $45,231.
+
+    Example 5:
+    - User: "Create an HTML with the chart image you just generated with the customer data."
+    - OrchestratorAgent:
+    {embed_open_delim}status_update:Generating HTML report with chart...{embed_close_delim}
+    {open_delim}save_artifact: filename="customer_analysis.html" mime_type="text/html" description="Interactive customer analysis dashboard"
+    <!DOCTYPE html>
+    <html>
+    <head>
+        <title>Customer Chart - {embed_open_delim}datetime:%Y-%m-%d{embed_close_delim}</title>
+        <style>
+            body {{ font-family: Arial, sans-serif; margin: 20px; }}
+            .metric {{ background: #f0f0f0; padding: 10px; margin: 10px 0; }}
+            img {{ max-width: 100%; height: auto; }}
+        </style>
+        </head>
+    <body>
+    <h1>Customer Analysis Report</h1>
+    <p>Generated: {embed_open_delim}datetime:iso{embed_close_delim}</p>
+        
+    <h2>Customer Distribution Chart</h2>
+    <img src="{embed_open_delim}artifact_content:customer_chart.png >>> format:datauri{embed_close_delim}" alt="Customer Distribution">
+    
+    </body>
+    </html>
+    {close_delim}
+
+    """
+
+
+def generate_orchestrator_base_instruction() -> str:
+    """Generate a typical orchestrator base instruction."""
+    return """You are the Orchestrator Agent within an AI agentic system. Your primary responsibilities are to:
+1. Process tasks received from external sources via the system Gateway.
+2. Analyze each task to determine the optimal execution strategy:
+   a. Single Agent Delegation: If the task can be fully addressed by a single peer agent (based on their declared capabilities/description), delegate the task to that agent.
+   b. Multi-Agent Coordination: If task completion requires a coordinated effort from multiple peer agents: first, devise a logical execution plan (detailing the sequence of agent invocations and any necessary data handoffs). Then, manage the execution of this plan, invoking each agent in the defined order.
+   c. Direct Execution: If the task is not suitable for delegation (neither to a single agent nor a multi-agent sequence) and falls within your own capabilities, execute the task yourself.
+
+Artifact Management Guidelines:
+- If an artifact was created during the task (either by yourself or a delegated agent), you must use the `list_artifacts` tool to get the details of the created artifacts.
+- You must then review the list of artifacts and return the ones that are important for the user by using the `signal_artifact_for_return` tool.
+- Provide regular progress updates using `status_update` embed directives, especially before initiating any tool call.
+"""
+
+
+def generate_peer_agent_instruction(agents: list) -> str:
+    """Generate peer agent instruction text."""
+    if not agents:
+        return ""
+    
+    peer_descriptions = []
+    for agent in agents:
+        name = agent["name"]
+        description = agent.get("description", "No description available.")
+        skills = agent.get("skills", [])
+        
+        skill_text = ""
+        if skills:
+            skill_items = [f"  - {s['name']}: {s['description']}" for s in skills]
+            skill_text = "\n" + "\n".join(skill_items)
+        
+        peer_descriptions.append(f"""
+### `peer_{name}`
+{description}{skill_text}""")
+    
+    peer_list_str = "\n".join(peer_descriptions)
+    
+    return f"""## Peer Agent Delegation
+
+You can delegate tasks to other specialized agents if they are better suited.
+
+**How to delegate:**
+- Use the `peer_<agent_name>(task_description: str)` tool for delegation
+- Replace `<agent_name>` with the actual name of the target agent
+- Provide a clear and detailed `task_description` for the peer agent
+- **Important:** The peer agent does not have access to your session history, so you must provide all required context necessary to fulfill the request
+
+## Available Peer Agents
+{peer_list_str}
+"""
+
+
+def generate_tool_definition(name: str, description: str, parameters: dict) -> str:
+    """Generate a tool definition in OpenAPI format (as JSON string)."""
+    import json
+    tool_def = {
+        "type": "function",
+        "function": {
+            "name": name,
+            "description": description,
+            "parameters": {
+                "type": "object",
+                "properties": parameters
+            }
+        }
+    }
+    return json.dumps(tool_def)
+
+
+def main():
+    print("=" * 80)
+    print("AGENT MESH TOKEN USAGE ANALYSIS")
+    print("Using tiktoken (cl100k_base encoding - GPT-4/Claude compatible)")
+    print("=" * 80)
+    print()
+    
+    # Track all components
+    components = {}
+    
+    # 1. Base Agent Instruction
+    base_instruction = generate_orchestrator_base_instruction()
+    components["Base Agent Instruction"] = base_instruction
+    
+    # 2. Planning Instruction
+    planning_instruction = generate_planning_instruction()
+    components["Planning Instruction"] = planning_instruction
+    
+    # 3. Fenced Artifact Instruction
+    fenced_artifact = generate_fenced_artifact_instruction()
+    components["Fenced Artifact Instruction"] = fenced_artifact
+    
+    # 4. Inline Template Instruction
+    inline_template = generate_inline_template_instruction()
+    components["Inline Template Instruction"] = inline_template
+    
+    # 5. Fenced Block Syntax Rules
+    syntax_rules = generate_fenced_block_syntax_rules()
+    components["Fenced Block Syntax Rules"] = syntax_rules
+    
+    # 6. Embed Instruction (with artifact_content)
+    embed_instruction = generate_embed_instruction(include_artifact_content=True)
+    components["Embed Instruction (full)"] = embed_instruction
+    
+    # 7. Conversation Flow Instruction
+    conversation_flow = generate_conversation_flow_instruction()
+    components["Conversation Flow Instruction"] = conversation_flow
+    
+    # 8. Examples Instruction
+    examples = generate_examples_instruction()
+    components["Examples Instruction"] = examples
+    
+    # 9. Peer Agent Instructions (example with 3 agents)
+    sample_agents = [
+        {
+            "name": "MarkitdownAgent",
+            "description": "An agent that converts various file types (like PDF, DOCX, XLSX, HTML, CSV, PPTX, ZIP) to Markdown format.",
+            "skills": [
+                {"name": "Document Conversion", "description": "Converts various file formats into clean, readable Markdown format."},
+                {"name": "Content Extraction", "description": "Analyzes and extracts specific information from documents."}
+            ]
+        },
+        {
+            "name": "WebAgent",
+            "description": "An agent that fetches content from web URLs.",
+            "skills": [
+                {"name": "Web Request", "description": "Fetches and processes content from web URLs."}
+            ]
+        },
+        {
+            "name": "MermaidAgent",
+            "description": "An agent that generates PNG images from Mermaid diagram syntax using a Python tool.",
+            "skills": [
+                {"name": "Mermaid Diagram Generator", "description": "Converts Mermaid syntax into visual PNG diagrams."}
+            ]
+        }
+    ]
+    peer_instruction = generate_peer_agent_instruction(sample_agents)
+    components["Peer Agent Instructions (3 agents)"] = peer_instruction
+    
+    # Print individual component analysis
+    print("SYSTEM INSTRUCTION COMPONENTS")
+    print("-" * 80)
+    
+    total_chars = 0
+    total_tokens = 0
+    
+    for name, text in components.items():
+        chars = len(text)
+        tokens = count_tokens(text)
+        total_chars += chars
+        total_tokens += tokens
+        print(f"{name}:")
+        print(f"  Characters: {chars:,}")
+        print(f"  Tokens:     {tokens:,}")
+        print()
+    
+    print("-" * 80)
+    print(f"TOTAL SYSTEM INSTRUCTION:")
+    print(f"  Characters: {total_chars:,}")
+    print(f"  Tokens:     {total_tokens:,}")
+    print()
+    
+    # Tool Definitions
+    print("=" * 80)
+    print("TOOL DEFINITIONS")
+    print("-" * 80)
+    
+    # Sample built-in tools
+    builtin_tools = [
+        ("create_artifact", "Creates a new artifact with the specified content.", {
+            "filename": {"type": "string", "description": "The name of the file to create"},
+            "content": {"type": "string", "description": "The content to write to the file"},
+            "mime_type": {"type": "string", "description": "The MIME type of the content"},
+            "description": {"type": "string", "description": "A description of the artifact"}
+        }),
+        ("list_artifacts", "Lists all artifacts in the current session.", {}),
+        ("load_artifact", "Loads the content of an artifact.", {
+            "filename": {"type": "string", "description": "The name of the file to load"},
+            "version": {"type": "integer", "description": "The version to load"}
+        }),
+        ("signal_artifact_for_return", "Signals that an artifact should be returned to the user.", {
+            "filename": {"type": "string", "description": "The name of the artifact"},
+            "version": {"type": "integer", "description": "The version to return"}
+        }),
+        ("delete_artifact", "Deletes an artifact.", {
+            "filename": {"type": "string", "description": "The name of the artifact to delete"}
+        }),
+        ("jq_query", "Executes a jq query on JSON data.", {
+            "query": {"type": "string", "description": "The jq query to execute"},
+            "data": {"type": "string", "description": "The JSON data to query"}
+        }),
+        ("sql_query", "Executes a SQL query on tabular data.", {
+            "query": {"type": "string", "description": "The SQL query to execute"},
+            "data_source": {"type": "string", "description": "The data source to query"}
+        }),
+        ("get_current_time", "Gets the current date and time.", {}),
+    ]
+    
+    tool_tokens_total = 0
+    for name, description, params in builtin_tools:
+        tool_def = generate_tool_definition(name, description, params)
+        tokens = count_tokens(tool_def)
+        tool_tokens_total += tokens
+        print(f"  {name}: {tokens} tokens")
+    
+    print(f"\nTotal Built-in Tools ({len(builtin_tools)} tools): {tool_tokens_total:,} tokens")
+    print()
+    
+    # Peer Agent Tool Definitions
+    print("PEER AGENT TOOL DEFINITIONS")
+    print("-" * 80)
+    
+    peer_tool_tokens = 0
+    for agent in sample_agents:
+        name = agent["name"]
+        description = agent["description"]
+        skills = agent.get("skills", [])
+        
+        # Build enhanced description like PeerAgentTool does
+        enhanced_desc = description
+        if skills:
+            skill_text = "\n\nCapabilities:\n" + "\n".join([f"- {s['name']}: {s['description']}" for s in skills])
+            enhanced_desc += skill_text
+        
+        tool_def = generate_tool_definition(
+            f"peer_{name}",
+            enhanced_desc,
+            {"task_description": {"type": "string", "description": "The task to delegate to this agent"}}
+        )
+        tokens = count_tokens(tool_def)
+        peer_tool_tokens += tokens
+        print(f"  peer_{name}: {tokens} tokens")
+    
+    print(f"\nTotal Peer Agent Tools ({len(sample_agents)} agents): {peer_tool_tokens:,} tokens")
+    print()
+    
+    # Summary
+    print("=" * 80)
+    print("TOTAL TOKEN USAGE SUMMARY")
+    print("=" * 80)
+    
+    all_tools_tokens = tool_tokens_total + peer_tool_tokens
+    
+    print(f"""
+┌─────────────────────────────────────────────────────────────────────────────┐
+│                         CACHEABLE COMPONENTS                                 │
+├─────────────────────────────────────────────────────────────────────────────┤
+│ System Instruction (all components)          │ {total_tokens:>6,} tokens │ {total_chars:>8,} chars │
+│ Built-in Tool Definitions ({len(builtin_tools)} tools)           │ {tool_tokens_total:>6,} tokens │              │
+│ Peer Agent Tool Definitions ({len(sample_agents)} agents)        │ {peer_tool_tokens:>6,} tokens │              │
+├─────────────────────────────────────────────────────────────────────────────┤
+│ TOTAL CACHEABLE                              │ {total_tokens + all_tools_tokens:>6,} tokens │              │
+└─────────────────────────────────────────────────────────────────────────────┘
+
+┌─────────────────────────────────────────────────────────────────────────────┐
+│                      NON-CACHEABLE COMPONENTS                                │
+├─────────────────────────────────────────────────────────────────────────────┤
+│ User Message (typical)                       │    50-500 tokens │              │
+│ Conversation History (per turn)              │  100-2000 tokens │              │
+│ Tool Responses (variable)                    │   50-5000 tokens │              │
+└─────────────────────────────────────────────────────────────────────────────┘
+""")
+    
+    # Cost estimation
+    cacheable_tokens = total_tokens + all_tools_tokens
+    
+    # Claude Sonnet pricing (as of late 2025)
+    input_price_per_1k = 0.003  # $3 per 1M tokens
+    cached_price_per_1k = 0.0003  # 90% discount on cache hits
+    output_price_per_1k = 0.015  # $15 per 1M tokens
+    
+    print("COST ESTIMATION (Claude Sonnet pricing)")
+    print("-" * 80)
+    
+    # First request (cache miss)
+    first_request_input = cacheable_tokens + 100  # + user message
+    first_request_cost = (first_request_input / 1000) * input_price_per_1k
+    output_tokens = 500
+    output_cost = (output_tokens / 1000) * output_price_per_1k
+    
+    print(f"First Request (cache miss):")
+    print(f"  Input tokens:  {first_request_input:,} @ ${input_price_per_1k}/1K = ${first_request_cost:.4f}")
+    print(f"  Output tokens: {output_tokens:,} @ ${output_price_per_1k}/1K = ${output_cost:.4f}")
+    print(f"  Total: ${first_request_cost + output_cost:.4f}")
+    print()
+    
+    # Subsequent request (cache hit)
+    fresh_tokens = 100 + 500  # user message + conversation history
+    cached_cost = (cacheable_tokens / 1000) * cached_price_per_1k
+    fresh_cost = (fresh_tokens / 1000) * input_price_per_1k
+    
+    print(f"Subsequent Request (cache hit):")
+    print(f"  Cached tokens: {cacheable_tokens:,} @ ${cached_price_per_1k}/1K = ${cached_cost:.4f}")
+    print(f"  Fresh tokens:  {fresh_tokens:,} @ ${input_price_per_1k}/1K = ${fresh_cost:.4f}")
+    print(f"  Output tokens: {output_tokens:,} @ ${output_price_per_1k}/1K = ${output_cost:.4f}")
+    print(f"  Total: ${cached_cost + fresh_cost + output_cost:.4f}")
+    print()
+    
+    savings = ((first_request_cost + output_cost) - (cached_cost + fresh_cost + output_cost)) / (first_request_cost + output_cost) * 100
+    print(f"Savings with caching: {savings:.1f}%")
+    print()
+    
+    # 10 requests scenario
+    print("10 Requests Scenario:")
+    total_without_cache = 10 * (first_request_cost + output_cost)
+    total_with_cache = (first_request_cost + output_cost) + 9 * (cached_cost + fresh_cost + output_cost)
+    print(f"  Without caching: ${total_without_cache:.4f}")
+    print(f"  With caching:    ${total_with_cache:.4f}")
+    print(f"  Savings:         ${total_without_cache - total_with_cache:.4f} ({(total_without_cache - total_with_cache) / total_without_cache * 100:.1f}%)")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
This pull request adds comprehensive documentation on prompt caching and token usage breakdown in Agent Mesh. The new docs explain how prompt caching works, how it is configured, its impact on latency and costs, and provide detailed estimates and strategies for optimizing token usage and cost. These additions help users understand and optimize their LLM configurations for efficiency and cost savings.

**Prompt Caching Documentation:**

* Added a new page, `prompt-caching.md`, detailing how prompt caching works in Agent Mesh, including configuration options, what gets cached (system instructions and tool definitions), provider support, best practices, and troubleshooting tips.

**Token Usage and Cost Optimization:**

* Added a new page, `token-usage-breakdown.md`, with a detailed breakdown of what is sent to the LLM per request, approximate token counts for each component, how prompt caching affects token usage and costs, and strategies for reducing token consumption. Includes tables, illustrative examples, and provider-specific caching behaviors.