### PR TITLE
hotfix: slack missing session_id

### DIFF
--- a/src/solace_agent_mesh/gateway/http_sse/services/task_logger_service.py
+++ b/src/solace_agent_mesh/gateway/http_sse/services/task_logger_service.py
@@ -570,13 +570,11 @@ class TaskLoggerService:
             from ..repository.session_repository import SessionRepository
             
             # Check if the session exists in this database
-            # Skip saving chat_tasks for sessions from other gateways (e.g., Slack)
             session_repo = SessionRepository()
-            existing_session = session_repo.find_by_id(db, session_id)
-            if not existing_session:
+            if not session_repo.exists(db, session_id):
                 log.debug(
                     f"{self.log_identifier} Session {session_id} not found in webui_gateway database "
-                    f"(Skipping chat message save for task {task_id}"
+                    f"Skipping chat message save for task {task_id}"
                 )
                 return
             


### PR DESCRIPTION
This pull request adds a safeguard to prevent saving chat messages for sessions that do not exist in the current database, which helps avoid issues when handling sessions originating from other gateways (such as Slack).

Session validation improvements:

* Added a check using `SessionRepository` in `task_logger_service.py` to verify if a session exists in the current database before saving chat messages, and skips saving if the session is not found (e.g., for sessions from other gateways).