### PR TITLE
fix(DATAGO-119908): Ensure that all events get buffered before SSE connection is made

### DIFF
--- a/src/solace_agent_mesh/gateway/http_sse/services/task_logger_service.py
+++ b/src/solace_agent_mesh/gateway/http_sse/services/task_logger_service.py
@@ -117,26 +117,10 @@ class TaskLoggerService:
                         
                         if message.metadata:
                             parent_task_id = message.metadata.get("parentTaskId")
-                            background_execution_enabled = message.metadata.get("background_execution", False)
-                            max_execution_time_ms = message.metadata.get("max_execution_time_ms")
-                            
-                            # Fallback: Enable background execution for specific agents
-                            agent_name = message.metadata.get("agent_name")
-                            background_enabled_agents = ["OrchestratorAgent", "DeepResearchAgent"]
-                            if not background_execution_enabled and agent_name in background_enabled_agents:
-                                background_execution_enabled = True
-                                max_execution_time_ms = 3600000  # 1 hour default
-                                log.info(
-                                    f"{self.log_identifier} Auto-enabled background execution for agent {agent_name}"
-                                )
-                            
-                            # Debug logging
-                            log.info(
-                                f"{self.log_identifier} Extracted metadata for task {task_id}: "
-                                f"background_execution={background_execution_enabled}, "
-                                f"max_execution_time_ms={max_execution_time_ms}, "
-                                f"all_metadata_keys={list(message.metadata.keys())}"
-                            )
+                            # Background tasks are disabled - always set to False
+                            # TODO: Re-enable when background task feature is fully tested
+                            background_execution_enabled = False
+                            max_execution_time_ms = None
                         else:
                             log.warning(
                                 f"{self.log_identifier} Message has no metadata for task {task_id}"

--- a/tests/unit/gateway/http_sse/test_sse_manager.py
+++ b/tests/unit/gateway/http_sse/test_sse_manager.py
@@ -45,6 +45,8 @@ class TestSSEManagerInitialization:
         assert manager.log_identifier == "[SSEManager]"
         # Verify the single threading lock exists
         assert hasattr(manager._lock, 'acquire') and hasattr(manager._lock, 'release')
+        # Verify connection tracking set is initialized
+        assert manager._tasks_with_prior_connection == set()
 
     def test_init_with_zero_queue_size(self):
         """Test SSEManager initialization with zero queue size."""
@@ -584,6 +586,115 @@ class TestSSEManagerEventDistribution:
         assert good_queue in manager._connections[task_id]
 
 
+class TestSSEManagerBackgroundTaskBuffering:
+    """Test background task buffering behavior."""
+
+    @pytest.mark.asyncio
+    async def test_background_task_buffers_before_first_connection(self):
+        """Test that background tasks buffer events before any connection is made."""
+        # Setup
+        event_buffer = MagicMock(spec=SSEEventBuffer)
+        manager = SSEManager(100, event_buffer)
+        task_id = "background-task-123"
+
+        # Mark task as background task
+        manager._background_task_cache[task_id] = True
+
+        event_data = {"message": "test event"}
+
+        # Execute - no connection made yet
+        await manager.send_event(task_id, event_data, "message")
+
+        # Verify - event should be buffered, not dropped
+        expected_payload = {
+            "event": "message",
+            "data": json.dumps(event_data, allow_nan=False)
+        }
+        event_buffer.buffer_event.assert_called_once_with(task_id, expected_payload)
+
+    @pytest.mark.asyncio
+    async def test_background_task_drops_after_disconnection(self):
+        """Test that background tasks drop events after client disconnects."""
+        # Setup
+        event_buffer = MagicMock(spec=SSEEventBuffer)
+        event_buffer.get_and_remove_buffer.return_value = None
+        manager = SSEManager(100, event_buffer)
+        task_id = "background-task-123"
+
+        # Mark task as background task
+        manager._background_task_cache[task_id] = True
+
+        # Create connection (simulates client connecting)
+        queue = await manager.create_sse_connection(task_id)
+
+        # Remove connection (simulates client disconnecting)
+        await manager.remove_sse_connection(task_id, queue)
+
+        event_data = {"message": "test event"}
+
+        # Execute - client has connected and disconnected
+        await manager.send_event(task_id, event_data, "message")
+
+        # Verify - event should be dropped, not buffered
+        event_buffer.buffer_event.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_create_connection_marks_task_as_having_prior_connection(self):
+        """Test that creating a connection marks the task in the tracking set."""
+        # Setup
+        event_buffer = MagicMock(spec=SSEEventBuffer)
+        event_buffer.get_and_remove_buffer.return_value = None
+        manager = SSEManager(100, event_buffer)
+        task_id = "test-task-123"
+
+        # Verify - task not in tracking set initially
+        assert task_id not in manager._tasks_with_prior_connection
+
+        # Execute
+        await manager.create_sse_connection(task_id)
+
+        # Verify - task is now in tracking set
+        assert task_id in manager._tasks_with_prior_connection
+
+    @pytest.mark.asyncio
+    async def test_close_all_for_task_clears_tracking(self):
+        """Test that close_all_for_task clears the connection tracking."""
+        # Setup
+        event_buffer = MagicMock(spec=SSEEventBuffer)
+        event_buffer.get_and_remove_buffer.return_value = None
+        manager = SSEManager(100, event_buffer)
+        task_id = "test-task-123"
+
+        await manager.create_sse_connection(task_id)
+        assert task_id in manager._tasks_with_prior_connection
+
+        # Execute
+        await manager.close_all_for_task(task_id)
+
+        # Verify - tracking is cleared
+        assert task_id not in manager._tasks_with_prior_connection
+
+    @pytest.mark.asyncio
+    async def test_close_all_clears_tracking(self):
+        """Test that close_all clears all connection tracking."""
+        # Setup
+        event_buffer = MagicMock(spec=SSEEventBuffer)
+        event_buffer.get_and_remove_buffer.return_value = None
+        manager = SSEManager(100, event_buffer)
+
+        # Create connections for multiple tasks
+        await manager.create_sse_connection("task-1")
+        await manager.create_sse_connection("task-2")
+
+        assert len(manager._tasks_with_prior_connection) == 2
+
+        # Execute
+        await manager.close_all()
+
+        # Verify - all tracking is cleared
+        assert len(manager._tasks_with_prior_connection) == 0
+
+
 class TestSSEManagerConnectionLifecycle:
     """Test connection lifecycle management."""
 
@@ -595,7 +706,7 @@ class TestSSEManagerConnectionLifecycle:
         event_buffer.get_and_remove_buffer.return_value = None
         manager = SSEManager(100, event_buffer)
         task_id = "test-task-123"
-        
+
         queue = await manager.create_sse_connection(task_id)
         
         # Execute


### PR DESCRIPTION
# PR: Fix SSE Event Buffering and Disable Background Tasks

## Summary

This PR fixes a critical issue where the first part of agent responses was being lost in the UI due to SSE buffering race conditions. It also disables the background tasks feature until it can be fully tested.

## Problem

Users reported that the beginning of agent responses were being cut off in the web UI. Investigation revealed two issues:

1. **Race condition with per-event-loop locks**: The SSEManager was using `asyncio.Lock` instances that were created per-event-loop. Since FastAPI and the SAC component run in different event loops, they obtained different locks, defeating the synchronization.

2. **Events dropped instead of buffered**: Events for tasks were being incorrectly dropped (instead of buffered) because tasks were misidentified as "background tasks that had disconnected" when they were actually new tasks that hadn't connected yet.

## Solution

### Fix 1: Threading Lock for Cross-Event-Loop Synchronization

Changed from per-event-loop `asyncio.Lock` to a single `threading.Lock` in `sse_manager.py`. This ensures proper synchronization regardless of which event loop is calling.

### Fix 2: Connection Tracking for Proper Buffering Behavior

Added `_tasks_with_prior_connection` tracking set to distinguish between:
- **No connection yet** → Buffer events (new task, client will connect soon)
- **Had connection but disconnected** → Drop events (background task, client left intentionally)

### Fix 3: Disable Background Tasks

Disabled the background tasks feature in `task_logger_service.py` by always setting `background_execution_enabled = False`. This feature was not adequately tested and was contributing to the event dropping issue.

## Files Changed

| File | Changes |
|------|---------|
| `src/solace_agent_mesh/gateway/http_sse/sse_manager.py` | Replaced per-event-loop asyncio locks with single threading lock; added connection tracking set |
| `src/solace_agent_mesh/gateway/http_sse/services/task_logger_service.py` | Disabled background task execution |
| `tests/unit/gateway/http_sse/test_sse_manager.py` | Added 5 new tests for background task buffering behavior |

## Testing

- Verified SSE events are properly buffered before client connects
- Confirmed full agent responses appear in UI without truncation
- Added unit tests covering:
  - Background task buffers before first connection
  - Background task drops after disconnection
  - Connection tracking set behavior
  - Cleanup methods clear tracking properly

## Notes

- The threading lock change is safe because the lock is only held briefly during dictionary operations, not during I/O.
