### PR TITLE
ci(DATAGO-119983): Add PR size validation workflow

### DIFF
--- a/.github/workflows/pr-size-validation.yaml
+++ b/.github/workflows/pr-size-validation.yaml
@@ -1,0 +1,19 @@
+name: "PR Size Validation"
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+jobs:
+  pr-size-check:
+    name: PR Size Check
+    runs-on: ubuntu-latest
+    permissions:
+      statuses: write
+      pull-requests: read
+    steps:
+      - name: Validate PR Size
+        uses: SolaceDev/solace-public-workflows/.github/actions/pr-size-check@main
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          max-lines: 1500


### PR DESCRIPTION
## Summary
Adds automated PR size validation to enforce a limit of 1500 lines per pull request.

## Implementation
- **Workflow**: `.github/workflows/pr-size-validation.yaml`
- **Action**: Uses `SolaceDev/solace-public-workflows/.github/actions/pr-size-check@main`
- **Limit**: 1500 lines (additions + deletions)
- **Status Check**: Posts `PR Validation / Size Check` status

## Behavior
- Runs automatically on all PR events (opened, synchronize, reopened)
- Posts a commit status showing actual PR size and configured limit
- Success: PR size ≤ 1500 lines
- Failure: PR size > 1500 lines (blocks merge if configured in branch protection)

## Configuration
The 1500 line limit can be adjusted by modifying the `max-lines` parameter in the workflow file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)