### PR TITLE
fix (DATAGO-119579): Fix spacing issue in lists with nested lists.

### DIFF
--- a/client/webui/frontend/src/lib/utils/themeHtmlStyles.ts
+++ b/client/webui/frontend/src/lib/utils/themeHtmlStyles.ts
@@ -14,6 +14,7 @@ export const getThemeHtmlStyles = (additionalClasses: string = ""): string => {
     /* Paragraphs */
     [&_p]:leading-[24px] [&_p]:text-foreground [&_p]:whitespace-pre-wrap [&_p]:mb-6
     [&_p:last-child]:mb-0
+    [&_li>p]:mb-0
 
     /* Text formatting */
     [&_strong]:font-semibold [&_strong]:text-foreground


### PR DESCRIPTION
This pull request introduces a small improvement to the styling logic in the `getThemeHtmlStyles` utility. The update ensures that paragraph elements inside list items (`li > p`) do not have unnecessary bottom margin, resulting in more consistent spacing within lists.

* Paragraphs inside list items (`li > p`) now have no bottom margin, improving list formatting in generated HTML styles.