### PR TITLE
feat(DATAGO-116403): add sam_access_token validation to middleware

### DIFF
--- a/src/solace_agent_mesh/shared/auth/middleware.py
+++ b/src/solace_agent_mesh/shared/auth/middleware.py
@@ -268,6 +268,11 @@ def create_oauth_middleware(component):
                             gateway_context={},
                             roles=roles,
                         )
+                    else:
+                        log.warning(
+                            "AuthMiddleware: Access token is enabled and provided but authorization service not available. "
+                            "Cannot resolve scopes for sam_access_token."
+                        )
 
                     request.state.user = {
                         "id": claims["sub"],


### PR DESCRIPTION
## Summary
- Add sam_access_token validation to middleware before falling back to IdP token
- Extract roles from token, resolve scopes via authorization_service
- Feature flag controlled via `trust_manager.access_token_enabled`
- Fully backwards compatible with existing IdP token flow

## Test plan
- [x] Unit tests for middleware sam_access_token validation (in enterprise repo)
- [x] Manual test with feature flag enabled
- [x] Manual test with feature flag disabled (verify IdP fallback)

🤖 Generated with [Claude Code](https://claude.com/claude-code)