### PR TITLE
docs(DATAGO-118708): Platform Service

### DIFF
--- a/docs/docs/documentation/components/components.md
+++ b/docs/docs/documentation/components/components.md
@@ -15,6 +15,10 @@ Agents are the intelligent processing units that perform tasks within the mesh. 
 
 Gateways serve as the entry and exit points for your agent mesh, translating between external protocols and the internal A2A communication standard. Whether you need REST APIs, webhooks, WebSocket connections, or integrations with platforms like Slack, gateways handle the protocol conversion and session management. They also manage authentication and authorization, ensuring that user permissions are properly enforced throughout the system. For gateway development and configuration details, see [Gateways](./gateways.md).
 
+## Platform Service
+
+The Platform Service is a dedicated backend microservice that handles management operations for the Web UI Gateway. For more details, see [Platform Service](./platform-service.md).
+
 ## Orchestrator
 
 The orchestrator is a specialized agent that manages complex workflows by breaking down requests into smaller tasks and coordinating their execution across multiple agents. It understands dependencies between tasks, manages parallel execution, and aggregates results to provide comprehensive responses. The orchestrator is particularly valuable for scenarios that require multiple specialized agents to work together toward a common goal. For orchestrator configuration and workflow design patterns, see [Orchestrator](./orchestrator.md).

--- a/docs/docs/documentation/components/platform-service.md
+++ b/docs/docs/documentation/components/platform-service.md
@@ -1,0 +1,40 @@
+---
+title: Platform Service
+sidebar_position: 265
+---
+
+# Platform Service
+
+The Platform Service is a dedicated backend microservice that handles management operations for the Web UI Gateway. It runs independently of the gateway, enabling separate scaling and deployment of the components.
+
+## What Does It Provide?
+
+The Platform Service provides the backend infrastructure for:
+
+- **Agent Builder** *(Enterprise)* - Create, read, update, and delete AI agents
+- **Connector Management** *(Enterprise)* - Manage database connectors that enable agents to query SQL databases
+- **Deployment Orchestration** *(Enterprise)* - Deploy agents to runtime environments
+- **Deployer Monitoring** *(Enterprise)* - Track health and availability of deployer services
+
+## Running the Platform Service
+
+A sample Platform Service configuration is automatically generated when you run:
+
+```bash
+sam init --gui
+```
+
+When prompted to enable the WebUI Gateway, select **Yes**. This will generate `configs/services/platform.yaml` with all necessary configuration.
+
+Start the Platform Service using the SAM CLI:
+
+```bash
+sam run configs/services/platform.yaml
+```
+
+The service runs on **port 8001** by default.
+
+:::note
+A Platform Service instance is only required when running the WebUI Gateway in combination with Agent Mesh Enterprise.
+:::
+

--- a/docs/docs/documentation/enterprise/agent-builder.md
+++ b/docs/docs/documentation/enterprise/agent-builder.md
@@ -61,7 +61,7 @@ For detailed information about creating and configuring connectors, see [Connect
 
 When you deploy an agent through Agent Builder, the deployment process involves several components working together to create running agent instances.
 
-The Gateway receives your deployment request and validates the agent configuration. It creates a deployment record in the database and publishes a deployment message to the Solace broker. The Deployer component (a separate containerized service) receives this message and creates a running agent instance using the configuration you provided. The Deployer sends status updates back to the Gateway through heartbeat messages, and the Gateway updates the deployment status you see in the UI.
+The Platform Service receives your deployment request and validates the agent configuration. It creates a deployment record in the database and publishes a deployment message to the Solace broker. The Deployer component (a separate containerized service) receives this message and creates a running agent instance using the configuration you provided. The Deployer sends status updates back to the Platform Service through heartbeat messages, and the Platform Service updates the deployment status you see in the UI.
 
 This architecture enables multiple Deployer instances to run independently for scalability and allows deployment operations to complete asynchronously without blocking the UI. You see status transitions (Deploying, Deployed, or Deployment Failed) as the Deployer works in the background.
 


### PR DESCRIPTION
Adds documentation for the Platform Service. This PR introduces a dedicated documentation page and updates existing documentation to accurately reflect the Platform Service's role in the architecture.

Note that I maintain the word `Service` rather than just `Platform` since this clearly conveys the idea that this is a component which supports other user-facing components. 

I also label features as *(enterprise)* to remove ambiguity. 

Here's a view showing ordering with other components: 
<img width="1474" height="865" alt="image" src="https://github.com/user-attachments/assets/b975c92d-18c0-45d5-b9c1-436cab63d2c0" />
