### PR TITLE
fix(DATAGO-121085): Adding Platform OAuth Callback endpoint to list of skipped paths

### DIFF
--- a/src/solace_agent_mesh/shared/auth/middleware.py
+++ b/src/solace_agent_mesh/shared/auth/middleware.py
@@ -189,6 +189,7 @@ def create_oauth_middleware(component):
                 "/api/v1/auth/login",
                 "/api/v1/auth/refresh",
                 "/api/v1/csrf-token",
+                "/api/v1/platform/mcp/oauth/callback",
                 "/health",
             ]
 


### PR DESCRIPTION
### What is the purpose of this change?

Allows MCP OAuth callback endpoint to receive redirects from external OAuth providers without requiring authentication (fixes "Not authenticated" errors during OAuth flow).

### How was this change implemented?

**Single Line Change:**
- `src/solace_agent_mesh/shared/auth/middleware.py`: Added `/api/v1/platform/mcp/oauth/callback` to `skip_paths` list

### Key Design Decisions

OAuth providers redirect to callback URLs without authentication credentials. The callback endpoint must be publicly accessible to complete the OAuth flow, then validates the OAuth `state` parameter for CSRF protection.

### How was this change tested?

- [x] Manual testing: Successfully completed OAuth flow with Miro MCP server
- [ ] Unit tests: No middleware tests exist
- [ ] Integration tests: Existing MCP OAuth integration tests should pass
- [ ] Known limitations: Only tested with MCP OAuth flows

### Is there anything the reviewers should focus on/be aware of?

**Security**: The endpoint is protected by OAuth state parameter validation - no user authentication needed at callback time since the external provider redirects without our session context.
