### PR TITLE
test(DATAGO-120269): Add unit testing to frontend

### DIFF
--- a/client/webui/frontend/.storybook/vitest.setup.ts
+++ b/client/webui/frontend/.storybook/vitest.setup.ts
@@ -1,6 +1,22 @@
 import { setProjectAnnotations } from "@storybook/react-vite";
 import * as projectAnnotations from "./preview";
 
+// Official workaround for "TypeError: window.matchMedia is not a function"
+// https://jestjs.io/docs/manual-mocks#mocking-methods-which-are-not-implemented-in-jsdom
+Object.defineProperty(window, "matchMedia", {
+    writable: true,
+    value: (query: any) => ({
+        matches: false,
+        media: query,
+        onchange: null,
+        addListener: () => {}, // deprecated
+        removeListener: () => {}, // deprecated
+        addEventListener: () => {},
+        removeEventListener: () => {},
+        dispatchEvent: () => {},
+    }),
+});
+
 // This is an important step to apply the right configuration when testing your stories.
 // More info at: https://storybook.js.org/docs/api/portable-stories/portable-stories-vitest#setprojectannotations
 setProjectAnnotations([projectAnnotations]);

--- a/client/webui/frontend/package-lock.json
+++ b/client/webui/frontend/package-lock.json
@@ -53,10 +53,13 @@
                 "@a2a-js/sdk": "^0.3.2",
                 "@eslint/js": "^9.25.0",
                 "@storybook/addon-vitest": "^10.1.10",
+                "@storybook/react": "^10.1.8",
                 "@storybook/react-vite": "^10.1.10",
                 "@tailwindcss/typography": "^0.5.16",
                 "@tanstack/eslint-plugin-query": "5.91.2",
                 "@testing-library/cypress": "^10.0.3",
+                "@testing-library/jest-dom": "^6.9.1",
+                "@testing-library/react": "^16.3.0",
                 "@types/js-yaml": "^4.0.9",
                 "@types/node": "^22.15.29",
                 "@types/react": "19.0.0",
@@ -70,6 +73,7 @@
                 "eslint-plugin-react-refresh": "^0.4.19",
                 "eslint-plugin-storybook": "^10.1.10",
                 "globals": "^16.0.0",
+                "jsdom": "^27.0.1",
                 "lint-staged": "^16.2.3",
                 "mocha-junit-reporter": "^2.2.1",
                 "msw": "^2.12.3",
@@ -139,6 +143,13 @@
                 "uuid": "dist/esm/bin/uuid"
             }
         },
+        "node_modules/@acemir/cssom": {
+            "version": "0.9.31",
+            "resolved": "https://registry.npmjs.org/@acemir/cssom/-/cssom-0.9.31.tgz",
+            "integrity": "sha512-ZnR3GSaH+/vJ0YlHau21FjfLYjMpYVIzTD8M8vIEQvIGxeOXyXdzCI140rrCY862p/C/BbzWsjc1dgnM9mkoTA==",
+            "dev": true,
+            "license": "MIT"
+        },
         "node_modules/@adobe/css-tools": {
             "version": "4.4.4",
             "dev": true,
@@ -154,6 +165,61 @@
             "engines": {
                 "node": ">=6.0.0"
             }
+        },
+        "node_modules/@asamuzakjp/css-color": {
+            "version": "4.1.1",
+            "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-4.1.1.tgz",
+            "integrity": "sha512-B0Hv6G3gWGMn0xKJ0txEi/jM5iFpT3MfDxmhZFb4W047GvytCf1DHQ1D69W3zHI4yWe2aTZAA0JnbMZ7Xc8DuQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@csstools/css-calc": "^2.1.4",
+                "@csstools/css-color-parser": "^3.1.0",
+                "@csstools/css-parser-algorithms": "^3.0.5",
+                "@csstools/css-tokenizer": "^3.0.4",
+                "lru-cache": "^11.2.4"
+            }
+        },
+        "node_modules/@asamuzakjp/css-color/node_modules/lru-cache": {
+            "version": "11.2.4",
+            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.4.tgz",
+            "integrity": "sha512-B5Y16Jr9LB9dHVkh6ZevG+vAbOsNOYCX+sXvFWFu7B3Iz5mijW3zdbMyhsh8ANd2mSWBYdJgnqi+mL7/LrOPYg==",
+            "dev": true,
+            "license": "BlueOak-1.0.0",
+            "engines": {
+                "node": "20 || >=22"
+            }
+        },
+        "node_modules/@asamuzakjp/dom-selector": {
+            "version": "6.7.6",
+            "resolved": "https://registry.npmjs.org/@asamuzakjp/dom-selector/-/dom-selector-6.7.6.tgz",
+            "integrity": "sha512-hBaJER6A9MpdG3WgdlOolHmbOYvSk46y7IQN/1+iqiCuUu6iWdQrs9DGKF8ocqsEqWujWf/V7b7vaDgiUmIvUg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@asamuzakjp/nwsapi": "^2.3.9",
+                "bidi-js": "^1.0.3",
+                "css-tree": "^3.1.0",
+                "is-potential-custom-element-name": "^1.0.1",
+                "lru-cache": "^11.2.4"
+            }
+        },
+        "node_modules/@asamuzakjp/dom-selector/node_modules/lru-cache": {
+            "version": "11.2.4",
+            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.4.tgz",
+            "integrity": "sha512-B5Y16Jr9LB9dHVkh6ZevG+vAbOsNOYCX+sXvFWFu7B3Iz5mijW3zdbMyhsh8ANd2mSWBYdJgnqi+mL7/LrOPYg==",
+            "dev": true,
+            "license": "BlueOak-1.0.0",
+            "engines": {
+                "node": "20 || >=22"
+            }
+        },
+        "node_modules/@asamuzakjp/nwsapi": {
+            "version": "2.3.9",
+            "resolved": "https://registry.npmjs.org/@asamuzakjp/nwsapi/-/nwsapi-2.3.9.tgz",
+            "integrity": "sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==",
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/@babel/code-frame": {
             "version": "7.27.1",
@@ -410,6 +476,141 @@
         "node_modules/@bcoe/v8-coverage": {
             "version": "1.0.2",
             "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@csstools/color-helpers": {
+            "version": "5.1.0",
+            "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-5.1.0.tgz",
+            "integrity": "sha512-S11EXWJyy0Mz5SYvRmY8nJYTFFd1LCNV+7cXyAgQtOOuzb4EsgfqDufL+9esx72/eLhsRdGZwaldu/h+E4t4BA==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/csstools"
+                },
+                {
+                    "type": "opencollective",
+                    "url": "https://opencollective.com/csstools"
+                }
+            ],
+            "license": "MIT-0",
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@csstools/css-calc": {
+            "version": "2.1.4",
+            "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-2.1.4.tgz",
+            "integrity": "sha512-3N8oaj+0juUw/1H3YwmDDJXCgTB1gKU6Hc/bB502u9zR0q2vd786XJH9QfrKIEgFlZmhZiq6epXl4rHqhzsIgQ==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/csstools"
+                },
+                {
+                    "type": "opencollective",
+                    "url": "https://opencollective.com/csstools"
+                }
+            ],
+            "license": "MIT",
+            "engines": {
+                "node": ">=18"
+            },
+            "peerDependencies": {
+                "@csstools/css-parser-algorithms": "^3.0.5",
+                "@csstools/css-tokenizer": "^3.0.4"
+            }
+        },
+        "node_modules/@csstools/css-color-parser": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-3.1.0.tgz",
+            "integrity": "sha512-nbtKwh3a6xNVIp/VRuXV64yTKnb1IjTAEEh3irzS+HkKjAOYLTGNb9pmVNntZ8iVBHcWDA2Dof0QtPgFI1BaTA==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/csstools"
+                },
+                {
+                    "type": "opencollective",
+                    "url": "https://opencollective.com/csstools"
+                }
+            ],
+            "license": "MIT",
+            "dependencies": {
+                "@csstools/color-helpers": "^5.1.0",
+                "@csstools/css-calc": "^2.1.4"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "peerDependencies": {
+                "@csstools/css-parser-algorithms": "^3.0.5",
+                "@csstools/css-tokenizer": "^3.0.4"
+            }
+        },
+        "node_modules/@csstools/css-parser-algorithms": {
+            "version": "3.0.5",
+            "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-3.0.5.tgz",
+            "integrity": "sha512-DaDeUkXZKjdGhgYaHNJTV9pV7Y9B3b644jCLs9Upc3VeNGg6LWARAT6O+Q+/COo+2gg/bM5rhpMAtf70WqfBdQ==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/csstools"
+                },
+                {
+                    "type": "opencollective",
+                    "url": "https://opencollective.com/csstools"
+                }
+            ],
+            "license": "MIT",
+            "engines": {
+                "node": ">=18"
+            },
+            "peerDependencies": {
+                "@csstools/css-tokenizer": "^3.0.4"
+            }
+        },
+        "node_modules/@csstools/css-syntax-patches-for-csstree": {
+            "version": "1.0.25",
+            "resolved": "https://registry.npmjs.org/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.0.25.tgz",
+            "integrity": "sha512-g0Kw9W3vjx5BEBAF8c5Fm2NcB/Fs8jJXh85aXqwEXiL+tqtOut07TWgyaGzAAfTM+gKckrrncyeGEZPcaRgm2Q==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/csstools"
+                },
+                {
+                    "type": "opencollective",
+                    "url": "https://opencollective.com/csstools"
+                }
+            ],
+            "license": "MIT-0",
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@csstools/css-tokenizer": {
+            "version": "3.0.4",
+            "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-3.0.4.tgz",
+            "integrity": "sha512-Vd/9EVDiu6PPJt9yAh6roZP6El1xHrdvIVGjyBsHR0RYwNHgL7FJPyIIW4fANJNG6FtyZfvlRPpFI4ZM/lubvw==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/csstools"
+                },
+                {
+                    "type": "opencollective",
+                    "url": "https://opencollective.com/csstools"
+                }
+            ],
             "license": "MIT",
             "engines": {
                 "node": ">=18"
@@ -673,6 +874,24 @@
             },
             "engines": {
                 "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+            }
+        },
+        "node_modules/@exodus/bytes": {
+            "version": "1.8.0",
+            "resolved": "https://registry.npmjs.org/@exodus/bytes/-/bytes-1.8.0.tgz",
+            "integrity": "sha512-8JPn18Bcp8Uo1T82gR8lh2guEOa5KKU/IEKvvdp0sgmi7coPBWf1Doi1EXsGZb2ehc8ym/StJCjffYV+ne7sXQ==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+            },
+            "peerDependencies": {
+                "@exodus/crypto": "^1.0.0-rc.4"
+            },
+            "peerDependenciesMeta": {
+                "@exodus/crypto": {
+                    "optional": true
+                }
             }
         },
         "node_modules/@floating-ui/core": {
@@ -3211,6 +3430,34 @@
             "dev": true,
             "license": "MIT"
         },
+        "node_modules/@testing-library/react": {
+            "version": "16.3.1",
+            "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-16.3.1.tgz",
+            "integrity": "sha512-gr4KtAWqIOQoucWYD/f6ki+j5chXfcPc74Col/6poTyqTmn7zRmodWahWRCp8tYd+GMqBonw6hstNzqjbs6gjw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@babel/runtime": "^7.12.5"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "peerDependencies": {
+                "@testing-library/dom": "^10.0.0",
+                "@types/react": "^18.0.0 || ^19.0.0",
+                "@types/react-dom": "^18.0.0 || ^19.0.0",
+                "react": "^18.0.0 || ^19.0.0",
+                "react-dom": "^18.0.0 || ^19.0.0"
+            },
+            "peerDependenciesMeta": {
+                "@types/react": {
+                    "optional": true
+                },
+                "@types/react-dom": {
+                    "optional": true
+                }
+            }
+        },
         "node_modules/@testing-library/user-event": {
             "version": "14.6.1",
             "dev": true,
@@ -4084,6 +4331,16 @@
                 "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
             }
         },
+        "node_modules/agent-base": {
+            "version": "7.1.4",
+            "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+            "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 14"
+            }
+        },
         "node_modules/aggregate-error": {
             "version": "3.1.0",
             "dev": true,
@@ -4326,6 +4583,16 @@
             "license": "BSD-3-Clause",
             "dependencies": {
                 "tweetnacl": "^0.14.3"
+            }
+        },
+        "node_modules/bidi-js": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/bidi-js/-/bidi-js-1.0.3.tgz",
+            "integrity": "sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "require-from-string": "^2.0.2"
             }
         },
         "node_modules/blob-util": {
@@ -4907,6 +5174,20 @@
                 "node": "*"
             }
         },
+        "node_modules/css-tree": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.1.0.tgz",
+            "integrity": "sha512-0eW44TGN5SQXU1mWSkKwFstI/22X2bG1nYzZTYMAWjylYURhse752YgbE4Cx46AC+bAvI+/dYTPRk1LqSUnu6w==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "mdn-data": "2.12.2",
+                "source-map-js": "^1.0.1"
+            },
+            "engines": {
+                "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
+            }
+        },
         "node_modules/css.escape": {
             "version": "1.5.1",
             "dev": true,
@@ -4921,6 +5202,32 @@
             },
             "engines": {
                 "node": ">=4"
+            }
+        },
+        "node_modules/cssstyle": {
+            "version": "5.3.7",
+            "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-5.3.7.tgz",
+            "integrity": "sha512-7D2EPVltRrsTkhpQmksIu+LxeWAIEk6wRDMJ1qljlv+CKHJM+cJLlfhWIzNA44eAsHXSNe3+vO6DW1yCYx8SuQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@asamuzakjp/css-color": "^4.1.1",
+                "@csstools/css-syntax-patches-for-csstree": "^1.0.21",
+                "css-tree": "^3.1.0",
+                "lru-cache": "^11.2.4"
+            },
+            "engines": {
+                "node": ">=20"
+            }
+        },
+        "node_modules/cssstyle/node_modules/lru-cache": {
+            "version": "11.2.4",
+            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.4.tgz",
+            "integrity": "sha512-B5Y16Jr9LB9dHVkh6ZevG+vAbOsNOYCX+sXvFWFu7B3Iz5mijW3zdbMyhsh8ANd2mSWBYdJgnqi+mL7/LrOPYg==",
+            "dev": true,
+            "license": "BlueOak-1.0.0",
+            "engines": {
+                "node": "20 || >=22"
             }
         },
         "node_modules/csstype": {
@@ -5345,6 +5652,20 @@
                 "node": ">=0.10"
             }
         },
+        "node_modules/data-urls": {
+            "version": "6.0.0",
+            "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-6.0.0.tgz",
+            "integrity": "sha512-BnBS08aLUM+DKamupXs3w2tJJoqU+AkaE/+6vQxi/G/DPmIZFJJp9Dkb1kM03AZx8ADehDUZgsNxju3mPXZYIA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "whatwg-mimetype": "^4.0.0",
+                "whatwg-url": "^15.0.0"
+            },
+            "engines": {
+                "node": ">=20"
+            }
+        },
         "node_modules/dayjs": {
             "version": "1.11.18",
             "dev": true,
@@ -5377,6 +5698,13 @@
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
             }
+        },
+        "node_modules/decimal.js": {
+            "version": "10.6.0",
+            "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
+            "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/deep-eql": {
             "version": "5.0.2",
@@ -6548,6 +6876,19 @@
                 "htmlparser2": "10.0.0"
             }
         },
+        "node_modules/html-encoding-sniffer": {
+            "version": "6.0.0",
+            "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-6.0.0.tgz",
+            "integrity": "sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@exodus/bytes": "^1.6.0"
+            },
+            "engines": {
+                "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+            }
+        },
         "node_modules/html-escaper": {
             "version": "2.0.2",
             "dev": true,
@@ -6589,6 +6930,20 @@
                 "entities": "^6.0.0"
             }
         },
+        "node_modules/http-proxy-agent": {
+            "version": "7.0.2",
+            "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
+            "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "agent-base": "^7.1.0",
+                "debug": "^4.3.4"
+            },
+            "engines": {
+                "node": ">= 14"
+            }
+        },
         "node_modules/http-signature": {
             "version": "1.4.0",
             "dev": true,
@@ -6600,6 +6955,20 @@
             },
             "engines": {
                 "node": ">=0.10"
+            }
+        },
+        "node_modules/https-proxy-agent": {
+            "version": "7.0.6",
+            "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+            "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "agent-base": "^7.1.2",
+                "debug": "4"
+            },
+            "engines": {
+                "node": ">= 14"
             }
         },
         "node_modules/human-signals": {
@@ -6816,6 +7185,13 @@
                 "node": ">=8"
             }
         },
+        "node_modules/is-potential-custom-element-name": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
+            "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
+            "dev": true,
+            "license": "MIT"
+        },
         "node_modules/is-stream": {
             "version": "2.0.1",
             "dev": true,
@@ -6958,6 +7334,79 @@
             "version": "0.1.1",
             "dev": true,
             "license": "MIT"
+        },
+        "node_modules/jsdom": {
+            "version": "27.4.0",
+            "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-27.4.0.tgz",
+            "integrity": "sha512-mjzqwWRD9Y1J1KUi7W97Gja1bwOOM5Ug0EZ6UDK3xS7j7mndrkwozHtSblfomlzyB4NepioNt+B2sOSzczVgtQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@acemir/cssom": "^0.9.28",
+                "@asamuzakjp/dom-selector": "^6.7.6",
+                "@exodus/bytes": "^1.6.0",
+                "cssstyle": "^5.3.4",
+                "data-urls": "^6.0.0",
+                "decimal.js": "^10.6.0",
+                "html-encoding-sniffer": "^6.0.0",
+                "http-proxy-agent": "^7.0.2",
+                "https-proxy-agent": "^7.0.6",
+                "is-potential-custom-element-name": "^1.0.1",
+                "parse5": "^8.0.0",
+                "saxes": "^6.0.0",
+                "symbol-tree": "^3.2.4",
+                "tough-cookie": "^6.0.0",
+                "w3c-xmlserializer": "^5.0.0",
+                "webidl-conversions": "^8.0.0",
+                "whatwg-mimetype": "^4.0.0",
+                "whatwg-url": "^15.1.0",
+                "ws": "^8.18.3",
+                "xml-name-validator": "^5.0.0"
+            },
+            "engines": {
+                "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+            },
+            "peerDependencies": {
+                "canvas": "^3.0.0"
+            },
+            "peerDependenciesMeta": {
+                "canvas": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/jsdom/node_modules/tldts": {
+            "version": "7.0.19",
+            "resolved": "https://registry.npmjs.org/tldts/-/tldts-7.0.19.tgz",
+            "integrity": "sha512-8PWx8tvC4jDB39BQw1m4x8y5MH1BcQ5xHeL2n7UVFulMPH/3Q0uiamahFJ3lXA0zO2SUyRXuVVbWSDmstlt9YA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "tldts-core": "^7.0.19"
+            },
+            "bin": {
+                "tldts": "bin/cli.js"
+            }
+        },
+        "node_modules/jsdom/node_modules/tldts-core": {
+            "version": "7.0.19",
+            "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.0.19.tgz",
+            "integrity": "sha512-lJX2dEWx0SGH4O6p+7FPwYmJ/bu1JbcGJ8RLaG9b7liIgZ85itUVEPbMtWRVrde/0fnDPEPHW10ZsKW3kVsE9A==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/jsdom/node_modules/tough-cookie": {
+            "version": "6.0.0",
+            "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-6.0.0.tgz",
+            "integrity": "sha512-kXuRi1mtaKMrsLUxz3sQYvVl37B0Ns6MzfrtV5DvJceE9bPyspOqk9xxv7XbZWcfLWbFmm997vl83qUWVJA64w==",
+            "dev": true,
+            "license": "BSD-3-Clause",
+            "dependencies": {
+                "tldts": "^7.0.5"
+            },
+            "engines": {
+                "node": ">=16"
+            }
         },
         "node_modules/jsesc": {
             "version": "3.1.0",
@@ -7384,6 +7833,13 @@
                 "crypt": "0.0.2",
                 "is-buffer": "~1.1.6"
             }
+        },
+        "node_modules/mdn-data": {
+            "version": "2.12.2",
+            "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.12.2.tgz",
+            "integrity": "sha512-IEn+pegP1aManZuckezWCO+XZQDplx1366JoVhTpMpBB1sPey/SbveZQUosKiKiGYjg1wH4pMlNgXbCiYgihQA==",
+            "dev": true,
+            "license": "CC0-1.0"
         },
         "node_modules/merge-stream": {
             "version": "2.0.0",
@@ -7922,6 +8378,19 @@
             },
             "engines": {
                 "node": ">=6"
+            }
+        },
+        "node_modules/parse5": {
+            "version": "8.0.0",
+            "resolved": "https://registry.npmjs.org/parse5/-/parse5-8.0.0.tgz",
+            "integrity": "sha512-9m4m5GSgXjL4AjumKzq1Fgfp3Z8rsvjRNbnkVwfu2ImRqE5D0LnY2QfDen18FSY9C573YU5XxSapdHZTZ2WolA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "entities": "^6.0.0"
+            },
+            "funding": {
+                "url": "https://github.com/inikulin/parse5?sponsor=1"
             }
         },
         "node_modules/path-exists": {
@@ -8632,6 +9101,16 @@
                 "node": ">=0.10.0"
             }
         },
+        "node_modules/require-from-string": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+            "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
         "node_modules/resolve": {
             "version": "1.22.11",
             "dev": true,
@@ -8820,6 +9299,19 @@
             "version": "2.1.2",
             "dev": true,
             "license": "MIT"
+        },
+        "node_modules/saxes": {
+            "version": "6.0.0",
+            "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
+            "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
+            "dev": true,
+            "license": "ISC",
+            "dependencies": {
+                "xmlchars": "^2.2.0"
+            },
+            "engines": {
+                "node": ">=v12.22.7"
+            }
         },
         "node_modules/scheduler": {
             "version": "0.25.0",
@@ -9287,6 +9779,13 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
+        "node_modules/symbol-tree": {
+            "version": "3.2.4",
+            "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+            "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
+            "dev": true,
+            "license": "MIT"
+        },
         "node_modules/tagged-tag": {
             "version": "1.0.0",
             "dev": true,
@@ -9483,6 +9982,19 @@
                 "node": ">=16"
             }
         },
+        "node_modules/tr46": {
+            "version": "6.0.0",
+            "resolved": "https://registry.npmjs.org/tr46/-/tr46-6.0.0.tgz",
+            "integrity": "sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "punycode": "^2.3.1"
+            },
+            "engines": {
+                "node": ">=20"
+            }
+        },
         "node_modules/tree-kill": {
             "version": "1.2.2",
             "dev": true,
@@ -9574,7 +10086,6 @@
         },
         "node_modules/typescript": {
             "version": "5.8.3",
-            "dev": true,
             "license": "Apache-2.0",
             "bin": {
                 "tsc": "bin/tsc",
@@ -10047,10 +10558,57 @@
                 "node": ">=14.0.0"
             }
         },
+        "node_modules/w3c-xmlserializer": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
+            "integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "xml-name-validator": "^5.0.0"
+            },
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/webidl-conversions": {
+            "version": "8.0.1",
+            "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-8.0.1.tgz",
+            "integrity": "sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==",
+            "dev": true,
+            "license": "BSD-2-Clause",
+            "engines": {
+                "node": ">=20"
+            }
+        },
         "node_modules/webpack-virtual-modules": {
             "version": "0.6.2",
             "dev": true,
             "license": "MIT"
+        },
+        "node_modules/whatwg-mimetype": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-4.0.0.tgz",
+            "integrity": "sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/whatwg-url": {
+            "version": "15.1.0",
+            "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-15.1.0.tgz",
+            "integrity": "sha512-2ytDk0kiEj/yu90JOAp44PVPUkO9+jVhyf+SybKlRHSDlvOOZhdPIrr7xTH64l4WixO2cP+wQIcgujkGBPPz6g==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "tr46": "^6.0.0",
+                "webidl-conversions": "^8.0.0"
+            },
+            "engines": {
+                "node": ">=20"
+            }
         },
         "node_modules/which": {
             "version": "2.0.2",
@@ -10241,6 +10799,23 @@
         },
         "node_modules/xml": {
             "version": "1.0.1",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/xml-name-validator": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
+            "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/xmlchars": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+            "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
             "dev": true,
             "license": "MIT"
         },

--- a/client/webui/frontend/package.json
+++ b/client/webui/frontend/package.json
@@ -53,7 +53,8 @@
         "preview": "vite preview",
         "storybook": "storybook dev -p 6006",
         "test:storybook": "vitest --project=storybook",
-        "ci:storybook": "CI=true npm run test:storybook"
+        "test:unit": "vitest --project=unit",
+        "ci:storybook": "CI=true vitest --project=unit --project=storybook"
     },
     "lint-staged": {
         "*.{js,jsx,ts,tsx}": [
@@ -116,10 +117,13 @@
         "@a2a-js/sdk": "^0.3.2",
         "@eslint/js": "^9.25.0",
         "@storybook/addon-vitest": "^10.1.10",
+        "@storybook/react": "^10.1.8",
         "@storybook/react-vite": "^10.1.10",
         "@tailwindcss/typography": "^0.5.16",
         "@tanstack/eslint-plugin-query": "5.91.2",
         "@testing-library/cypress": "^10.0.3",
+        "@testing-library/jest-dom": "^6.9.1",
+        "@testing-library/react": "^16.3.0",
         "@types/js-yaml": "^4.0.9",
         "@types/node": "^22.15.29",
         "@types/react": "19.0.0",
@@ -133,6 +137,7 @@
         "eslint-plugin-react-refresh": "^0.4.19",
         "eslint-plugin-storybook": "^10.1.10",
         "globals": "^16.0.0",
+        "jsdom": "^27.0.1",
         "lint-staged": "^16.2.3",
         "mocha-junit-reporter": "^2.2.1",
         "msw": "^2.12.3",

--- a/client/webui/frontend/vitest.config.ts
+++ b/client/webui/frontend/vitest.config.ts
@@ -1,4 +1,4 @@
-import { defineConfig, mergeConfig } from "vitest/config";
+import { defineConfig, defineProject, mergeConfig } from "vitest/config";
 import { playwright } from "@vitest/browser-playwright";
 
 import { storybookTest } from "@storybook/addon-vitest/vitest-plugin";
@@ -34,6 +34,18 @@ export default mergeConfig(
                         setupFiles: ["./.storybook/vitest.setup.ts"],
                     },
                 },
+                defineProject({
+                    test: {
+                        name: "unit",
+                        globals: true,
+                        environment: "jsdom",
+                        include: ["src/**/*.test.{ts,tsx}"],
+                        setupFiles: ["./.storybook/vitest.setup.ts"],
+                        alias: {
+                            "@": path.resolve(dirname, "src"),
+                        },
+                    },
+                }),
             ],
         },
     })


### PR DESCRIPTION
This pull request improves the frontend testing setup by introducing a dedicated unit test configuration using Vitest and jsdom, mocking browser APIs for better compatibility, and adding essential testing dependencies. These changes make it easier to run and maintain both Storybook and unit tests in the project.

**Testing configuration improvements:**

* Added a new `unit` test project to `vitest.config.ts` that uses the `jsdom` environment and includes only unit test files, ensuring a clear separation between Storybook and unit tests. (`client/webui/frontend/vitest.config.ts`, [client/webui/frontend/vitest.config.tsR37-R48](diffhunk://#diff-8b2dc703760c3b604d2574df8c20fbf15163c3dd29919b9f5a87567b7142066bR37-R48))
* Updated npm scripts in `package.json` to support running unit tests separately and to run both unit and Storybook tests in CI. (`client/webui/frontend/package.json`, [client/webui/frontend/package.jsonL56-R57](diffhunk://#diff-2a0b1b97cd2a8a0f6ee43d592510c4b820af1558c2225e11df9b45533a36e36cL56-R57))

**Test environment compatibility:**

* Mocked the `window.matchMedia` API in the Storybook Vitest setup file to prevent errors in jsdom, improving reliability for components that use media queries. (`client/webui/frontend/.storybook/vitest.setup.ts`, [client/webui/frontend/.storybook/vitest.setup.tsR4-R19](diffhunk://#diff-1dcf9d73d5029cd0399741ea81fb75916f49f76dd9e9cbb2cd0d62173ee98906R4-R19))

**Dependency updates:**

* Added testing-related dependencies including `@storybook/react`, `@testing-library/jest-dom`, `@testing-library/react`, and `jsdom` to `package.json` to support the new test configuration and improve test capabilities. (`client/webui/frontend/package.json`, [[1]](diffhunk://#diff-2a0b1b97cd2a8a0f6ee43d592510c4b820af1558c2225e11df9b45533a36e36cR120-R126) [[2]](diffhunk://#diff-2a0b1b97cd2a8a0f6ee43d592510c4b820af1558c2225e11df9b45533a36e36cR140)