### PR TITLE
feat(DATAGO-119367): Add wide logs for auditing MCP server usage

### DIFF
--- a/src/solace_agent_mesh/agent/adk/embed_resolving_mcp_toolset.py
+++ b/src/solace_agent_mesh/agent/adk/embed_resolving_mcp_toolset.py
@@ -76,6 +76,18 @@ def _get_base_mcp_tool_class() -> tuple[type[MCPTool], bool]:
 _BaseMcpToolClass, _base_supports_tool_config = _get_base_mcp_tool_class()
 
 
+def _log_mcp_tool_call(userId, agentId, tool_name, session_id):
+    """ A short log message so that customers can track tool usage per user/agent """
+    log.info(
+        "MCP Tool Call - UserID: %s, AgentID: %s, ToolName: %s, SessionID: %s",
+        userId,
+        agentId,
+        tool_name,
+        session_id,
+        extra={"user_id": userId, "agent_id": agentId, "tool_name": tool_name, "session_id": session_id },
+    )
+
+
 class EmbedResolvingMCPTool(_BaseMcpToolClass):
     """
     Custom MCPTool that resolves embeds in parameters before calling the actual MCP tool.
@@ -285,6 +297,7 @@ class EmbedResolvingMCPTool(_BaseMcpToolClass):
 
         # Get context for embed resolution - pass the tool_context object directly
         context_for_embeds = tool_context
+        _log_mcp_tool_call(tool_context.session.user_id, tool_context.agent_name, self.name, tool_context.session.id)
 
         if context_for_embeds:
             log.debug(


### PR DESCRIPTION
### What is the purpose of this change?

Adds structured logging for MCP tool calls to enable tracking and auditing of tool usage per user and agent.

### How was this change implemented?

Added `_log_mcp_tool_call` function in `embed_resolving_mcp_toolset.py` that creates info-level logs with structured fields (user_id, agent_id, tool_name, session_id). Called before tool execution in `EmbedResolvingMCPTool.call_tool`.

### How was this change tested?

- [x] Manual testing: Deploy to test environment and verify logs appear when MCP tools are called

### Is there anything the reviewers should focus on/be aware of?

Verify the structured fields in the `extra` parameter are sufficient for auditing needs. Log level is INFO to ensure visibility without debug mode.