### PR TITLE
fix(DATAGO-117142): adding await to ensure logout doesn't get logged immediately back in

### DIFF
--- a/client/webui/frontend/src/lib/components/navigation/NavigationList.tsx
+++ b/client/webui/frontend/src/lib/components/navigation/NavigationList.tsx
@@ -21,15 +21,17 @@ export const NavigationList: React.FC<NavigationListProps> = ({ items, bottomIte
     // When authorization is enabled, show menu with user info and settings/logout
     const { configUseAuthorization, configFeatureEnablement } = useConfigContext();
     const logoutEnabled = configUseAuthorization && configFeatureEnablement?.logout ? true : false;
+
     const { userInfo, logout } = useAuthContext();
+    const userName = typeof userInfo?.username === "string" ? userInfo.username : "Guest";
 
     const handleSettingsClick = () => {
         setMenuOpen(false);
         setSettingsDialogOpen(true);
     };
-    const handleLogoutClick = () => {
+    const handleLogoutClick = async () => {
         setMenuOpen(false);
-        logout();
+        await logout();
     };
 
     return (
@@ -76,8 +78,10 @@ export const NavigationList: React.FC<NavigationListProps> = ({ items, bottomIte
                             </Tooltip>
                             <PopoverContent side="right" align="end" className="w-60 p-0">
                                 <div className="flex items-center gap-2 border-b px-3 py-4">
-                                    <User className="size-4" />
-                                    <span className="text-sm font-medium">{typeof userInfo?.username === "string" ? userInfo.username : "Guest"}</span>
+                                    <User className="size-4 shrink-0" />
+                                    <div className="min-w-0 truncate text-sm font-medium" title={userName}>
+                                        {userName}
+                                    </div>
                                 </div>
                                 <Menu
                                     actions={[

--- a/client/webui/frontend/src/stories/SettingsDialog.stories.tsx
+++ b/client/webui/frontend/src/stories/SettingsDialog.stories.tsx
@@ -47,7 +47,7 @@ const meta = {
             },
         },
         authContext: {
-            userInfo: { username: "Story Username" },
+            userInfo: { username: "Story Username With a Very Long Name" },
         },
     },
     decorators: [
@@ -191,7 +191,7 @@ export const Logout = {
         await within(document.body).findByRole("menuitem", { name: "Settings" });
 
         // Verify user name  and logout menu item
-        await within(document.body).findByText("Story Username");
+        await within(document.body).findByText(/Story Username/i);
         const logoutButton = await within(document.body).findByRole("menuitem", { name: "Log Out" });
         await expect(logoutButton).toBeInTheDocument();
     },


### PR DESCRIPTION
### What is the purpose of this change?

    Logging out was logging back in immediately (also fixing overflow of long name)

### How was this change implemented?

   Adding await to ensure logout doesn't get logged immediately back in (via a useEffect re-rending) and truncating long names

### How was this change tested?

- [ ] Manual testing: [describe scenarios]
- [x] Unit tests: [new/modified tests]
- [ ] Integration tests: [if applicable]
- [ ] Known limitations: [what wasn't tested] => Needs manual testing in deployed enterprise version.

### Is there anything the reviewers should focus on/be aware of?

    There's a feature flag as this flow will not be revealed until logging out has been tested more broadly.
