### PR TITLE
feat: add cors_allowed_origin_regex config for Platform Service

### DIFF
--- a/src/solace_agent_mesh/services/platform/api/main.py
+++ b/src/solace_agent_mesh/services/platform/api/main.py
@@ -232,14 +232,20 @@ def _setup_middleware(component: "PlatformServiceComponent"):
     # Combine and deduplicate
     allowed_origins = list(set(auto_trusted_origins + configured_origins))
 
+    # Get optional regex pattern for CORS origins (useful for local dev with dynamic ports)
+    cors_origin_regex = component.get_cors_origin_regex()
+
     app.add_middleware(
         CORSMiddleware,
         allow_origins=allowed_origins,
+        allow_origin_regex=cors_origin_regex if cors_origin_regex else None,
         allow_credentials=True,
         allow_methods=["*"],
         allow_headers=["*"],
     )
     log.info(f"CORS middleware added with origins: {allowed_origins}")
+    if cors_origin_regex:
+        log.info(f"  CORS origin regex pattern: {cors_origin_regex}")
     if auto_trusted_origins:
         log.info(f"  Auto-added trusted origins: {auto_trusted_origins}")
 

--- a/src/solace_agent_mesh/services/platform/app.py
+++ b/src/solace_agent_mesh/services/platform/app.py
@@ -90,6 +90,13 @@ class PlatformServiceApp(App):
             "description": "List of allowed origins for CORS requests.",
         },
         {
+            "name": "cors_allowed_origin_regex",
+            "required": False,
+            "type": "string",
+            "default": "",
+            "description": "Regex pattern for allowed CORS origins. Useful for local development with dynamic ports (e.g., 'https?://(localhost|127\\.0\\.0\\.1):\\\\d+').",
+        },
+        {
             "name": "external_auth_service_url",
             "required": False,
             "type": "string",

--- a/src/solace_agent_mesh/services/platform/component.py
+++ b/src/solace_agent_mesh/services/platform/component.py
@@ -115,6 +115,7 @@ class PlatformServiceComponent(SamComponentBase):
             self.ssl_certfile = self.get_config("ssl_certfile", "")
             self.ssl_keyfile_password = self.get_config("ssl_keyfile_password", "")
             self.cors_allowed_origins = self.get_config("cors_allowed_origins", ["*"])
+            self.cors_allowed_origin_regex = self.get_config("cors_allowed_origin_regex", "")
 
             # OAuth2 configuration (enterprise feature - defaults to community mode)
             self.external_auth_service_url = self.get_config("external_auth_service_url", "")
@@ -577,6 +578,15 @@ class PlatformServiceComponent(SamComponentBase):
             List of allowed origin strings.
         """
         return self.cors_allowed_origins
+
+    def get_cors_origin_regex(self) -> str:
+        """
+        Return the configured CORS allowed origin regex pattern.
+
+        Returns:
+            Regex pattern string, or empty string if not configured.
+        """
+        return self.cors_allowed_origin_regex
 
     def get_namespace(self) -> str:
         """

--- a/tests/unit/services/platform/test_cors_auto_construction.py
+++ b/tests/unit/services/platform/test_cors_auto_construction.py
@@ -18,6 +18,7 @@ def mock_component():
     """Mock PlatformServiceComponent."""
     component = MagicMock()
     component.get_cors_origins.return_value = ["http://localhost:3000"]
+    component.get_cors_origin_regex.return_value = ""
     component.get_config.return_value = False
     return component
 
@@ -57,6 +58,12 @@ def _get_cors_allowed_origins(mock_fastapi_app):
     """Helper to get CORS allowed origins from the first add_middleware call."""
     cors_call = mock_fastapi_app.add_middleware.call_args_list[0]
     return cors_call[1]["allow_origins"]
+
+
+def _get_cors_origin_regex(mock_fastapi_app):
+    """Helper to get CORS origin regex from the first add_middleware call."""
+    cors_call = mock_fastapi_app.add_middleware.call_args_list[0]
+    return cors_call[1].get("allow_origin_regex")
 
 
 class TestPlatformServiceCorsAutoConstruction:
@@ -218,3 +225,44 @@ class TestPlatformServiceCorsAutoConstruction:
         allowed_origins = _get_cors_allowed_origins(mock_fastapi_app)
 
         assert "https://localhost:9443" in allowed_origins
+
+    def test_cors_origin_regex_not_set_by_default(
+        self, mock_fastapi_app, mock_component, clean_env
+    ):
+        """Test that CORS origin regex is None when not configured."""
+        clean_env.setenv("FASTAPI_HOST", "127.0.0.1")
+        clean_env.setenv("FASTAPI_PORT", "8000")
+
+        _setup_middleware(mock_component)
+
+        cors_regex = _get_cors_origin_regex(mock_fastapi_app)
+
+        assert cors_regex is None
+
+    def test_cors_origin_regex_passed_to_middleware(
+        self, mock_fastapi_app, mock_component, clean_env
+    ):
+        """Test that CORS origin regex is passed to CORSMiddleware when configured."""
+        clean_env.setenv("FASTAPI_HOST", "127.0.0.1")
+        clean_env.setenv("FASTAPI_PORT", "8000")
+        mock_component.get_cors_origin_regex.return_value = r"https?://(localhost|127\.0\.0\.1):\d+"
+
+        _setup_middleware(mock_component)
+
+        cors_regex = _get_cors_origin_regex(mock_fastapi_app)
+
+        assert cors_regex == r"https?://(localhost|127\.0\.0\.1):\d+"
+
+    def test_cors_origin_regex_empty_string_becomes_none(
+        self, mock_fastapi_app, mock_component, clean_env
+    ):
+        """Test that empty string regex is converted to None."""
+        clean_env.setenv("FASTAPI_HOST", "127.0.0.1")
+        clean_env.setenv("FASTAPI_PORT", "8000")
+        mock_component.get_cors_origin_regex.return_value = ""
+
+        _setup_middleware(mock_component)
+
+        cors_regex = _get_cors_origin_regex(mock_fastapi_app)
+
+        assert cors_regex is None


### PR DESCRIPTION
## Summary

- Add `cors_allowed_origin_regex` config option to Platform Service
- Enables regex-based CORS origin matching for local development scenarios
- Useful when ports are dynamically assigned (e.g., `minikube service`)

## Problem

When using `minikube service` or other tools that assign random ports, CORS fails because the origin (e.g., `http://localhost:52341`) is not in the allowed origins list.

## Solution

Add support for Starlette's `allow_origin_regex` parameter in CORSMiddleware. Users can configure a regex pattern like:

```yaml
cors_allowed_origin_regex: "https?://(localhost|127\\.0\\.0\\.1):\\d+"
```

This matches any localhost port without needing to know the port in advance.

## Changes

- `app.py`: Add `cors_allowed_origin_regex` config schema
- `component.py`: Add instance variable and getter method
- `api/main.py`: Pass `allow_origin_regex` to CORSMiddleware
- `test_cors_auto_construction.py`: Add unit tests

## Test plan

- [x] Unit tests pass (13/13)
- [ ] Manual test with minikube random ports

🤖 Generated with [Claude Code](https://claude.com/claude-code)