### PR TITLE
fix(DATAGO-118655) - Auth Enabled MCP gateway (part 2)

### DIFF
--- a/src/solace_agent_mesh/gateway/generic/component.py
+++ b/src/solace_agent_mesh/gateway/generic/component.py
@@ -324,6 +324,8 @@ class GenericGatewayComponent(BaseGatewayComponent, GatewayContext):
             log.info(
                 "%s Authenticated user: %s", log_id_prefix, user_identity.get("id")
             )
+            # Add user_id to external_input so adapter can use it for permission checks.
+            external_input["user_id"] = user_identity.get("id")
 
             # 2. Task Preparation
             sam_task = await self.adapter.prepare_task(external_input, endpoint_context)


### PR DESCRIPTION
### What is the purpose of this change?

Fixed missing user_id argument - which later is expected to be in external_input for adapter to pull user permissions
see expecting codebase: https://github.com/SolaceLabs/solace-agent-mesh-core-plugins/blob/fa4707ef3717e5cbcea587c390e00b50441eaa66/sam-mcp-server-gateway-adapter/src/sam_mcp_server_gateway_adapter/adapter.py#L345

### How was this change implemented?

    added the missing arg for downstream consumer to be able to pull data from.

### Key Design Decisions _(optional - delete if not applicable)_

    Why did you choose this approach over alternatives?

### How was this change tested?

- [x] Manual testing: [describe scenarios]
This setup requires, spinning SAMe -with mcp gateway enabled + configured, can be reproduced only on stag/beta - since in local dev these args are pre-populated with fallback args.

- [ ] Unit tests: [new/modified tests]
- [ ] Integration tests: [if applicable]
- [ ] Known limitations: [what wasn't tested]

### Is there anything the reviewers should focus on/be aware of?

    - This is used for brand new flow.
