### PR TITLE
fix: Register exception handlers in Platform Service for proper error responses

### DIFF
--- a/src/solace_agent_mesh/services/platform/api/main.py
+++ b/src/solace_agent_mesh/services/platform/api/main.py
@@ -342,6 +342,10 @@ def _setup_routers():
     except Exception as e:
         log.warning(f"Failed to load enterprise platform routers: {e}")
 
+    from solace_agent_mesh.shared.exceptions.exception_handlers import register_exception_handlers
+    register_exception_handlers(app)
+    log.info("Registered shared exception handlers")
+
 
 @app.get("/health", tags=["Health"])
 async def health_check():


### PR DESCRIPTION
## Summary

The Platform Service was not registering exception handlers, causing custom exceptions like `BusinessRuleViolationError` to return generic 500 errors instead of formatted JSON responses with clear error messages.

This resulted in poor UX where the frontend showed "failed to fetch" instead of helpful messages like "deployer is offline".

## Changes

- Added `register_exception_handlers(app)` call in Platform Service `_setup_routers()`
- Matches the pattern already used in WebUI Gateway
- Enables proper error response formatting for all custom exceptions

## Impact

Now when business rule violations or other errors occur, the API returns:
- ✅ Proper HTTP status codes (422 for validation, 404 for not found, etc.)
- ✅ JSON responses with clear `message` field
- ✅ Consistent error format across all endpoints

## Example

**Before:**
```
Status: 500
Body: Internal Server Error (generic)
UI: "failed to fetch"
```

**After:**
```
Status: 422
Body: {"message": "Cannot perform deploy operation: deployer is offline. Please ensure the deployer service is running."}
UI: Shows the actual error message
```

## Test Plan

- [ ] Deploy an agent with deployer offline - should show clear error message
- [ ] Trigger validation errors - should show field-level details
- [ ] Verify 404, 409, 422 status codes return proper JSON responses