### PR TITLE
chore(DATAGO-121520): Add instruction field to workflow agent nodes

### DIFF
--- a/examples/agents/all_node_types_workflow.yaml
+++ b/examples/agents/all_node_types_workflow.yaml
@@ -872,6 +872,11 @@ apps:
             type: agent
             agent_name: "CustomerEnricher"
             depends_on: [validate_order]
+            # Demonstrates the 'instruction' field for providing workflow-specific guidance
+            instruction: |
+              You are being invoked as part of an order processing workflow.
+              Enrich the customer data with tier and discount information.
+              This data will be used by downstream nodes to calculate discounts.
             input:
               customer_id: "{{workflow.input.customer_id}}"
 

--- a/src/solace_agent_mesh/workflow/app.py
+++ b/src/solace_agent_mesh/workflow/app.py
@@ -122,6 +122,7 @@ class AgentNode(WorkflowNode):
     - `when`: Conditional execution clause (Argo-style)
     - `retryStrategy`: Retry configuration
     - `timeout`: Node-specific timeout override
+    - `instruction`: Optional guidance text sent to the target agent
     """
 
     type: Literal["agent"] = "agent"
@@ -129,6 +130,14 @@ class AgentNode(WorkflowNode):
     input: Optional[Dict[str, Any]] = Field(
         default=None,
         description="Input mapping. If omitted, inferred from dependencies.",
+    )
+    instruction: Optional[str] = Field(
+        default=None,
+        description=(
+            "Optional instruction/guidance text sent to the target agent. "
+            "Supports template expressions like '{{workflow.input.context}}'. "
+            "Provides context for how the agent should process the request."
+        ),
     )
 
     # Optional schema overrides

--- a/src/solace_agent_mesh/workflow/workflow_schema.json
+++ b/src/solace_agent_mesh/workflow/workflow_schema.json
@@ -147,6 +147,10 @@
           "description": "Input mapping for the agent. Supports template expressions like '{{workflow.input.field}}' or '{{other_node.output.field}}'. If omitted, inferred from dependencies.",
           "additionalProperties": true
         },
+        "instruction": {
+          "type": "string",
+          "description": "Optional instruction/guidance text sent to the target agent. Supports template expressions like '{{workflow.input.context}}' or '{{previous_node.output.instructions}}'. Provides context for how the agent should process the request."
+        },
         "input_schema_override": {
           "$ref": "#/$defs/jsonSchema",
           "description": "Override the agent's default input schema for this invocation."

--- a/tests/unit/workflow/test_workflow_agent_card.py
+++ b/tests/unit/workflow/test_workflow_agent_card.py
@@ -311,3 +311,68 @@ class TestWorkflowConfigJson:
 
         assert len(config["nodes"]) == 4
         assert len(config["nodes"]) == len(workflow.nodes)
+
+
+class TestAgentNodeInstruction:
+    """Tests for AgentNode instruction field."""
+
+    def test_agent_node_with_instruction(self):
+        """AgentNode accepts instruction field."""
+        node = AgentNode(
+            id="analyze",
+            type="agent",
+            agent_name="DataAnalyzer",
+            instruction="Analyze this data using statistical methods.",
+        )
+        assert node.instruction == "Analyze this data using statistical methods."
+
+    def test_agent_node_instruction_optional(self):
+        """AgentNode works without instruction field."""
+        node = AgentNode(
+            id="analyze",
+            type="agent",
+            agent_name="DataAnalyzer",
+        )
+        assert node.instruction is None
+
+    def test_agent_node_with_template_instruction(self):
+        """AgentNode accepts template expressions in instruction."""
+        node = AgentNode(
+            id="process",
+            type="agent",
+            agent_name="Processor",
+            instruction="Process using context: {{workflow.input.context}}",
+        )
+        assert "{{workflow.input.context}}" in node.instruction
+
+    def test_workflow_with_instruction_parses(self):
+        """Workflow with instruction in agent node parses correctly."""
+        workflow = WorkflowDefinition(
+            description="Test workflow",
+            nodes=[
+                AgentNode(
+                    id="step1",
+                    type="agent",
+                    agent_name="Agent1",
+                    instruction="{{workflow.input.context}}",
+                ),
+            ],
+            output_mapping={"result": "{{step1.output}}"},
+        )
+        assert workflow.nodes[0].instruction == "{{workflow.input.context}}"
+
+    def test_agent_node_with_multiline_instruction(self):
+        """AgentNode accepts multiline instruction."""
+        instruction = """You are being invoked as part of a workflow.
+Please follow these guidelines:
+1. Be thorough
+2. Be concise
+3. Be accurate"""
+        node = AgentNode(
+            id="analyze",
+            type="agent",
+            agent_name="Analyzer",
+            instruction=instruction,
+        )
+        assert node.instruction == instruction
+        assert "Be thorough" in node.instruction


### PR DESCRIPTION
## Summary
- Add optional `instruction` field to workflow agent nodes that allows workflow creators to provide additional context/guidance to target agents
- The instruction supports template expressions (e.g., `{{workflow.input.context}}`) that are resolved at runtime
- Add integration test validating that instruction with template expression is properly resolved and appears in LLM requests

## Changes
- Add `instruction` field to `AgentNode` model in `app.py`
- Add `_resolve_string_with_templates()` method in `agent_caller.py` to handle embedded templates within strings
- Update `workflow_schema.json` with `instruction` property documentation
- Add unit tests for instruction field parsing
- Add integration test validating instruction appears in LLM requests with resolved templates
- Add example usage in `all_node_types_workflow.yaml`
- Fix deprecated `conditional` node type in test fixtures (converted to `switch`)

## Test plan
- [x] Unit tests pass: `pytest tests/unit/workflow/ -v` (133 tests)
- [x] Integration test passes: `pytest tests/integration/scenarios_programmatic/test_workflow_errors.py::test_workflow_instruction_appears_in_llm_request -v`
- [x] Integration test validates:
  - Static instruction text appears in LLM request
  - Template expression `{{workflow.input.context}}` is resolved to actual value
  - Unresolved template placeholder does NOT appear (proving resolution worked)