### PR TITLE
fix (DATAGO-119939) Deleting a version of a SAM artifact deletes all versions

### DIFF
--- a/src/llm_detail.txt
+++ b/src/llm_detail.txt
@@ -2403,7 +2403,7 @@ result = await multi_speaker_text_to_speech(
 - `append_to_artifact(filename: str, content_chunk: str, mime_type: str, tool_context: ToolContext = None) -> Dict[str, Any]` - Appends content to existing artifact
 - `apply_embed_and_create_artifact(output_filename: str, embed_directive: str, output_metadata: Optional[Dict[str, Any]] = None, tool_context: ToolContext = None) -> Dict[str, Any]` - Resolves embed directives and creates artifacts
 - `extract_content_from_artifact(filename: str, extraction_goal: str, version: Optional[str] = "latest", output_filename_base: Optional[str] = None, tool_context: ToolContext = None) -> Dict[str, Any]` - Uses LLM to extract/transform artifact content
-- `delete_artifact(filename: str, version: Optional[int] = None, tool_context: ToolContext = None) -> Dict[str, Any]` - Deletes artifact versions
+- `delete_artifact(filename: str, version: Optional[int] = None, confirm_delete: bool = False, tool_context: ToolContext = None) -> Dict[str, Any]` - Deletes ALL versions of an artifact (requires confirmation)
 
 **Usage Examples:**
 ```python

--- a/src/solace_agent_mesh/agent/agent_llm_detail.txt
+++ b/src/solace_agent_mesh/agent/agent_llm_detail.txt
@@ -1370,7 +1370,7 @@ result = await multi_speaker_text_to_speech(
 - `apply_embed_and_create_artifact(output_filename: str, embed_directive: str, output_metadata: Optional[Dict[str, Any]] = None, tool_context: ToolContext = None) -> Dict[str, Any]` - Resolves embed directives and creates new artifacts
 - `extract_content_from_artifact(filename: str, extraction_goal: str, version: Optional[str] = "latest", output_filename_base: Optional[str] = None, tool_context: ToolContext = None) -> Dict[str, Any]` - Uses LLM to extract/transform artifact content
 - `append_to_artifact(filename: str, content_chunk: str, mime_type: str, tool_context: ToolContext = None) -> Dict[str, Any]` - Appends content to existing artifacts
-- `delete_artifact(filename: str, version: Optional[int] = None, tool_context: ToolContext = None) -> Dict[str, Any]` - Deletes artifact versions
+- `delete_artifact(filename: str, version: Optional[int] = None, confirm_delete: bool = False, tool_context: ToolContext = None) -> Dict[str, Any]` - Deletes ALL versions of an artifact (requires confirmation)
 
 **Usage Examples:**
 ```python

--- a/src/solace_agent_mesh/agent/tools/builtin_artifact_tools.py
+++ b/src/solace_agent_mesh/agent/tools/builtin_artifact_tools.py
@@ -1740,18 +1740,20 @@ tool_registry.register(extract_content_from_artifact_tool_def)
 async def delete_artifact(
     filename: str,
     version: Optional[int] = None,
+    confirm_delete: bool = False,
     tool_context: ToolContext = None,
 ) -> Dict[str, Any]:
     """
-    Deletes a specific version of an artifact, or all versions if no version is specified.
+    Deletes all versions of an artifact. Version-specific deletion is not currently supported.
 
     Args:
         filename: The name of the artifact to delete.
-        version: The specific version number to delete. If not provided, all versions will be deleted.
+        version: Reserved for future use. Currently not supported - returns error if specified.
+        confirm_delete: Must be set to True to confirm deletion. If False, returns confirmation prompt.
         tool_context: The context provided by the ADK framework.
 
     Returns:
-        A dictionary indicating the result of the deletion.
+        A dictionary indicating the result of the deletion or requesting confirmation.
     """
     if not tool_context:
         return {
@@ -1760,9 +1762,7 @@ async def delete_artifact(
             "message": "ToolContext is missing, cannot delete artifact.",
         }
 
-    log_identifier = (
-        f"[BuiltinArtifactTool:delete_artifact:{filename}:{version or 'all'}]"
-    )
+    log_identifier = f"[BuiltinArtifactTool:delete_artifact:{filename}]"
     log.debug("%s Processing request.", log_identifier)
 
     try:
@@ -1780,14 +1780,32 @@ async def delete_artifact(
                 "ArtifactService does not support deleting artifacts."
             )
 
+        # Error if version-specific deletion requested (not currently supported)
         if version is not None:
-            log.warning(
-                "%s Deleting a specific version (%s) is not supported by the current artifact service interface. "
-                "All versions of the artifact will be deleted.",
-                log_identifier,
-                version,
-            )
+            return {
+                "status": "error",
+                "filename": filename,
+                "version_requested": version,
+                "message": f"Deleting a specific version ({version}) is not currently supported. Only deletion of ALL versions is supported. To delete all versions, omit 'version' and set confirm_delete=True.",
+            }
 
+        # Get version list for confirmation message
+        versions = await artifact_service.list_versions(
+            app_name=app_name, user_id=user_id, session_id=session_id, filename=filename
+        )
+
+        # Require confirmation before deleting
+        if not confirm_delete:
+            count = len(versions) if versions else "unknown number of"
+            return {
+                "status": "confirmation_required",
+                "filename": filename,
+                "version_count": len(versions) if versions else None,
+                "versions": versions,
+                "message": f"WARNING: This operation is irreversible and will permanently delete artifact '{filename}' and ALL {count} version(s). To proceed, call this tool again with confirm_delete=True.",
+            }
+
+        # Proceed with deletion
         await artifact_service.delete_artifact(
             app_name=app_name,
             user_id=user_id,
@@ -1795,17 +1813,12 @@ async def delete_artifact(
             filename=filename,
         )
 
-        log.info(
-            "%s Successfully deleted artifact '%s' version '%s'.",
-            log_identifier,
-            filename,
-            version or "all",
-        )
+        log.info("%s Successfully deleted artifact '%s'.", log_identifier, filename)
         return {
             "status": "success",
             "filename": filename,
-            "version": version or "all",
-            "message": f"Artifact '{filename}' version '{version or 'all'}' deleted successfully.",
+            "versions_deleted": len(versions) if versions else None,
+            "message": f"Artifact '{filename}' deleted successfully.",
         }
 
     except FileNotFoundError as e:
@@ -1829,7 +1842,7 @@ async def delete_artifact(
 delete_artifact_tool_def = BuiltinTool(
     name="delete_artifact",
     implementation=delete_artifact,
-    description="Deletes a specific version of an artifact, or all versions if no version is specified.",
+    description="Deletes all versions of an artifact. IMPORTANT: Requires explicit confirmation via confirm_delete=True parameter. The first call without confirmation will return details about what will be deleted.",
     category="artifact_management",
     category_name=CATEGORY_NAME,
     category_description=CATEGORY_DESCRIPTION,
@@ -1843,7 +1856,12 @@ delete_artifact_tool_def = BuiltinTool(
             ),
             "version": adk_types.Schema(
                 type=adk_types.Type.INTEGER,
-                description="The specific version number to delete. If not provided, all versions will be deleted.",
+                description="Reserved for future use. Version-specific deletion is not currently supported - will return error if specified.",
+                nullable=True,
+            ),
+            "confirm_delete": adk_types.Schema(
+                type=adk_types.Type.BOOLEAN,
+                description="Must be set to True to actually perform the deletion. If False or omitted, returns a confirmation prompt with details about what will be deleted (including version count).",
                 nullable=True,
             ),
         },

--- a/src/solace_agent_mesh/agent/tools/tools_llm.txt
+++ b/src/solace_agent_mesh/agent/tools/tools_llm.txt
@@ -76,7 +76,7 @@ result = await multi_speaker_text_to_speech(
 - `append_to_artifact(filename: str, content_chunk: str, mime_type: str, tool_context: ToolContext = None) -> Dict[str, Any]` - Appends content to existing artifact
 - `apply_embed_and_create_artifact(output_filename: str, embed_directive: str, output_metadata: Optional[Dict[str, Any]] = None, tool_context: ToolContext = None) -> Dict[str, Any]` - Resolves embed directives and creates artifacts
 - `extract_content_from_artifact(filename: str, extraction_goal: str, version: Optional[str] = "latest", output_filename_base: Optional[str] = None, tool_context: ToolContext = None) -> Dict[str, Any]` - Uses LLM to extract/transform artifact content
-- `delete_artifact(filename: str, version: Optional[int] = None, tool_context: ToolContext = None) -> Dict[str, Any]` - Deletes artifact versions
+- `delete_artifact(filename: str, version: Optional[int] = None, confirm_delete: bool = False, tool_context: ToolContext = None) -> Dict[str, Any]` - Deletes ALL versions of an artifact (requires confirmation)
 
 **Usage Examples:**
 ```python

--- a/src/solace_agent_mesh/agent/tools/tools_llm_detail.txt
+++ b/src/solace_agent_mesh/agent/tools/tools_llm_detail.txt
@@ -84,7 +84,7 @@ result = await multi_speaker_text_to_speech(
 - `apply_embed_and_create_artifact(output_filename: str, embed_directive: str, output_metadata: Optional[Dict[str, Any]] = None, tool_context: ToolContext = None) -> Dict[str, Any]` - Resolves embed directives and creates new artifacts
 - `extract_content_from_artifact(filename: str, extraction_goal: str, version: Optional[str] = "latest", output_filename_base: Optional[str] = None, tool_context: ToolContext = None) -> Dict[str, Any]` - Uses LLM to extract/transform artifact content
 - `append_to_artifact(filename: str, content_chunk: str, mime_type: str, tool_context: ToolContext = None) -> Dict[str, Any]` - Appends content to existing artifacts
-- `delete_artifact(filename: str, version: Optional[int] = None, tool_context: ToolContext = None) -> Dict[str, Any]` - Deletes artifact versions
+- `delete_artifact(filename: str, version: Optional[int] = None, confirm_delete: bool = False, tool_context: ToolContext = None) -> Dict[str, Any]` - Deletes ALL versions of an artifact (requires confirmation)
 
 **Note:** To return artifacts to users, use the `«artifact_return:filename[:version]»` embed in your response text instead of a tool call. This is more efficient and provides a better user experience.
 

--- a/src/solace_agent_mesh/solace_agent_mesh_llm_detail.txt
+++ b/src/solace_agent_mesh/solace_agent_mesh_llm_detail.txt
@@ -1370,7 +1370,7 @@ result = await multi_speaker_text_to_speech(
 - `apply_embed_and_create_artifact(output_filename: str, embed_directive: str, output_metadata: Optional[Dict[str, Any]] = None, tool_context: ToolContext = None) -> Dict[str, Any]` - Resolves embed directives and creates new artifacts
 - `extract_content_from_artifact(filename: str, extraction_goal: str, version: Optional[str] = "latest", output_filename_base: Optional[str] = None, tool_context: ToolContext = None) -> Dict[str, Any]` - Uses LLM to extract/transform artifact content
 - `append_to_artifact(filename: str, content_chunk: str, mime_type: str, tool_context: ToolContext = None) -> Dict[str, Any]` - Appends content to existing artifacts
-- `delete_artifact(filename: str, version: Optional[int] = None, tool_context: ToolContext = None) -> Dict[str, Any]` - Deletes artifact versions
+- `delete_artifact(filename: str, version: Optional[int] = None, confirm_delete: bool = False, tool_context: ToolContext = None) -> Dict[str, Any]` - Deletes ALL versions of an artifact (requires confirmation)
 
 **Usage Examples:**
 ```python


### PR DESCRIPTION
Problem:
- when requesting a certain version of artifact to be deleted LLM will delete all of them. (this is due to current tool contract)

Cause:
- we never supported capability to delete certain artifact version (even tho tool contract states it is possible)

Fix:
 - mimic manual artifact delete operation, when LLM will issue call to delete we will prompt user with an error stating certain version can not be deleted, and to confirm user is ok to purge artifact entirely.

Future directions:
- tool contract stays as is (i.e version is still part of it) once adk will introduce this capability we'll implement it accordingly.
  plus reduce potential regression should SAMe or other external dependencies rely on this version.

to test:
 - create an artifact, have more than 1 version of it, prompt LLM to delete certain version, ensure u are warned what is supported. 


run tests:

```
make test-setup && make test-unit
```