### PR TITLE
fix(DATAGO-120298): Investigate and fix garbled conversation displayed in AI Assistant

### DIFF
--- a/client/webui/frontend/src/lib/components/chat/PromptsCommand.tsx
+++ b/client/webui/frontend/src/lib/components/chat/PromptsCommand.tsx
@@ -102,11 +102,13 @@ export const PromptsCommand: React.FC<PromptsCommandProps> = ({ isOpen, onClose,
             .filter(m => !m.isStatusBubble && !m.isError && !m.authenticationLink)
             .map(m => {
                 const role = m.isUser ? "User" : "Assistant";
+                // Join text parts with empty string to preserve streaming text continuity
+                // (streaming text is stored as multiple text parts, one per chunk)
                 const text =
                     m.parts
                         ?.filter(p => p.kind === "text")
                         .map(p => (p as { text: string }).text)
-                        .join("\n") || "";
+                        .join("") || "";
                 return `${role}: ${text}`;
             })
             .join("\n\n");


### PR DESCRIPTION
This pull request refines how prompt text is handled and improves the logic for displaying update badges in the template preview panel. The main improvements include making streaming text display more continuous and simplifying the tracking of updates and field highlights.

**Prompt text handling:**

* Changed the way streaming prompt text is joined in `PromptsCommand.tsx` to use an empty string instead of a newline, ensuring smooth streaming text continuity for user and assistant messages.

**Template preview panel logic:**

* Removed unnecessary `useEffect` and simplified the state tracking in `TemplatePreviewPanel.tsx` by using refs to count updates and track highlighted fields, making the logic more straightforward and less error-prone.
* Adjusted the condition for showing badges to only display them after the first update, improving the user experience when highlighting updated fields.
* Cleaned up imports by removing unused `useEffect` from `TemplatePreviewPanel.tsx`.