### PR TITLE
ci(DATAGO-120987): fix release workflow with skipped security checks

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -191,6 +191,7 @@ jobs:
   build_and_push_docker:
     name: Build and Push to DockerHub
     needs: release
+    if: always() && (needs.release.result == 'success')
     uses: SolaceLabs/solace-agent-mesh/.github/workflows/build-push-dockerhub.yml@main
     with:
       version: ${{ needs.release.outputs.new_version }}


### PR DESCRIPTION
### What is the purpose of this change?

 Fix dockerhub push job being 

### How was this change implemented?

When any job in the dependency chain is skipped, downstream jobs without if: always() are automatically skipped, even if their direct dependency succeeded.
So we need to use `always()` with a condition


### How was this change tested?

- [x] [Manual testing: [describe scenarios]](https://github.com/SolaceLabs/solace-agent-mesh/actions/runs/20757317178/job/59602804310)
- [x] Unit tests: [new/modified tests]
- [x] Integration tests: [if applicable]
- [ ] Known limitations: [what wasn't tested]

### Is there anything the reviewers should focus on/be aware of?

    Special attention areas, potential risks, or open questions
