### PR TITLE
ci: add rc blocking

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,6 +15,11 @@ on:
         required: false
         description: "Skip security checks"
         default: false
+      skip_rc_check:
+        type: boolean
+        required: false
+        description: "Skip RC verification (emergency releases only)"
+        default: false
 
 permissions:
   id-token: write
@@ -24,9 +29,85 @@ permissions:
   pull-requests: read
 
 jobs:
+  # Verify the current version has passed RC testing
+  verify-rc:
+    name: Verify RC Status
+    if: ${{ github.event.inputs.skip_rc_check != 'true' }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
+        with:
+          fetch-depth: 0 # Need enough history to find last non-skip-ci commit
+
+      - name: Find Last RC-Tested Commit
+        id: find-commit
+        run: |
+          echo "Finding the last commit that triggered RC tests..."
+
+          # Find the most recent commit without [skip ci] or [ci skip]
+          COMMIT_SHA=$(git log --invert-grep --grep='\[skip ci\]' --grep='\[ci skip\]' -i -1 --format='%H')
+
+          if [ -z "$COMMIT_SHA" ]; then
+            echo "::error::Could not find a non-skip-ci commit"
+            exit 1
+          fi
+
+          echo "Found RC-tested commit: $COMMIT_SHA"
+          echo "  Message: $(git log -1 --format='%s' $COMMIT_SHA)"
+          echo "commit_sha=$COMMIT_SHA" >> $GITHUB_OUTPUT
+
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a # v4.3.1
+        with:
+          aws-access-key-id: ${{ secrets.MANIFEST_READ_ONLY_AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.MANIFEST_READ_ONLY_AWS_SECRET_ACCESS_KEY }}
+          aws-region: ${{ secrets.AWS_DEFAULT_REGION }}
+
+      - name: Get RC SHA from DynamoDB
+        id: get-rc-sha
+        uses: SolaceDev/solace-public-workflows/.github/actions/cicd-helper@main
+        with:
+          rc_step: get_item_value_from_dynamodb
+          ddb_query_json: '{"squad": "ai", "repository": "solace-agent-mesh"}'
+          ddb_table_name: solace-cloud-manifest
+          ddb_partition_key: squad
+          ddb_field_path: rc.sha
+          ddb_output_name: RC_SHA
+
+      - name: Verify RC SHA
+        run: |
+          EXPECTED_SHA="${{ steps.find-commit.outputs.commit_sha }}"
+          RC_SHA="${{ steps.get-rc-sha.outputs.RC_SHA }}"
+
+          echo "Expected SHA (last RC-tested commit): $EXPECTED_SHA"
+          echo "RC SHA from DynamoDB: $RC_SHA"
+
+          if [ "$RC_SHA" = "NOT_FOUND" ] || [ "$RC_SHA" = "FIELD_NOT_FOUND" ]; then
+            echo "::error::No RC entry found in DynamoDB for solace-agent-mesh"
+            echo "Please run the RC pipeline first by pushing to main."
+            exit 1
+          fi
+
+          if [ "$RC_SHA" != "$EXPECTED_SHA" ]; then
+            echo "::error::RC SHA mismatch!"
+            echo "  Expected: $EXPECTED_SHA"
+            echo "  Found in DynamoDB: $RC_SHA"
+            echo ""
+            echo "The commit that passed RC testing does not match the expected release commit."
+            echo "This could mean new commits were added without running RC tests."
+            exit 1
+          fi
+
+          echo "✅ RC verification passed - SHA matches: $RC_SHA"
+
   # Run security checks first via reusable workflow (conditionally)
   security-checks:
-    if: ${{ github.event.inputs.skip_security_checks != 'true' }}
+    needs: verify-rc
+    if: |
+      always() &&
+      (needs.verify-rc.result == 'success' || needs.verify-rc.result == 'skipped') &&
+      github.event.inputs.skip_security_checks != 'true'
     uses: SolaceDev/solace-public-workflows/.github/workflows/hatch_release_security_checks.yml@main
     with:
       whitesource_project_name: "solace-agent-mesh"
@@ -49,13 +130,14 @@ jobs:
   # Release to PyPI using Trusted Publishing
   release:
     name: Release to PyPI
-    # We need always() here because when security-checks is skipped (via skip_security_checks input),
+    # We need always() here because when security-checks or verify-rc is skipped,
     # GitHub Actions would by default skip ALL dependent jobs. The always() forces evaluation of our
-    # condition, allowing the release to proceed when security-checks was either successful OR skipped.
-    # This enables emergency releases when security checks need to be bypassed.
-    needs: security-checks
+    # condition, allowing the release to proceed when checks were either successful OR skipped.
+    # This enables emergency releases when checks need to be bypassed.
+    needs: [verify-rc, security-checks]
     if: |
       always() && 
+      (needs.verify-rc.result == 'success' || needs.verify-rc.result == 'skipped') &&
       (needs.security-checks.result == 'success' || needs.security-checks.result == 'skipped')
     runs-on: ubuntu-latest
     timeout-minutes: 20


### PR DESCRIPTION
Verify RC tag in dynamodb table during release. 
Find the latest commit (non `ci skip`) and verify that it's present in the dynamodb RC field 