### PR TITLE
feat(DATAGO-121143): Exclude Platform Service health endpoint from authentication

### DIFF
--- a/src/solace_agent_mesh/shared/auth/middleware.py
+++ b/src/solace_agent_mesh/shared/auth/middleware.py
@@ -190,6 +190,7 @@ def create_oauth_middleware(component):
                 "/api/v1/auth/refresh",
                 "/api/v1/csrf-token",
                 "/api/v1/platform/mcp/oauth/callback",
+                "/api/v1/platform/health",
                 "/health",
             ]
 


### PR DESCRIPTION
## Summary
- Added `/api/v1/platform/health` to the list of paths that skip OAuth authentication
- This allows load balancers (ALB, NGINX) and monitoring systems (Kubernetes probes, external monitors) to check Platform Service health without requiring authentication

## Changes
- Modified `src/solace_agent_mesh/shared/auth/middleware.py` to include `/api/v1/platform/health` in the `skip_paths` list

## Behavior
- **Platform Service health endpoint** (`/api/v1/platform/health`): ✅ No authentication required
- **Gateway health endpoints** (`/api/v1/platform/gateways/health`, `/api/v1/platform/gateways/{id}/health`): 🔒 Authentication still required
- **Gateway discovery endpoint** (`/api/v1/platform/gateways`): 🔒 Authentication still required

## Rationale
The Platform Service health endpoint is designed for infrastructure monitoring and should be accessible without authentication to ensure:
- Load balancers can perform health checks
- Kubernetes liveness/readiness probes work correctly
- External monitoring systems can track service availability

Gateway monitoring endpoints remain protected as they expose operational data about the gateway fleet.

## Test Plan
- [ ] Verify `/api/v1/platform/health` is accessible without authentication
- [ ] Verify gateway health endpoints still require authentication
- [ ] Test with load balancer health checks
- [ ] Test Kubernetes probe configuration if deployed

🤖 Generated with [Claude Code](https://claude.com/claude-code)