### PR TITLE
fix(DATAGO-117142): clearing tokens and tidying empty states

### DIFF
--- a/client/webui/frontend/src/lib/providers/AuthProvider.tsx
+++ b/client/webui/frontend/src/lib/providers/AuthProvider.tsx
@@ -3,6 +3,7 @@ import React, { useState, useEffect, type ReactNode } from "react";
 import { api } from "@/lib/api";
 import { AuthContext } from "@/lib/contexts/AuthContext";
 import { useConfigContext, useCsrfContext } from "@/lib/hooks";
+import { EmptyState } from "../components";
 
 interface AuthProviderProps {
     children: ReactNode;
@@ -74,25 +75,21 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
         try {
             if (configUseAuthorization) {
                 await api.webui.post("/api/v1/auth/logout");
+                setIsAuthenticated(false);
+                setUserInfo(null);
+                clearCsrfToken();
+
+                // Clear tokens from localStorage - set in authCallback.tsx
+                localStorage.removeItem("access_token");
+                localStorage.removeItem("refresh_token");
             }
         } catch (error) {
             console.error("Error calling logout endpoint:", error);
-        } finally {
-            setIsAuthenticated(false);
-            setUserInfo(null);
-            clearCsrfToken();
         }
     };
 
     if (isLoading) {
-        return (
-            <div className="flex min-h-screen items-center justify-center bg-white dark:bg-gray-900">
-                <div className="text-center">
-                    <div className="border-solace-green mx-auto mb-4 h-12 w-12 animate-spin rounded-full border-b-2"></div>
-                    <h1 className="text-2xl text-black dark:text-white">Checking Authentication...</h1>
-                </div>
-            </div>
-        );
+        return <EmptyState variant="loading" title="Checking Authentication..." className="h-screen w-screen" />;
     }
 
     return (

--- a/client/webui/frontend/src/lib/providers/ConfigProvider.tsx
+++ b/client/webui/frontend/src/lib/providers/ConfigProvider.tsx
@@ -167,26 +167,12 @@ export function ConfigProvider({ children }: Readonly<ConfigProviderProps>) {
 
     // If config is not yet available, handle loading and error states.
     if (loading) {
-        return (
-            <div className="flex min-h-screen items-center justify-center bg-white dark:bg-gray-900">
-                <div className="text-center">
-                    <div className="border-solace-green mx-auto mb-4 h-12 w-12 animate-spin rounded-full border-b-2"></div>
-                    <h1 className="text-2xl text-black dark:text-white">Loading Configuration...</h1>
-                </div>
-            </div>
-        );
+        return <EmptyState variant="loading" title="Loading Configuration..." className="h-screen w-screen" />;
     }
 
     if (error) {
-        return <EmptyState className="h-screen w-screen" variant="error" title="Configuration Error" subtitle="Please check the backend server and network connection, then refresh the page." />;
+        return <EmptyState variant="error" title="Configuration Error" subtitle="Please check the backend server and network connection, then refresh the page." className="h-screen w-screen" />;
     }
 
-    return (
-        <div className="flex min-h-screen items-center justify-center bg-white dark:bg-gray-900">
-            <div className="text-center">
-                <div className="border-solace-green mx-auto mb-4 h-12 w-12 animate-spin rounded-full border-b-2"></div>
-                <h1 className="text-2xl">Initializing Application...</h1>
-            </div>
-        </div>
-    );
+    return <EmptyState variant="loading" title="Initializing Application..." className="h-screen w-screen" />;
 }


### PR DESCRIPTION
### What is the purpose of this change?

Clearing access tokens on logout (and unrelated swapping out custom code for empty state component)
   
### How was this change implemented?

    High-level approach - what files/components changed and why?
This pull request refactors the loading and error state UI in both the `AuthProvider` and `ConfigProvider` components to use the shared `EmptyState` component, improving code consistency and reusability. Additionally, the logout logic in `AuthProvider` is updated to ensure tokens are properly cleared from localStorage.

UI consistency and code reuse:

* Replaced custom loading and error state markup in `AuthProvider.tsx` and `ConfigProvider.tsx` with the shared `EmptyState` component for all loading and error scenarios. [[1]](diffhunk://#diff-8b359133dc616535b6c6ac8f33cbfe43fc5ac561c6c7ecff9692c7adec44e13eL77-R92) [[2]](diffhunk://#diff-1702a9ee3bb92cc283449909be944ce1b923189f086422419ea7a656171fba37L170-R177)
* Updated import statements to include `EmptyState` from the shared components directory in `AuthProvider.tsx`.

Authentication logic improvements:

* Enhanced the logout process in `AuthProvider.tsx` to clear `access_token` and `refresh_token` from localStorage, in addition to resetting authentication state and CSRF token.


### How was this change tested?

- [ ] Manual testing: [describe scenarios]
- [ ] Unit tests: [new/modified tests]
- [ ] Integration tests: [if applicable]
- [ ] Known limitations: [what wasn't tested]

### Is there anything the reviewers should focus on/be aware of?

   Only testable in deployed instance, but still protected by config feature flag so will be unused until working.
