### PR TITLE
fix(DATAGO-120188): Pre-register long-running tools before invoking them and handle sync errors when invoking them

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -202,6 +202,7 @@ markers = [
     "tools: marks tests related to the agent tools",
     "audio_tools: marks tests related to the audio_tools",
     "peer_tool: marks tests for calling peer agents",
+    "parallel_tool: marks tests related to the parallel_tool",
     "builtin_artifact_tools: marks tests related to the builtin_artifact_tools",
     "builtin_data_analysis_tools: marks tests related to the builtin_data_analysis_tools",
     "general_agent_tools: marks tests related to the general_agent_tools",

--- a/src/solace_agent_mesh/agent/adk/runner.py
+++ b/src/solace_agent_mesh/agent/adk/runner.py
@@ -261,7 +261,11 @@ async def run_adk_async_task(
     logical_task_id = a2a_context.get("logical_task_id", "unknown_task")
     event_loop_stored = False
     current_loop = asyncio.get_running_loop()
-    is_paused = False
+    # Track pending long-running tools by their function_call IDs
+    # This replaces the simple boolean is_paused to properly handle sync returns
+    pending_long_running_tools: set[str] = set()
+    # Collect synchronous responses from long-running tools for potential re-run
+    sync_tool_responses: list[adk_types.Part] = []
 
     adk_event_generator = component.runner.run_async(
         user_id=adk_session.user_id,
@@ -316,7 +320,10 @@ async def run_adk_async_task(
                 break
 
             if event.long_running_tool_ids:
-                is_paused = True
+                # Track which long-running tool calls are pending (waiting for async response)
+                pending_long_running_tools = pending_long_running_tools.union(
+                    event.long_running_tool_ids
+                )
 
             if not event_loop_stored and event.invocation_id:
                 task_context.set_event_loop(current_loop)
@@ -342,8 +349,18 @@ async def run_adk_async_task(
             if event.content and event.content.parts:
                 for part in event.content.parts:
                     if part.function_response:
-                        if part.function_response.name.startswith("peer_"):
-                            pass
+                        # Check if this is a sync response from a long-running tool
+                        # (i.e., the tool returned immediately instead of async)
+                        response_id = part.function_response.id
+                        if response_id and response_id in pending_long_running_tools:
+                            pending_long_running_tools.discard(response_id)
+                            sync_tool_responses.append(part)
+                            log.info(
+                                "%s Long-running tool %s (id=%s) returned synchronously.",
+                                component.log_identifier,
+                                part.function_response.name,
+                                response_id,
+                            )
 
     except TaskCancelledError:
         raise
@@ -374,13 +391,54 @@ async def run_adk_async_task(
             f"Task {logical_task_id} was cancelled before finalization."
         )
 
-    if is_paused:
+    invocation_id = a2a_context.get("invocation_id")
+
+    # Check if we still have pending long-running tools (waiting for async responses)
+    if pending_long_running_tools:
+        # Store any sync responses using the SAME format as event_handlers.py
+        # This ensures they're combined with async responses when _retrigger is called
+        if sync_tool_responses:
+            for part in sync_tool_responses:
+                result = {
+                    "adk_function_call_id": part.function_response.id,
+                    "peer_tool_name": part.function_response.name,
+                    "payload": part.function_response.response,  # Already a dict from ADK
+                }
+                task_context.record_parallel_result(result, invocation_id)
+            log.info(
+                "%s Stored %d sync tool response(s) for later combination. Waiting for: %s",
+                component.log_identifier,
+                len(sync_tool_responses),
+                pending_long_running_tools,
+            )
+
         log.info(
-            "%s ADK run completed by invoking a long-running tool. Task %s will remain open, awaiting peer response.",
+            "%s Task %s paused, waiting for %d async tool response(s).",
             component.log_identifier,
             logical_task_id,
+            len(pending_long_running_tools),
         )
         return True
+
+    # All tools returned synchronously - re-run ADK with their responses
+    # The ADK already created the Part objects, so we use them directly (no duplication)
+    if sync_tool_responses:
+        log.info(
+            "%s All %d long-running tool(s) returned synchronously for task %s. Re-running ADK.",
+            component.log_identifier,
+            len(sync_tool_responses),
+            logical_task_id,
+        )
+        # Use the Part objects directly from the ADK (already properly formatted)
+        tool_response_content = adk_types.Content(role="tool", parts=sync_tool_responses)
+        return await run_adk_async_task(
+            component=component,
+            task_context=task_context,
+            adk_session=adk_session,
+            adk_content=tool_response_content,
+            run_config=run_config,
+            a2a_context=a2a_context,
+        )
 
     log.debug(
         "%s ADK run_async completed for task %s. Returning to wrapper for finalization.",

--- a/src/solace_agent_mesh/agent/adk/setup.py
+++ b/src/solace_agent_mesh/agent/adk/setup.py
@@ -1221,7 +1221,17 @@ def initialize_adk_agent(
         # The callbacks are executed in the order they are added to this list.
         callbacks_in_order_for_after_model = []
 
-        # 1. Fenced Artifact Block Processing (must run before auto-continue)
+        # 1. Pre-register long-running tools (must run BEFORE tool execution)
+        preregister_cb = functools.partial(
+            adk_callbacks.preregister_long_running_tools_callback, host_component=component
+        )
+        callbacks_in_order_for_after_model.append(preregister_cb)
+        log.debug(
+            "%s Added preregister_long_running_tools_callback to after_model chain.",
+            component.log_identifier,
+        )
+
+        # 2. Fenced Artifact Block Processing (must run before auto-continue)
         artifact_block_cb = functools.partial(
             adk_callbacks.process_artifact_blocks_callback, host_component=component
         )
@@ -1231,7 +1241,7 @@ def initialize_adk_agent(
             component.log_identifier,
         )
 
-        # 2. Auto-Continuation (may short-circuit the chain)
+        # 3. Auto-Continuation (may short-circuit the chain)
         auto_continue_cb = functools.partial(
             adk_callbacks.auto_continue_on_max_tokens_callback, host_component=component
         )
@@ -1241,13 +1251,13 @@ def initialize_adk_agent(
             component.log_identifier,
         )
 
-        # 3. Solace LLM Response Logging
+        # 4. Solace LLM Response Logging
         solace_llm_response_cb = functools.partial(
             adk_callbacks.solace_llm_response_callback, host_component=component
         )
         callbacks_in_order_for_after_model.append(solace_llm_response_cb)
 
-        # 4. Chunk Logging
+        # 5. Chunk Logging
         log_chunk_cb = functools.partial(
             adk_callbacks.log_streaming_chunk_callback, host_component=component
         )

--- a/src/solace_agent_mesh/agent/tools/peer_agent_tool.py
+++ b/src/solace_agent_mesh/agent/tools/peer_agent_tool.py
@@ -20,6 +20,7 @@ from ...common.exceptions import MessageSizeExceededError
 
 log = logging.getLogger(__name__)
 
+
 class ArtifactIdentifier(BaseModel):
     """Identifies a specific version of an artifact."""
 
@@ -90,7 +91,10 @@ class PeerAgentTool(BaseTool):
             Enhanced description string with markdown formatting
         """
         # Start with base description - ensure it's clean (no extra whitespace)
-        base_desc = agent_card.description or f"Interact with the {self.target_agent_name} agent."
+        base_desc = (
+            agent_card.description
+            or f"Interact with the {self.target_agent_name} agent."
+        )
         base_desc = " ".join(base_desc.split())  # Normalize whitespace
 
         # Extract skills information
@@ -101,7 +105,7 @@ class PeerAgentTool(BaseTool):
             skill_names = []
             for skill in agent_card.skills[:max_skills_to_show]:
                 # Prefer name, fallback to id
-                skill_name = getattr(skill, 'name', None) or getattr(skill, 'id', None)
+                skill_name = getattr(skill, "name", None) or getattr(skill, "id", None)
                 if skill_name:
                     skill_names.append(skill_name)
 
@@ -113,7 +117,9 @@ class PeerAgentTool(BaseTool):
 
             # Include skill count in the header
             if skill_count > 1:
-                enhanced_desc = f"{base_desc}\n\n**Skills ({skill_count}):** {skills_str}"
+                enhanced_desc = (
+                    f"{base_desc}\n\n**Skills ({skill_count}):** {skills_str}"
+                )
             else:
                 enhanced_desc = f"{base_desc}\n\n**Skills:** {skills_str}"
 
@@ -122,7 +128,9 @@ class PeerAgentTool(BaseTool):
                 # Truncate to first 4 skills to keep it concise
                 skill_names = []
                 for skill in agent_card.skills[:4]:
-                    skill_name = getattr(skill, 'name', None) or getattr(skill, 'id', None)
+                    skill_name = getattr(skill, "name", None) or getattr(
+                        skill, "id", None
+                    )
                     if skill_name:
                         skill_names.append(skill_name)
                 skills_str = ", ".join(skill_names)
@@ -131,7 +139,9 @@ class PeerAgentTool(BaseTool):
                     skills_str += f" ({remaining} more...)"
 
                 if skill_count > 1:
-                    enhanced_desc = f"{base_desc}\n\n**Skills ({skill_count}):** {skills_str}"
+                    enhanced_desc = (
+                        f"{base_desc}\n\n**Skills ({skill_count}):** {skills_str}"
+                    )
                 else:
                     enhanced_desc = f"{base_desc}\n\n**Skills:** {skills_str}"
         else:
@@ -264,13 +274,10 @@ class PeerAgentTool(BaseTool):
                     f"TaskExecutionContext not found for task '{main_logical_task_id}'"
                 )
 
-            task_context_obj.register_parallel_call_sent(invocation_id)
-            log.info(
-                "%s Registered parallel call for invocation %s. Current state: %s",
-                log_identifier,
-                invocation_id,
-                task_context_obj.parallel_tool_calls.get(invocation_id),
-            )
+            # NOTE: register_parallel_call_sent is called in
+            # preregister_long_running_tools_callback (after_model_callback)
+            # BEFORE tool execution begins. This prevents race conditions where
+            # one tool completes before another registers.
 
             a2a_message_parts = self._prepare_a2a_parts(args, tool_context)
             a2a_metadata = {}

--- a/tests/integration/scenarios_declarative/test_data/multi_agent/delegation/test_parallel_peer_delegation.yaml
+++ b/tests/integration/scenarios_declarative/test_data/multi_agent/delegation/test_parallel_peer_delegation.yaml
@@ -1,0 +1,104 @@
+# Test Case: Parallel peer delegation - verifies that multiple peer tools can be called
+# in parallel and their responses are properly combined.
+#
+# This test validates:
+# 1. The preregister_long_running_tools_callback pre-registers all parallel calls before execution
+# 2. Both peer agents process their tasks independently
+# 3. The main agent receives and combines both responses
+#
+# Related to DATAGO-120188: Handle long-running tools better
+test_case_id: "parallel_peer_delegation_001"
+description: "Tests parallel delegation to two peer agents (A and B) in a single LLM turn."
+tags: ["all", "agent", "tools", "delegation"]
+skip_intermediate_events: true
+
+gateway_input:
+  target_agent_name: "TestAgent"
+  user_identity: "parallel_delegation_tester@example.com"
+  prompt:
+    parts:
+      - text: "Please ask TestPeerAgentA to say 'Hello from A' and TestPeerAgentB to say 'Hello from B' at the same time."
+
+llm_interactions:
+  # Turn 1: TestAgent receives the request and delegates to both peers in parallel
+  - static_response:
+      choices:
+        - message:
+            role: "assistant"
+            content: "I'll ask both peer agents simultaneously."
+            tool_calls:
+              - id: "call_peer_a_parallel"
+                type: "function"
+                function:
+                  name: "peer_TestPeerAgentA"
+                  arguments: '{"task_description": "Please say Hello from A"}'
+              - id: "call_peer_b_parallel"
+                type: "function"
+                function:
+                  name: "peer_TestPeerAgentB"
+                  arguments: '{"task_description": "Please say Hello from B"}'
+    expected_request:
+      messages_contain:
+        - role: "user"
+          content_contains: "ask TestPeerAgentA"
+      tools_present:
+        - "peer_TestPeerAgentA"
+        - "peer_TestPeerAgentB"
+
+  # Turn 2: TestPeerAgentA receives its task and responds
+  - static_response:
+      choices:
+        - message:
+            role: "assistant"
+            content: "Hello from A"
+    expected_request:
+      messages_contain:
+        - role: "user"
+          content_contains: "say Hello from A"
+
+  # Turn 3: TestPeerAgentB receives its task and responds
+  - static_response:
+      choices:
+        - message:
+            role: "assistant"
+            content: "Hello from B"
+    expected_request:
+      messages_contain:
+        - role: "user"
+          content_contains: "say Hello from B"
+
+  # Turn 4: TestAgent receives both responses and formulates the final response
+  # Note: Since peer responses arrive asynchronously, we don't validate the exact order.
+  # We only verify that the messages contain the expected content from both peers.
+  - static_response:
+      choices:
+        - message:
+            role: "assistant"
+            content: "Both peer agents responded: TestPeerAgentA said 'Hello from A' and TestPeerAgentB said 'Hello from B'."
+    expected_request:
+      # Validate that both peer responses are present (order may vary due to async)
+      messages_contain:
+        - role: "tool"
+          content_contains: "Hello from A"
+        - role: "tool"
+          content_contains: "Hello from B"
+
+expected_gateway_output:
+  - type: "final_response"
+    kind: task
+    id: '*'
+    contextId: session_parallel_peer_delegation_001
+    status:
+      state: "completed"
+      message:
+        kind: message
+        messageId: '*'
+        role: agent
+        parts:
+          - type: "text"
+            text_contains:
+              - "Both peer agents responded"
+              - "Hello from A"
+              - "Hello from B"
+
+expected_artifacts: []

--- a/tests/integration/scenarios_programmatic/test_parallel_peer_tool_sync_returns.py
+++ b/tests/integration/scenarios_programmatic/test_parallel_peer_tool_sync_returns.py
@@ -1,0 +1,609 @@
+"""
+Programmatic integration tests for parallel peer tool synchronous return handling.
+
+These tests verify the fix for the race condition where parallel long-running tool calls
+could cause the agent to hang if one tool returns synchronously (e.g., validation error)
+while others are still being registered or execute asynchronously.
+
+Related to DATAGO-120188: Handle long-running tools better
+
+Test Strategy:
+- To cause synchronous error returns from PeerAgentTool, we monkeypatch `submit_a2a_task`
+  to raise `MessageSizeExceededError` for specific peer agents.
+- This error is caught in `run_async` and returns `{"status": "error", ...}` synchronously.
+- The monkeypatch happens AFTER tool registration, so it doesn't break the ADK's tool
+  filtering callbacks.
+"""
+
+import pytest
+
+from sam_test_infrastructure.llm_server.server import (
+    TestLLMServer,
+    ChatCompletionResponse,
+    Message,
+    Choice,
+    ToolCall,
+    ToolCallFunction,
+    Usage,
+)
+from sam_test_infrastructure.gateway_interface.component import (
+    TestGatewayComponent,
+)
+from solace_agent_mesh.agent.sac.app import SamAgentApp
+from solace_agent_mesh.agent.sac.component import SamAgentComponent
+from solace_agent_mesh.common.exceptions import MessageSizeExceededError
+from a2a.types import Task, TaskState
+
+from .test_helpers import (
+    prime_llm_server,
+    create_gateway_input_data,
+    submit_test_input,
+    get_all_task_events,
+    find_first_event_of_type,
+)
+
+
+pytestmark = [
+    pytest.mark.all,
+    pytest.mark.asyncio,
+    pytest.mark.agent,
+    pytest.mark.tools,
+]
+
+
+async def test_single_peer_tool_sync_error_no_hang(
+    test_llm_server: TestLLMServer,
+    test_gateway_app_instance: TestGatewayComponent,
+    sam_app_under_test: SamAgentApp,  # noqa: ARG001 - required for fixture setup
+    main_agent_component: SamAgentComponent,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """
+    Test that when a single peer tool returns synchronously with an error,
+    the agent does NOT hang and properly continues execution.
+
+    This validates Bug 1 fix: Agent hangs on synchronous returns.
+
+    Scenario:
+    1. LLM requests a peer tool call (peer_TestPeerAgentA)
+    2. submit_a2a_task raises MessageSizeExceededError
+    3. Tool returns synchronously with error dict
+    4. Agent should NOT hang and should re-run LLM with the error response
+    5. LLM provides final response
+    """
+    scenario_id = "single_peer_sync_error_001"
+    print(f"\nRunning scenario: {scenario_id}")
+
+    # First LLM response: Request a call to peer agent
+    llm_response_peer_call = ChatCompletionResponse(
+        id=f"chatcmpl-{scenario_id}-step1",
+        model="test-model-sam-peer-call",
+        choices=[
+            Choice(
+                message=Message(
+                    role="assistant",
+                    content="I'll ask TestPeerAgentA to help with this.",
+                    tool_calls=[
+                        ToolCall(
+                            id="call_peer_a_sync_error",
+                            type="function",
+                            function=ToolCallFunction(
+                                name="peer_TestPeerAgentA",
+                                arguments='{"task_description": "Help me with this task."}',
+                            ),
+                        )
+                    ],
+                ),
+                finish_reason="tool_calls",
+            )
+        ],
+        usage=Usage(prompt_tokens=10, completion_tokens=8, total_tokens=18),
+    ).model_dump(exclude_none=True)
+
+    # Second LLM response: Process the error and provide final response
+    llm_response_final = ChatCompletionResponse(
+        id=f"chatcmpl-{scenario_id}-step2",
+        model="test-model-sam-final",
+        choices=[
+            Choice(
+                message=Message(
+                    role="assistant",
+                    content="I received an error when trying to contact the peer agent due to message size limits.",
+                ),
+                finish_reason="stop",
+            )
+        ],
+        usage=Usage(prompt_tokens=50, completion_tokens=15, total_tokens=65),
+    ).model_dump(exclude_none=True)
+
+    prime_llm_server(test_llm_server, [llm_response_peer_call, llm_response_final])
+
+    target_agent = "TestAgent"
+    user_identity = f"test_user_{scenario_id}@example.com"
+    input_texts = ["Please ask TestPeerAgentA to help me."]
+
+    test_input_data = create_gateway_input_data(
+        target_agent=target_agent,
+        user_identity=user_identity,
+        text_parts_content=input_texts,
+        scenario_id=scenario_id,
+    )
+
+    # Store original method
+    original_submit_a2a_task = main_agent_component.submit_a2a_task
+
+    # Create a patched method that raises MessageSizeExceededError for TestPeerAgentA
+    def patched_submit_a2a_task(target_agent_name, **kwargs):
+        if target_agent_name == "TestPeerAgentA":
+            raise MessageSizeExceededError("Simulated message size exceeded for testing")
+        return original_submit_a2a_task(target_agent_name=target_agent_name, **kwargs)
+
+    monkeypatch.setattr(main_agent_component, "submit_a2a_task", patched_submit_a2a_task)
+
+    task_id = await submit_test_input(
+        test_gateway_app_instance, test_input_data, scenario_id
+    )
+
+    # Wait for task completion with a reasonable timeout
+    # If the bug is present, this will timeout (hang)
+    all_events = await get_all_task_events(
+        gateway_component=test_gateway_app_instance,
+        task_id=task_id,
+        overall_timeout=15.0,
+    )
+
+    assert all_events, f"Scenario {scenario_id}: No events captured"
+
+    # Find final task response
+    final_task = find_first_event_of_type(all_events, Task, fail_if_not_found=False)
+    assert final_task is not None, f"Scenario {scenario_id}: No final Task event found"
+    assert (
+        final_task.status.state == TaskState.completed
+    ), f"Scenario {scenario_id}: Task not completed, got {final_task.status.state}"
+
+    # Verify we got the expected number of LLM calls (2)
+    captured_requests = test_llm_server.get_captured_requests()
+    assert (
+        len(captured_requests) >= 2
+    ), f"Scenario {scenario_id}: Expected at least 2 LLM calls, got {len(captured_requests)}"
+
+    # Verify the second request contains the error response from the peer tool
+    second_request = captured_requests[1]
+    tool_messages = [
+        msg for msg in second_request.messages if msg.role == "tool"
+    ]
+    assert (
+        len(tool_messages) > 0
+    ), f"Scenario {scenario_id}: Expected tool response in second LLM call"
+
+    # Check that the tool response contains an error about message size
+    tool_response_content = tool_messages[0].content
+    if isinstance(tool_response_content, str):
+        assert "error" in tool_response_content.lower() or "size" in tool_response_content.lower(), (
+            f"Scenario {scenario_id}: Expected error about message size in tool response, got: {tool_response_content}"
+        )
+
+    print(f"Scenario {scenario_id}: Passed - Agent did not hang on sync error")
+
+
+async def test_parallel_peer_tools_all_sync_errors(
+    test_llm_server: TestLLMServer,
+    test_gateway_app_instance: TestGatewayComponent,
+    sam_app_under_test: SamAgentApp,  # noqa: ARG001 - required for fixture setup
+    main_agent_component: SamAgentComponent,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """
+    Test that when ALL parallel peer tools return synchronously with errors,
+    the agent properly re-runs with all error responses.
+
+    This validates the all-sync case in the runner.py fix.
+
+    Scenario:
+    1. LLM requests two parallel peer tool calls
+    2. Both submit_a2a_task calls raise MessageSizeExceededError
+    3. Both tools return synchronously with error dicts
+    4. Agent should re-run LLM with both error responses
+    5. LLM provides final response acknowledging both errors
+    """
+    scenario_id = "parallel_peers_all_sync_error_001"
+    print(f"\nRunning scenario: {scenario_id}")
+
+    # First LLM response: Request calls to two peer agents in parallel
+    llm_response_parallel_calls = ChatCompletionResponse(
+        id=f"chatcmpl-{scenario_id}-step1",
+        model="test-model-sam-parallel",
+        choices=[
+            Choice(
+                message=Message(
+                    role="assistant",
+                    content="I'll ask both peer agents to help.",
+                    tool_calls=[
+                        ToolCall(
+                            id="call_peer_a_parallel",
+                            type="function",
+                            function=ToolCallFunction(
+                                name="peer_TestPeerAgentA",
+                                arguments='{"task_description": "Task for agent A"}',
+                            ),
+                        ),
+                        ToolCall(
+                            id="call_peer_b_parallel",
+                            type="function",
+                            function=ToolCallFunction(
+                                name="peer_TestPeerAgentB",
+                                arguments='{"task_description": "Task for agent B"}',
+                            ),
+                        ),
+                    ],
+                ),
+                finish_reason="tool_calls",
+            )
+        ],
+        usage=Usage(prompt_tokens=10, completion_tokens=12, total_tokens=22),
+    ).model_dump(exclude_none=True)
+
+    # Second LLM response: Process both errors and provide final response
+    llm_response_final = ChatCompletionResponse(
+        id=f"chatcmpl-{scenario_id}-step2",
+        model="test-model-sam-final",
+        choices=[
+            Choice(
+                message=Message(
+                    role="assistant",
+                    content="Both peer agent requests failed due to message size limits.",
+                ),
+                finish_reason="stop",
+            )
+        ],
+        usage=Usage(prompt_tokens=80, completion_tokens=20, total_tokens=100),
+    ).model_dump(exclude_none=True)
+
+    prime_llm_server(test_llm_server, [llm_response_parallel_calls, llm_response_final])
+
+    target_agent = "TestAgent"
+    user_identity = f"test_user_{scenario_id}@example.com"
+    input_texts = ["Please ask both TestPeerAgentA and TestPeerAgentB to help."]
+
+    test_input_data = create_gateway_input_data(
+        target_agent=target_agent,
+        user_identity=user_identity,
+        text_parts_content=input_texts,
+        scenario_id=scenario_id,
+    )
+
+    # Store original method
+    original_submit_a2a_task = main_agent_component.submit_a2a_task
+
+    # Create a patched method that raises MessageSizeExceededError for both peers
+    def patched_submit_a2a_task(target_agent_name, **kwargs):
+        if target_agent_name in ("TestPeerAgentA", "TestPeerAgentB"):
+            raise MessageSizeExceededError(f"Simulated message size exceeded for {target_agent_name}")
+        return original_submit_a2a_task(target_agent_name=target_agent_name, **kwargs)
+
+    monkeypatch.setattr(main_agent_component, "submit_a2a_task", patched_submit_a2a_task)
+
+    task_id = await submit_test_input(
+        test_gateway_app_instance, test_input_data, scenario_id
+    )
+
+    # Wait for task completion
+    # If the bug is present (all sync without re-run), this would hang or error
+    all_events = await get_all_task_events(
+        gateway_component=test_gateway_app_instance,
+        task_id=task_id,
+        overall_timeout=15.0,
+    )
+
+    assert all_events, f"Scenario {scenario_id}: No events captured"
+
+    # Find final task response
+    final_task = find_first_event_of_type(all_events, Task, fail_if_not_found=False)
+    assert final_task is not None, f"Scenario {scenario_id}: No final Task event found"
+    assert (
+        final_task.status.state == TaskState.completed
+    ), f"Scenario {scenario_id}: Task not completed, got {final_task.status.state}"
+
+    # Verify we got the expected number of LLM calls
+    captured_requests = test_llm_server.get_captured_requests()
+    assert (
+        len(captured_requests) >= 2
+    ), f"Scenario {scenario_id}: Expected at least 2 LLM calls, got {len(captured_requests)}"
+
+    # Verify the second request contains BOTH tool error responses
+    second_request = captured_requests[1]
+    tool_messages = [
+        msg for msg in second_request.messages if msg.role == "tool"
+    ]
+    # Should have 2 tool responses (one for each failed peer call)
+    assert (
+        len(tool_messages) >= 2
+    ), f"Scenario {scenario_id}: Expected 2 tool responses in second LLM call, got {len(tool_messages)}"
+
+    print(f"Scenario {scenario_id}: Passed - Agent re-ran with all sync errors")
+
+
+async def test_mixed_sync_async_parallel_peer_tools(
+    test_llm_server: TestLLMServer,
+    test_gateway_app_instance: TestGatewayComponent,
+    sam_app_under_test: SamAgentApp,  # noqa: ARG001 - required for fixture setup
+    main_agent_component: SamAgentComponent,
+    peer_b_component: SamAgentComponent,  # noqa: ARG001 - ensures peer B is running
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """
+    Test that when parallel peer tools return with a mix of sync errors and
+    async responses, the agent properly waits for async and combines all responses.
+
+    This validates the mixed sync/async case in the runner.py fix.
+
+    Scenario:
+    1. LLM requests two parallel peer tool calls (A and B)
+    2. Peer A's submit_a2a_task raises MessageSizeExceededError -> sync error
+    3. Peer B's submit_a2a_task succeeds -> waits for async response
+    4. When B's response arrives, both results are combined and sent to LLM
+    5. LLM provides final response
+    """
+    scenario_id = "mixed_sync_async_001"
+    print(f"\nRunning scenario: {scenario_id}")
+
+    # First LLM response: Request calls to two peer agents in parallel
+    llm_response_parallel_calls = ChatCompletionResponse(
+        id=f"chatcmpl-{scenario_id}-step1",
+        model="test-model-sam-mixed",
+        choices=[
+            Choice(
+                message=Message(
+                    role="assistant",
+                    content="I'll ask both peer agents to help.",
+                    tool_calls=[
+                        ToolCall(
+                            id="call_peer_a_mixed",
+                            type="function",
+                            function=ToolCallFunction(
+                                name="peer_TestPeerAgentA",
+                                arguments='{"task_description": "Task for agent A"}',
+                            ),
+                        ),
+                        ToolCall(
+                            id="call_peer_b_mixed",
+                            type="function",
+                            function=ToolCallFunction(
+                                name="peer_TestPeerAgentB",
+                                arguments='{"task_description": "Task for agent B"}',
+                            ),
+                        ),
+                    ],
+                ),
+                finish_reason="tool_calls",
+            )
+        ],
+        usage=Usage(prompt_tokens=10, completion_tokens=12, total_tokens=22),
+    ).model_dump(exclude_none=True)
+
+    # Second LLM response (for peer agent B): Respond to the task
+    llm_response_peer_b = ChatCompletionResponse(
+        id=f"chatcmpl-{scenario_id}-step2",
+        model="test-model-peerB-response",
+        choices=[
+            Choice(
+                message=Message(
+                    role="assistant",
+                    content="Response from TestPeerAgentB!",
+                ),
+                finish_reason="stop",
+            )
+        ],
+        usage=Usage(prompt_tokens=20, completion_tokens=5, total_tokens=25),
+    ).model_dump(exclude_none=True)
+
+    # Third LLM response: Main agent processes both results (error from A, success from B)
+    llm_response_final = ChatCompletionResponse(
+        id=f"chatcmpl-{scenario_id}-step3",
+        model="test-model-sam-final",
+        choices=[
+            Choice(
+                message=Message(
+                    role="assistant",
+                    content="TestPeerAgentA failed due to message size, but TestPeerAgentB responded successfully.",
+                ),
+                finish_reason="stop",
+            )
+        ],
+        usage=Usage(prompt_tokens=80, completion_tokens=20, total_tokens=100),
+    ).model_dump(exclude_none=True)
+
+    prime_llm_server(
+        test_llm_server,
+        [llm_response_parallel_calls, llm_response_peer_b, llm_response_final],
+    )
+
+    target_agent = "TestAgent"
+    user_identity = f"test_user_{scenario_id}@example.com"
+    input_texts = ["Please ask both TestPeerAgentA and TestPeerAgentB to help."]
+
+    test_input_data = create_gateway_input_data(
+        target_agent=target_agent,
+        user_identity=user_identity,
+        text_parts_content=input_texts,
+        scenario_id=scenario_id,
+    )
+
+    # Store original method
+    original_submit_a2a_task = main_agent_component.submit_a2a_task
+
+    # Create a patched method that raises MessageSizeExceededError for TestPeerAgentA only
+    def patched_submit_a2a_task(target_agent_name, **kwargs):
+        if target_agent_name == "TestPeerAgentA":
+            raise MessageSizeExceededError("Simulated message size exceeded for TestPeerAgentA")
+        return original_submit_a2a_task(target_agent_name=target_agent_name, **kwargs)
+
+    monkeypatch.setattr(main_agent_component, "submit_a2a_task", patched_submit_a2a_task)
+
+    task_id = await submit_test_input(
+        test_gateway_app_instance, test_input_data, scenario_id
+    )
+
+    # Wait for task completion
+    # The agent should wait for B's async response and combine with A's sync error
+    all_events = await get_all_task_events(
+        gateway_component=test_gateway_app_instance,
+        task_id=task_id,
+        overall_timeout=30.0,  # Allow time for async inter-agent communication
+    )
+
+    assert all_events, f"Scenario {scenario_id}: No events captured"
+
+    # Find final task response
+    final_task = find_first_event_of_type(all_events, Task, fail_if_not_found=False)
+    assert final_task is not None, f"Scenario {scenario_id}: No final Task event found"
+    assert (
+        final_task.status.state == TaskState.completed
+    ), f"Scenario {scenario_id}: Task not completed, got {final_task.status.state}"
+
+    # Verify we got the expected number of LLM calls
+    captured_requests = test_llm_server.get_captured_requests()
+    # Should have at least 3 calls: main parallel request, peer B response, main combines results
+    assert (
+        len(captured_requests) >= 3
+    ), f"Scenario {scenario_id}: Expected at least 3 LLM calls, got {len(captured_requests)}"
+
+    # Verify the third request contains BOTH tool responses
+    # (sync error from A stored earlier, async success from B)
+    third_request = captured_requests[2]
+    tool_messages = [
+        msg for msg in third_request.messages if msg.role == "tool"
+    ]
+    # Should have 2 tool responses (error from A + success from B)
+    assert (
+        len(tool_messages) >= 2
+    ), f"Scenario {scenario_id}: Expected 2 tool responses in third LLM call, got {len(tool_messages)}"
+
+    print(f"Scenario {scenario_id}: Passed - Agent combined sync error with async response")
+
+
+async def test_successful_parallel_peer_delegation(
+    test_llm_server: TestLLMServer,
+    test_gateway_app_instance: TestGatewayComponent,
+    sam_app_under_test: SamAgentApp,  # noqa: ARG001 - required for test fixture setup
+    main_agent_component: SamAgentComponent,  # noqa: ARG001 - may be used for debugging
+    peer_a_component: SamAgentComponent,  # noqa: ARG001 - ensures peer agent is running
+):
+    """
+    Test that the preregister_long_running_tools_callback properly pre-registers
+    all peer tool calls before execution begins, and parallel delegation works correctly.
+
+    This validates Bug 2 fix: Race condition in registration - ensures pre-registration
+    happens atomically before any tool execution.
+
+    Scenario:
+    1. LLM requests a peer tool call
+    2. The preregistration callback should be invoked
+    3. The tool should complete successfully (async response via broker)
+    4. LLM processes the response
+    """
+    scenario_id = "successful_parallel_delegation_001"
+    print(f"\nRunning scenario: {scenario_id}")
+
+    # First LLM response: Request a peer tool call
+    llm_response_peer_call = ChatCompletionResponse(
+        id=f"chatcmpl-{scenario_id}-step1",
+        model="test-model-sam-prereg",
+        choices=[
+            Choice(
+                message=Message(
+                    role="assistant",
+                    content="I'll delegate this to TestPeerAgentA.",
+                    tool_calls=[
+                        ToolCall(
+                            id="call_peer_a_prereg",
+                            type="function",
+                            function=ToolCallFunction(
+                                name="peer_TestPeerAgentA",
+                                arguments='{"task_description": "Say hello"}',
+                            ),
+                        )
+                    ],
+                ),
+                finish_reason="tool_calls",
+            )
+        ],
+        usage=Usage(prompt_tokens=10, completion_tokens=8, total_tokens=18),
+    ).model_dump(exclude_none=True)
+
+    # Second LLM response (for peer agent A): Respond to the task
+    llm_response_peer_a = ChatCompletionResponse(
+        id=f"chatcmpl-{scenario_id}-step2",
+        model="test-model-peerA-response",
+        choices=[
+            Choice(
+                message=Message(
+                    role="assistant",
+                    content="Hello from TestPeerAgentA!",
+                ),
+                finish_reason="stop",
+            )
+        ],
+        usage=Usage(prompt_tokens=20, completion_tokens=5, total_tokens=25),
+    ).model_dump(exclude_none=True)
+
+    # Third LLM response: Main agent processes peer response
+    llm_response_final = ChatCompletionResponse(
+        id=f"chatcmpl-{scenario_id}-step3",
+        model="test-model-sam-final",
+        choices=[
+            Choice(
+                message=Message(
+                    role="assistant",
+                    content="TestPeerAgentA responded with: Hello!",
+                ),
+                finish_reason="stop",
+            )
+        ],
+        usage=Usage(prompt_tokens=50, completion_tokens=10, total_tokens=60),
+    ).model_dump(exclude_none=True)
+
+    prime_llm_server(
+        test_llm_server,
+        [llm_response_peer_call, llm_response_peer_a, llm_response_final],
+    )
+
+    target_agent = "TestAgent"
+    user_identity = f"test_user_{scenario_id}@example.com"
+    input_texts = ["Please ask TestPeerAgentA to say hello."]
+
+    test_input_data = create_gateway_input_data(
+        target_agent=target_agent,
+        user_identity=user_identity,
+        text_parts_content=input_texts,
+        scenario_id=scenario_id,
+    )
+
+    task_id = await submit_test_input(
+        test_gateway_app_instance, test_input_data, scenario_id
+    )
+
+    # Wait for task completion
+    all_events = await get_all_task_events(
+        gateway_component=test_gateway_app_instance,
+        task_id=task_id,
+        overall_timeout=30.0,  # Allow more time for inter-agent communication
+    )
+
+    assert all_events, f"Scenario {scenario_id}: No events captured"
+
+    # Find final task response
+    final_task = find_first_event_of_type(all_events, Task, fail_if_not_found=False)
+    assert final_task is not None, f"Scenario {scenario_id}: No final Task event found"
+    assert (
+        final_task.status.state == TaskState.completed
+    ), f"Scenario {scenario_id}: Task not completed, got {final_task.status.state}"
+
+    # Verify LLM was called the expected number of times
+    captured_requests = test_llm_server.get_captured_requests()
+    # Should have at least 3 calls: main->peer request, peer response, main processes peer response
+    assert (
+        len(captured_requests) >= 3
+    ), f"Scenario {scenario_id}: Expected at least 3 LLM calls, got {len(captured_requests)}"
+
+    print(f"Scenario {scenario_id}: Passed - Preregistration and delegation worked correctly")


### PR DESCRIPTION
## Summary

- Fix race condition where parallel long-running peer tool calls could cause the agent to hang or produce incorrect results
- Pre-register all long-running tool calls atomically BEFORE tool execution begins
- Properly handle synchronous error returns from peer tools (e.g., `MessageSizeExceededError`)

## Problem

Two bugs existed in the parallel peer tool execution flow:

### Bug 1: Agent Hangs on Synchronous Returns
When a peer tool returned synchronously (e.g., validation error, message size exceeded), the `is_paused` flag was set to `True` but never cleared. This caused the agent to hang forever waiting for an async response that had already arrived synchronously.

### Bug 2: Race Condition in Registration
Tools called `register_parallel_call_sent()` inside their `run_async()` method. Since tools execute via `asyncio.gather` (non-deterministic order), if Tool A completed before Tool B even registered, the system incorrectly thought all calls were done (completed=1, total=1).

## Solution

1. **Pre-registration callback** (`callbacks.py`): New `preregister_long_running_tools_callback` runs as an `after_model_callback` BEFORE tool execution begins, registering all peer tool calls atomically.

2. **Proper sync response tracking** (`runner.py`): Replace simple `is_paused` boolean with `pending_long_running_tools` set and `sync_tool_responses` list to properly track which tools are still pending vs. returned synchronously.

3. **Handle all-sync case** (`runner.py`): When ALL peer tools return synchronously, re-run the ADK immediately with the error responses instead of waiting forever.

4. **Remove redundant registration** (`peer_agent_tool.py`): Remove the `register_parallel_call_sent()` call from inside the tool since it's now handled by the callback.

## Test plan

- [x] Run `test_parallel_peer_delegation.yaml` - validates parallel peer delegation happy path
- [x] Run `test_parallel_peer_tool_sync_returns.py` - 4 tests covering:
  - Single peer tool sync error (validates Bug 1 fix)
  - All parallel peer tools sync errors (validates all-sync re-run)
  - Mixed sync/async parallel peer tools (validates mixed case handling)
  - Successful parallel delegation (validates Bug 2 fix - preregistration)
- [x] Run existing delegation tests to ensure no regressions
