### PR TITLE
fix(DATAGO-120511) FE | Fix double scroll issue in project side panel

### DIFF
--- a/client/webui/frontend/src/lib/components/projects/KnowledgeSection.tsx
+++ b/client/webui/frontend/src/lib/components/projects/KnowledgeSection.tsx
@@ -242,7 +242,7 @@ export const KnowledgeSection: React.FC<KnowledgeSectionProps> = ({ project }) =
                             <Upload className={`mx-auto mb-1 h-5 w-5 transition-colors ${isDragging ? "text-primary" : "text-muted-foreground"}`} />
                             <p className={`text-xs transition-colors ${isDragging ? "text-primary font-medium" : "text-muted-foreground"}`}>{isDragging ? "Drop files here to upload" : "Drag and drop files here to upload"}</p>
                         </div>
-                        <div className="max-h-[400px] space-y-1 overflow-y-auto rounded-md">
+                        <div className="space-y-1 rounded-md">
                             {sortedArtifacts.map(artifact => (
                                 <DocumentListItem
                                     key={artifact.filename}


### PR DESCRIPTION
This pull request makes a small UI change to the `KnowledgeSection` component. It removes the `max-h-[400px]` and `overflow-y-auto` classes from the container that displays uploaded artifacts, so the list will no longer have a maximum height or scroll bar.

* Removed scrolling and maximum height restriction from the artifact list container in `KnowledgeSection.tsx`