### PR TITLE
feat(DATAGO-114389): PR 5c: Workflow Runtime - Advanced Node Types

### DIFF
--- a/src/solace_agent_mesh/workflow/agent_caller.py
+++ b/src/solace_agent_mesh/workflow/agent_caller.py
@@ -1,0 +1,347 @@
+"""
+AgentCaller component for invoking agents via A2A.
+"""
+
+import logging
+import uuid
+import re
+import json
+from datetime import datetime, timezone
+from typing import Any, Dict, Optional, TYPE_CHECKING
+
+from a2a.types import MessageSendParams, SendMessageRequest, Message as A2AMessage
+
+from ..common import a2a
+from ..common.data_parts import StructuredInvocationRequest
+from ..common.agent_card_utils import get_schemas_from_agent_card
+from ..agent.utils.artifact_helpers import (
+    save_artifact_with_metadata,
+    format_artifact_uri,
+)
+from .app import WorkflowNode
+from .workflow_execution_context import WorkflowExecutionContext, WorkflowExecutionState
+
+if TYPE_CHECKING:
+    from .component import WorkflowExecutorComponent
+
+log = logging.getLogger(__name__)
+
+
+class AgentCaller:
+    """Manages A2A calls to agents from workflow."""
+
+    def __init__(self, host_component: "WorkflowExecutorComponent"):
+        self.host = host_component
+
+    async def call_agent(
+        self,
+        node: WorkflowNode,
+        workflow_state: WorkflowExecutionState,
+        workflow_context: WorkflowExecutionContext,
+        sub_task_id: Optional[str] = None,
+    ) -> str:
+        """
+        Invoke an agent for a workflow node.
+        Returns sub-task ID for correlation.
+        """
+        log_id = f"{self.host.log_identifier}[CallAgent:{node.agent_name}]"
+
+        # Generate sub-task ID if not provided
+        if not sub_task_id:
+            sub_task_id = (
+                f"wf_{workflow_state.execution_id}_{node.id}_{uuid.uuid4().hex[:8]}"
+            )
+        # Resolve input data
+        input_data = await self._resolve_node_input(node, workflow_state)
+
+        # Get schemas from agent card extensions if available
+        agent_card = self.host.agent_registry.get_agent(node.agent_name)
+        card_input_schema, card_output_schema = get_schemas_from_agent_card(agent_card)
+
+        # Use override schemas if provided, otherwise use schemas from agent card
+        input_schema = node.input_schema_override or card_input_schema
+        output_schema = node.output_schema_override or card_output_schema
+
+        # Construct A2A message
+        message = await self._construct_agent_message(
+            node,
+            input_data,
+            input_schema,
+            output_schema,
+            workflow_state,
+            sub_task_id,
+            workflow_context,
+        )
+
+        # Publish request
+        await self._publish_agent_request(
+            node.agent_name, message, sub_task_id, workflow_context
+        )
+
+        # Track in workflow context
+        workflow_context.track_agent_call(node.id, sub_task_id)
+
+        return sub_task_id
+
+    async def _resolve_node_input(
+        self, node: WorkflowNode, workflow_state: WorkflowExecutionState
+    ) -> Dict[str, Any]:
+        """
+        Resolve input mapping for a node.
+        If input is not provided, infer it from dependencies.
+        """
+        # Case 1: Explicit Input Mapping
+        if node.input is not None:
+            resolved_input = {}
+            for key, value in node.input.items():
+                # Use DAGExecutor's resolve_value to handle templates and operators
+                resolved_value = self.host.dag_executor.resolve_value(
+                    value, workflow_state
+                )
+                resolved_input[key] = resolved_value
+            return resolved_input
+
+        # Case 2: Implicit Input Inference
+        log.debug(
+            f"{self.host.log_identifier} Node '{node.id}' has no explicit input. Inferring from dependencies."
+        )
+
+        # Case 2a: No dependencies (Initial Node) -> Use Workflow Input
+        if not node.depends_on:
+            if "workflow_input" not in workflow_state.node_outputs:
+                raise ValueError("Workflow input has not been initialized")
+            return workflow_state.node_outputs["workflow_input"]["output"]
+
+        # Case 2b: Single Dependency -> Use Dependency Output
+        if len(node.depends_on) == 1:
+            dep_id = node.depends_on[0]
+
+            # Check if dependency is a conditional node
+            dep_node = self.host.dag_executor.nodes.get(dep_id)
+            if dep_node and dep_node.type == "conditional":
+                log.debug(
+                    f"{self.host.log_identifier} Node '{node.id}' depends on conditional '{dep_id}'. Using workflow input."
+                )
+                if "workflow_input" not in workflow_state.node_outputs:
+                    raise ValueError("Workflow input has not been initialized")
+                return workflow_state.node_outputs["workflow_input"]["output"]
+
+            if dep_id not in workflow_state.node_outputs:
+                raise ValueError(f"Dependency '{dep_id}' has not completed")
+            return workflow_state.node_outputs[dep_id]["output"]
+
+        # Case 2c: Multiple Dependencies -> Ambiguous
+        raise ValueError(
+            f"Node '{node.id}' has multiple dependencies {node.depends_on} but no explicit 'input' mapping. "
+            "Implicit input inference is only supported for nodes with 0 or 1 dependency. "
+            "Please provide an explicit 'input' mapping."
+        )
+
+    def _generate_result_embed_reminder(
+        self, output_schema: Optional[Dict[str, Any]]
+    ) -> str:
+        """Generate user-facing reminder about result embed requirement."""
+        if output_schema:
+            return """
+REMINDER: When you complete this task, you MUST end your response with:
+«result:artifact=<your_artifact_name>:<version> status=success»
+
+For example: «result:artifact=analysis_results.json:0 status=success»
+
+This is required for the workflow to continue. Without this result embed, the workflow will fail.
+"""
+        else:
+            return """
+REMINDER: When you complete this task, you MUST end your response with:
+«result:artifact=<your_artifact_name>:<version> status=success»
+
+This is MANDATORY for the workflow to continue.
+"""
+
+    async def _construct_agent_message(
+        self,
+        node: WorkflowNode,
+        input_data: Dict[str, Any],
+        input_schema: Optional[Dict[str, Any]],
+        output_schema: Optional[Dict[str, Any]],
+        workflow_state: WorkflowExecutionState,
+        sub_task_id: str,
+        workflow_context: WorkflowExecutionContext,
+    ) -> A2AMessage:
+        """Construct A2A message for agent."""
+
+        # Build message parts
+        parts = []
+
+        # Generate unique output filename for this workflow node
+        # Use last 8 chars of sub_task_id for uniqueness (contains UUID)
+        unique_suffix = sub_task_id[-8:] if len(sub_task_id) >= 8 else sub_task_id
+        # Sanitize workflow name (replace spaces/special chars with underscore)
+        safe_workflow_name = re.sub(
+            r"[^a-zA-Z0-9_-]", "_", workflow_state.workflow_name
+        )
+        # node.id already includes iteration index for map nodes (e.g., "generate_data_0")
+        suggested_output_filename = f"{safe_workflow_name}_{node.id}_{unique_suffix}.json"
+
+        # 1. Structured invocation request (must be first)
+        invocation_request = StructuredInvocationRequest(
+            type="structured_invocation_request",
+            workflow_name=workflow_state.workflow_name,
+            node_id=node.id,
+            input_schema=input_schema,
+            output_schema=output_schema,
+            suggested_output_filename=suggested_output_filename,
+        )
+        parts.append(a2a.create_data_part(data=invocation_request.model_dump()))
+
+        # Determine if we should send as structured artifact or text
+        should_send_artifact = False
+        if input_schema:
+            # Check if it's NOT a single text schema
+            is_single_text = (
+                input_schema.get("type") == "object"
+                and len(input_schema.get("properties", {})) == 1
+                and "text" in input_schema.get("properties", {})
+                and input_schema["properties"]["text"].get("type") == "string"
+            )
+            should_send_artifact = not is_single_text
+
+        if should_send_artifact:
+            # Create and save input artifact
+            filename = f"input_{node.id}_{sub_task_id}.json"
+            content_bytes = json.dumps(input_data).encode("utf-8")
+            user_id = workflow_context.a2a_context["user_id"]
+            session_id = workflow_context.a2a_context["session_id"]
+
+            try:
+                save_result = await save_artifact_with_metadata(
+                    artifact_service=self.host.artifact_service,
+                    app_name=self.host.workflow_name,
+                    user_id=user_id,
+                    session_id=session_id,
+                    filename=filename,
+                    content_bytes=content_bytes,
+                    mime_type="application/json",
+                    metadata_dict={
+                        "description": f"Input for node {node.id}",
+                        "source": "workflow_execution",
+                    },
+                    timestamp=datetime.now(timezone.utc),
+                )
+
+                if save_result["status"] == "success":
+                    version = save_result["data_version"]
+                    uri = format_artifact_uri(
+                        app_name=self.host.workflow_name,
+                        user_id=user_id,
+                        session_id=session_id,
+                        filename=filename,
+                        version=version,
+                    )
+                    parts.append(
+                        a2a.create_file_part_from_uri(
+                            uri=uri, name=filename, mime_type="application/json"
+                        )
+                    )
+                    log.info(
+                        f"{self.host.log_identifier} Created input artifact for node {node.id}: {filename}"
+                    )
+                else:
+                    raise RuntimeError(
+                        f"Failed to save input artifact: {save_result.get('message')}"
+                    )
+
+            except Exception as e:
+                log.error(
+                    f"{self.host.log_identifier} Error saving input artifact for node {node.id}: {e}"
+                )
+                raise e
+
+        else:
+            # Send as text/data parts (Chat Mode)
+            if "query" in input_data:
+                parts.append(a2a.create_text_part(text=input_data["query"]))
+            elif "text" in input_data:
+                parts.append(a2a.create_text_part(text=input_data["text"]))
+            else:
+                # Fallback for unstructured data without 'query'/'text' keys
+                text_parts = []
+                for key, value in input_data.items():
+                    text_parts.append(f"{key}: {value}")
+                if text_parts:
+                    parts.append(a2a.create_text_part(text="\n".join(text_parts)))
+
+        # Add reminder about result embed requirement
+        reminder_text = self._generate_result_embed_reminder(output_schema)
+        parts.append(a2a.create_text_part(text=reminder_text))
+
+        # Construct message using helper function
+        # Use the original workflow session ID as context_id so that RUN_BASED sessions
+        # will be created as {workflow_session_id}:{sub_task_id}:run, allowing the workflow
+        # to find artifacts saved by the node using get_original_session_id()
+        message = a2a.create_user_message(
+            parts=parts,
+            task_id=sub_task_id,
+            context_id=workflow_context.a2a_context["session_id"],
+            metadata={
+                "workflow_name": workflow_state.workflow_name,
+                "node_id": node.id,
+                "sub_task_id": sub_task_id,
+                "parentTaskId": workflow_context.workflow_task_id,
+            },
+        )
+
+        return message
+
+    async def _publish_agent_request(
+        self,
+        agent_name: str,
+        message: A2AMessage,
+        sub_task_id: str,
+        workflow_context: WorkflowExecutionContext,
+    ):
+        """Publish A2A request to agent."""
+        log_id = f"{self.host.log_identifier}[PublishAgentRequest:{agent_name}]"
+
+        # Get agent request topic
+        request_topic = a2a.get_agent_request_topic(self.host.namespace, agent_name)
+
+        # Create SendMessageRequest
+        send_params = MessageSendParams(message=message)
+        a2a_request = SendMessageRequest(id=sub_task_id, params=send_params)
+
+        # Construct reply-to and status topics
+        reply_to_topic = a2a.get_agent_response_topic(
+            self.host.namespace, self.host.workflow_name, sub_task_id
+        )
+        status_topic = a2a.get_peer_agent_status_topic(
+            self.host.namespace, self.host.workflow_name, sub_task_id
+        )
+
+        # User properties
+        user_properties = {
+            "replyTo": reply_to_topic,
+            "a2aStatusTopic": status_topic,
+            "userId": workflow_context.a2a_context["user_id"],
+            "a2aUserConfig": workflow_context.a2a_context.get("a2a_user_config", {}),
+        }
+
+        # Publish request
+        self.host.publish_a2a_message(
+            payload=a2a_request.model_dump(by_alias=True, exclude_none=True),
+            topic=request_topic,
+            user_properties=user_properties,
+        )
+
+        log.debug(
+            f"{log_id} Published agent request to {request_topic} (sub_task_id: {sub_task_id})"
+        )
+
+        # Set timeout tracking
+        timeout_seconds = self.host.get_config("default_node_timeout_seconds", 300)
+        self.host.cache_service.add_data(
+            key=sub_task_id,
+            value=workflow_context.workflow_task_id,
+            expiry=timeout_seconds,
+            component=self.host,
+        )


### PR DESCRIPTION
# PR 5c: Workflow Runtime - Advanced Node Types

## Overview

This PR completes the DAG executor with advanced node types: switch (multi-way branching), loop (while iteration), and map (parallel for-each). It also includes the AgentCaller for A2A communication with agents.

## Branch Information

- **Branch Name:** `pr/workflows-5c-advanced-nodes`
- **Target:** `pr/workflows-5b-dag-core`

## Files Changed

### `src/solace_agent_mesh/workflow/dag_executor.py` (lines ~700-1382)

Advanced node execution methods:

| Method | Purpose |
|--------|---------|
| `_execute_switch_node()` | Multi-way branching (first match wins) |
| `_execute_loop_node()` | While-loop iteration |
| `_execute_map_node()` | Parallel for-each iteration |
| `_launch_map_iterations()` | Launch map iterations with concurrency |
| `_skip_branch()` | Mark unexecuted branches as skipped |
| `resolve_value()` | Resolve template expressions |
| `handle_node_completion()` | Process node completion, trigger next nodes |
| `_finalize_map_node()` | Aggregate map results |

### `src/solace_agent_mesh/workflow/agent_caller.py`

Agent invocation via A2A (~350 lines):

| Method | Purpose |
|--------|---------|
| `call_agent()` | Main entry point for agent invocation |
| `_resolve_node_input()` | Resolve input templates |
| `_construct_agent_message()` | Build A2A message |
| `_create_input_artifact()` | Store input as artifact |
| `_publish_agent_request()` | Send message via broker |

## Key Concepts

### Switch Node Execution

Multi-way branching evaluates cases in order:

```yaml
- id: router
  type: switch
  cases:
    - when: "'{{step1.output.type}}' == 'urgent'"
      then: urgent_handler
    - when: "'{{step1.output.type}}' == 'normal'"
      then: normal_handler
  default: fallback_handler
```

```
1. Evaluate each case condition in order
2. First matching case wins
3. Non-matching branches are marked SKIPPED
4. If no match, use default (or skip all)
```

### Loop Node Execution

While-loop with "do-while" semantics:

```yaml
- id: retry_loop
  type: loop
  node: retry_attempt
  condition: "'{{retry_attempt.output.status}}' != 'success'"
  max_iterations: 5
  delay: "5s"
```

```
1. First iteration runs unconditionally
2. After each iteration, evaluate condition
3. Continue while condition is true
4. Apply delay between iterations
5. Stop at max_iterations
```

**Iteration tracking:**
- `_loop_iteration`: Current iteration index
- Results from each iteration update node outputs

### Map Node Execution

Parallel for-each with concurrency control:

```yaml
- id: process_items
  type: map
  items: "{{step1.output.items}}"
  node: process_single
  concurrency_limit: 3
  max_items: 100
```

```
1. Resolve items array from template
2. Initialize map state (pending, active, completed)
3. Launch iterations up to concurrency_limit
4. As iterations complete, launch more
5. When all complete, aggregate results
```

**Iteration context:**
- `_map_item`: Current item being processed
- `_map_index`: Index of current item
- Each iteration gets unique node ID: `process_items_0`, `process_items_1`, etc.

### Value Resolution

The `resolve_value()` method handles:

1. **Simple templates**: `"{{step1.output.field}}"`
2. **Nested paths**: `"{{step1.output.data.items[0].name}}"`
3. **Special variables**:
   - `workflow.input.*`: Workflow input data
   - `_map_item`: Current map iteration item
   - `_map_index`: Current map iteration index
   - `_loop_iteration`: Current loop iteration

### Node Completion Handling

`handle_node_completion()` processes agent responses:

1. Match response to node via correlation ID
2. Extract result from `StructuredInvocationResult`
3. Store output in `node_outputs`
4. Mark node as completed
5. For map nodes: aggregate results, check if all done
6. For loop nodes: re-evaluate condition, continue or stop
7. Trigger `execute_workflow()` to process next nodes

### Agent Caller Flow

```
1. Resolve input templates
2. Get schemas from agent card
3. Create input artifact
4. Build A2A message with:
   - StructuredInvocationRequest data part
   - FilePart referencing input artifact
5. Publish to agent request topic
6. Track correlation ID
```