### PR TITLE
chore: Add always-run status check for UI CI workflow

### DIFF
--- a/.github/workflows/ui-ci.yml
+++ b/.github/workflows/ui-ci.yml
@@ -242,13 +242,13 @@ jobs:
       - name: Check build status
         run: |
           if [[ "${{ needs.check-paths.outputs.should-run }}" == "false" ]]; then
-            echo "UI files not changed, skipping tests"
+            echo "UI files not changed, skipping UI build and tests"
             exit 0
           elif [[ "${{ needs.ui-build-and-test.result }}" == "success" ]]; then
-            echo "UI tests passed"
+            echo "UI build/tests passed"
             exit 0
           else
-            echo "UI tests failed"
+            echo "UI build/tests failed"
             exit 1
           fi
 


### PR DESCRIPTION
## Summary
- Fixes the issue where the UI CI workflow blocks PRs when only backend code is modified
- Adds an always-run status check that passes when UI files haven't changed

## Problem
The "Build and Test UI" workflow uses path filters (`client/webui/frontend/**`) and only runs when frontend code changes. When set as a required status check in GitHub, this blocks backend-only PRs because the check never runs and isn't marked as passed.

## Solution
This PR implements the GitHub-recommended pattern for path-filtered workflows with required status checks:

1. **check-paths job**: Always runs and detects if UI files changed using `dorny/paths-filter@v3`
2. **ui-build-and-test job**: Now conditional - only runs when UI files changed
3. **ui-ci-status job**: Always runs and reports the final status:
   - ✅ Passes when UI files unchanged (allows backend-only PRs to merge)
   - ✅ Passes when UI tests run and succeed
   - ❌ Fails when UI tests run and fail
4. **bump-version job**: Updated to only run when UI files changed

## Next Steps
After merging, update GitHub branch protection rules:
- Remove "Build and Test UI" as a required status check
- Add "UI CI Status" as the required status check

This will allow backend-only PRs to pass while still enforcing UI tests when frontend code is modified.

## Test plan
- [ ] Test with backend-only changes - should show "UI CI Status" as passed
- [ ] Test with frontend changes - should run full UI tests and report status
- [ ] Test with frontend changes that fail tests - should report failure

🤖 Generated with [Claude Code](https://claude.com/claude-code)