### PR TITLE
fix(security): update dependencies to address vulnerabilities

### DIFF
--- a/client/webui/frontend/package-lock.json
+++ b/client/webui/frontend/package-lock.json
@@ -42,7 +42,7 @@
                 "react-intersection-observer": "^9.16.0",
                 "react-json-view-lite": "^2.4.1",
                 "react-resizable-panels": "^3.0.3",
-                "react-router-dom": "7.9.3",
+                "react-router-dom": "7.12.0",
                 "tailwind-merge": "^3.3.0",
                 "tailwind-scrollbar-hide": "^4.0.0",
                 "tailwindcss": "^4.1.10",
@@ -110,7 +110,7 @@
                 "@types/react-dom": "19.0.0",
                 "react": "19.0.0",
                 "react-dom": "19.0.0",
-                "react-router-dom": "7.9.3"
+                "react-router-dom": "7.12.0"
             }
         },
         "node_modules/@a2a-js/sdk": {
@@ -1412,6 +1412,16 @@
             "version": "2.1.0",
             "dev": true,
             "license": "MIT"
+        },
+        "node_modules/@pkgjs/parseargs": {
+            "version": "0.11.0",
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "peer": true,
+            "engines": {
+                "node": ">=14"
+            }
         },
         "node_modules/@polka/url": {
             "version": "1.0.0-next.29",
@@ -3139,14 +3149,14 @@
             }
         },
         "node_modules/@tanstack/eslint-plugin-query/node_modules/@typescript-eslint/project-service": {
-            "version": "8.52.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.52.0.tgz",
-            "integrity": "sha512-xD0MfdSdEmeFa3OmVqonHi+Cciab96ls1UhIF/qX/O/gPu5KXD0bY9lu33jj04fjzrXHcuvjBcBC+D3SNSadaw==",
+            "version": "8.53.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.53.0.tgz",
+            "integrity": "sha512-Bl6Gdr7NqkqIP5yP9z1JU///Nmes4Eose6L1HwpuVHwScgDPPuEWbUVhvlZmb8hy0vX9syLk5EGNL700WcBlbg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@typescript-eslint/tsconfig-utils": "^8.52.0",
-                "@typescript-eslint/types": "^8.52.0",
+                "@typescript-eslint/tsconfig-utils": "^8.53.0",
+                "@typescript-eslint/types": "^8.53.0",
                 "debug": "^4.4.3"
             },
             "engines": {
@@ -3161,14 +3171,14 @@
             }
         },
         "node_modules/@tanstack/eslint-plugin-query/node_modules/@typescript-eslint/scope-manager": {
-            "version": "8.52.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.52.0.tgz",
-            "integrity": "sha512-ixxqmmCcc1Nf8S0mS0TkJ/3LKcC8mruYJPOU6Ia2F/zUUR4pApW7LzrpU3JmtePbRUTes9bEqRc1Gg4iyRnDzA==",
+            "version": "8.53.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.53.0.tgz",
+            "integrity": "sha512-kWNj3l01eOGSdVBnfAF2K1BTh06WS0Yet6JUgb9Cmkqaz3Jlu0fdVUjj9UI8gPidBWSMqDIglmEXifSgDT/D0g==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@typescript-eslint/types": "8.52.0",
-                "@typescript-eslint/visitor-keys": "8.52.0"
+                "@typescript-eslint/types": "8.53.0",
+                "@typescript-eslint/visitor-keys": "8.53.0"
             },
             "engines": {
                 "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -3179,9 +3189,9 @@
             }
         },
         "node_modules/@tanstack/eslint-plugin-query/node_modules/@typescript-eslint/tsconfig-utils": {
-            "version": "8.52.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.52.0.tgz",
-            "integrity": "sha512-jl+8fzr/SdzdxWJznq5nvoI7qn2tNYV/ZBAEcaFMVXf+K6jmXvAFrgo/+5rxgnL152f//pDEAYAhhBAZGrVfwg==",
+            "version": "8.53.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.53.0.tgz",
+            "integrity": "sha512-K6Sc0R5GIG6dNoPdOooQ+KtvT5KCKAvTcY8h2rIuul19vxH5OTQk7ArKkd4yTzkw66WnNY0kPPzzcmWA+XRmiA==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -3196,9 +3206,9 @@
             }
         },
         "node_modules/@tanstack/eslint-plugin-query/node_modules/@typescript-eslint/types": {
-            "version": "8.52.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.52.0.tgz",
-            "integrity": "sha512-LWQV1V4q9V4cT4H5JCIx3481iIFxH1UkVk+ZkGGAV1ZGcjGI9IoFOfg3O6ywz8QqCDEp7Inlg6kovMofsNRaGg==",
+            "version": "8.53.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.53.0.tgz",
+            "integrity": "sha512-Bmh9KX31Vlxa13+PqPvt4RzKRN1XORYSLlAE+sO1i28NkisGbTtSLFVB3l7PWdHtR3E0mVMuC7JilWJ99m2HxQ==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -3210,16 +3220,16 @@
             }
         },
         "node_modules/@tanstack/eslint-plugin-query/node_modules/@typescript-eslint/typescript-estree": {
-            "version": "8.52.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.52.0.tgz",
-            "integrity": "sha512-XP3LClsCc0FsTK5/frGjolyADTh3QmsLp6nKd476xNI9CsSsLnmn4f0jrzNoAulmxlmNIpeXuHYeEQv61Q6qeQ==",
+            "version": "8.53.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.53.0.tgz",
+            "integrity": "sha512-pw0c0Gdo7Z4xOG987u3nJ8akL9093yEEKv8QTJ+Bhkghj1xyj8cgPaavlr9rq8h7+s6plUJ4QJYw2gCZodqmGw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@typescript-eslint/project-service": "8.52.0",
-                "@typescript-eslint/tsconfig-utils": "8.52.0",
-                "@typescript-eslint/types": "8.52.0",
-                "@typescript-eslint/visitor-keys": "8.52.0",
+                "@typescript-eslint/project-service": "8.53.0",
+                "@typescript-eslint/tsconfig-utils": "8.53.0",
+                "@typescript-eslint/types": "8.53.0",
+                "@typescript-eslint/visitor-keys": "8.53.0",
                 "debug": "^4.4.3",
                 "minimatch": "^9.0.5",
                 "semver": "^7.7.3",
@@ -3238,16 +3248,16 @@
             }
         },
         "node_modules/@tanstack/eslint-plugin-query/node_modules/@typescript-eslint/utils": {
-            "version": "8.52.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.52.0.tgz",
-            "integrity": "sha512-wYndVMWkweqHpEpwPhwqE2lnD2DxC6WVLupU/DOt/0/v+/+iQbbzO3jOHjmBMnhu0DgLULvOaU4h4pwHYi2oRQ==",
+            "version": "8.53.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.53.0.tgz",
+            "integrity": "sha512-XDY4mXTez3Z1iRDI5mbRhH4DFSt46oaIFsLg+Zn97+sYrXACziXSQcSelMybnVZ5pa1P6xYkPr5cMJyunM1ZDA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@eslint-community/eslint-utils": "^4.9.1",
-                "@typescript-eslint/scope-manager": "8.52.0",
-                "@typescript-eslint/types": "8.52.0",
-                "@typescript-eslint/typescript-estree": "8.52.0"
+                "@typescript-eslint/scope-manager": "8.53.0",
+                "@typescript-eslint/types": "8.53.0",
+                "@typescript-eslint/typescript-estree": "8.53.0"
             },
             "engines": {
                 "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -3262,13 +3272,13 @@
             }
         },
         "node_modules/@tanstack/eslint-plugin-query/node_modules/@typescript-eslint/visitor-keys": {
-            "version": "8.52.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.52.0.tgz",
-            "integrity": "sha512-ink3/Zofus34nmBsPjow63FP5M7IGff0RKAgqR6+CFpdk22M7aLwC9gOcLGYqr7MczLPzZVERW9hRog3O4n1sQ==",
+            "version": "8.53.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.53.0.tgz",
+            "integrity": "sha512-LZ2NqIHFhvFwxG0qZeLL9DvdNAHPGCY5dIRwBhyYeU+LfLhcStE1ImjsuTG/WaVh3XysGaeLW8Rqq7cGkPCFvw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@typescript-eslint/types": "8.52.0",
+                "@typescript-eslint/types": "8.53.0",
                 "eslint-visitor-keys": "^4.2.1"
             },
             "engines": {
@@ -8964,7 +8974,9 @@
             }
         },
         "node_modules/react-router": {
-            "version": "7.9.3",
+            "version": "7.12.0",
+            "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.12.0.tgz",
+            "integrity": "sha512-kTPDYPFzDVGIIGNLS5VJykK0HfHLY5MF3b+xj0/tTyNYL1gF1qs7u67Z9jEhQk2sQ98SUaHxlG31g1JtF7IfVw==",
             "license": "MIT",
             "dependencies": {
                 "cookie": "^1.0.1",
@@ -8984,10 +8996,12 @@
             }
         },
         "node_modules/react-router-dom": {
-            "version": "7.9.3",
+            "version": "7.12.0",
+            "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.12.0.tgz",
+            "integrity": "sha512-pfO9fiBcpEfX4Tx+iTYKDtPbrSLLCbwJ5EqP+SPYQu1VYCXdy79GSj0wttR0U4cikVdlImZuEZ/9ZNCgoaxwBA==",
             "license": "MIT",
             "dependencies": {
-                "react-router": "7.9.3"
+                "react-router": "7.12.0"
             },
             "engines": {
                 "node": ">=20.0.0"
@@ -9336,6 +9350,8 @@
         },
         "node_modules/set-cookie-parser": {
             "version": "2.7.2",
+            "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.7.2.tgz",
+            "integrity": "sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw==",
             "license": "MIT"
         },
         "node_modules/setimmediate": {

--- a/client/webui/frontend/package.json
+++ b/client/webui/frontend/package.json
@@ -99,7 +99,7 @@
         "react-intersection-observer": "^9.16.0",
         "react-json-view-lite": "^2.4.1",
         "react-resizable-panels": "^3.0.3",
-        "react-router-dom": "7.9.3",
+        "react-router-dom": "7.12.0",
         "tailwind-merge": "^3.3.0",
         "tailwind-scrollbar-hide": "^4.0.0",
         "tailwindcss": "^4.1.10",
@@ -111,7 +111,7 @@
         "@types/react-dom": "19.0.0",
         "react": "19.0.0",
         "react-dom": "19.0.0",
-        "react-router-dom": "7.9.3"
+        "react-router-dom": "7.12.0"
     },
     "devDependencies": {
         "@a2a-js/sdk": "^0.3.2",

--- a/config_portal/frontend/package-lock.json
+++ b/config_portal/frontend/package-lock.json
@@ -6,8 +6,8 @@
     "": {
       "name": "solace-agent-mesh-config-portal-frontend",
       "dependencies": {
-        "@remix-run/node": "^2.16.2",
-        "@remix-run/react": "^2.16.2",
+        "@remix-run/node": "2.17.4",
+        "@remix-run/react": "2.17.4",
         "isbot": "^4",
         "lucide-react": "^0.542.0",
         "react": "^18.2.0",
@@ -15,7 +15,7 @@
         "react-markdown": "^10.1.0"
       },
       "devDependencies": {
-        "@remix-run/dev": "^2.16.2",
+        "@remix-run/dev": "2.17.4",
         "@types/react": "^18.2.20",
         "@types/react-dom": "^18.2.7",
         "@typescript-eslint/eslint-plugin": "^6.7.4",
@@ -561,8 +561,6 @@
     },
     "node_modules/@esbuild/darwin-arm64": {
       "version": "0.25.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.25.1.tgz",
-      "integrity": "sha512-5hEZKPf+nQjYoSr/elb62U19/l1mZDdqidGfmFutVUjjUZrOazAtwK+Kr+3y0C/oeJfLlxo9fXb1w7L+P7E4FQ==",
       "cpu": [
         "arm64"
       ],
@@ -1283,7 +1281,9 @@
       }
     },
     "node_modules/@remix-run/dev": {
-      "version": "2.16.2",
+      "version": "2.17.4",
+      "resolved": "https://registry.npmjs.org/@remix-run/dev/-/dev-2.17.4.tgz",
+      "integrity": "sha512-El7r5W6ErX9KIy27+urbc4SIZnIlVDgTOUqzA7Zbv7caKYrsvgj/Z3i/LPy4VNfv0G1EdawPOrygJgIKT4r2FA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1297,9 +1297,9 @@
         "@babel/types": "^7.22.5",
         "@mdx-js/mdx": "^2.3.0",
         "@npmcli/package-json": "^4.0.1",
-        "@remix-run/node": "2.16.2",
-        "@remix-run/router": "1.23.0",
-        "@remix-run/server-runtime": "2.16.2",
+        "@remix-run/node": "2.17.4",
+        "@remix-run/router": "1.23.2",
+        "@remix-run/server-runtime": "2.17.4",
         "@types/mdx": "^2.0.5",
         "@vanilla-extract/integration": "^6.2.0",
         "arg": "^5.0.1",
@@ -1338,10 +1338,10 @@
         "remark-mdx-frontmatter": "^1.0.1",
         "semver": "^7.3.7",
         "set-cookie-parser": "^2.6.0",
-        "tar-fs": "^2.1.1",
+        "tar-fs": "^2.1.3",
         "tsconfig-paths": "^4.0.0",
-        "valibot": "^0.41.0",
-        "vite-node": "3.0.0-beta.2",
+        "valibot": "^1.2.0",
+        "vite-node": "^3.1.3",
         "ws": "^7.5.10"
       },
       "bin": {
@@ -1351,8 +1351,8 @@
         "node": ">=18.0.0"
       },
       "peerDependencies": {
-        "@remix-run/react": "^2.16.2",
-        "@remix-run/serve": "^2.16.2",
+        "@remix-run/react": "^2.17.0",
+        "@remix-run/serve": "^2.17.0",
         "typescript": "^5.1.0",
         "vite": "^5.1.0 || ^6.0.0",
         "wrangler": "^3.28.2"
@@ -1373,16 +1373,18 @@
       }
     },
     "node_modules/@remix-run/node": {
-      "version": "2.16.2",
+      "version": "2.17.4",
+      "resolved": "https://registry.npmjs.org/@remix-run/node/-/node-2.17.4.tgz",
+      "integrity": "sha512-9A29JaYiGHDEmaiQuD1IlO/TrQxnnkj98GpytihU+Nz6yTt6RwzzyMMqTAoasRd1dPD4OeSaSqbwkcim/eE76Q==",
       "license": "MIT",
       "dependencies": {
-        "@remix-run/server-runtime": "2.16.2",
+        "@remix-run/server-runtime": "2.17.4",
         "@remix-run/web-fetch": "^4.4.2",
         "@web3-storage/multipart-parser": "^1.0.0",
         "cookie-signature": "^1.1.0",
         "source-map-support": "^0.5.21",
         "stream-slice": "^0.1.2",
-        "undici": "^6.11.1"
+        "undici": "^6.21.2"
       },
       "engines": {
         "node": ">=18.0.0"
@@ -1397,14 +1399,16 @@
       }
     },
     "node_modules/@remix-run/react": {
-      "version": "2.16.2",
+      "version": "2.17.4",
+      "resolved": "https://registry.npmjs.org/@remix-run/react/-/react-2.17.4.tgz",
+      "integrity": "sha512-MeXHacIBoohr9jzec5j/Rmk57xk34korkPDDb0OPHgkdvh20lO5fJoSAcnZfjTIOH+Vsq1ZRQlmvG5PRQ/64Sw==",
       "license": "MIT",
       "dependencies": {
-        "@remix-run/router": "1.23.0",
-        "@remix-run/server-runtime": "2.16.2",
-        "react-router": "6.30.0",
-        "react-router-dom": "6.30.0",
-        "turbo-stream": "2.4.0"
+        "@remix-run/router": "1.23.2",
+        "@remix-run/server-runtime": "2.17.4",
+        "react-router": "6.30.3",
+        "react-router-dom": "6.30.3",
+        "turbo-stream": "2.4.1"
       },
       "engines": {
         "node": ">=18.0.0"
@@ -1421,23 +1425,27 @@
       }
     },
     "node_modules/@remix-run/router": {
-      "version": "1.23.0",
+      "version": "1.23.2",
+      "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.23.2.tgz",
+      "integrity": "sha512-Ic6m2U/rMjTkhERIa/0ZtXJP17QUi2CbWE7cqx4J58M8aA3QTfW+2UlQ4psvTX9IO1RfNVhK3pcpdjej7L+t2w==",
       "license": "MIT",
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@remix-run/server-runtime": {
-      "version": "2.16.2",
+      "version": "2.17.4",
+      "resolved": "https://registry.npmjs.org/@remix-run/server-runtime/-/server-runtime-2.17.4.tgz",
+      "integrity": "sha512-oCsFbPuISgh8KpPKsfBChzjcntvTz5L+ggq9VNYWX8RX3yA7OgQpKspRHOSxb05bw7m0Hx+L1KRHXjf3juKX8w==",
       "license": "MIT",
       "dependencies": {
-        "@remix-run/router": "1.23.0",
+        "@remix-run/router": "1.23.2",
         "@types/cookie": "^0.6.0",
         "@web3-storage/multipart-parser": "^1.0.0",
-        "cookie": "^0.6.0",
+        "cookie": "^0.7.2",
         "set-cookie-parser": "^2.4.8",
         "source-map": "^0.7.3",
-        "turbo-stream": "2.4.0"
+        "turbo-stream": "2.4.1"
       },
       "engines": {
         "node": ">=18.0.0"
@@ -1453,6 +1461,8 @@
     },
     "node_modules/@remix-run/web-blob": {
       "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@remix-run/web-blob/-/web-blob-3.1.0.tgz",
+      "integrity": "sha512-owGzFLbqPH9PlKb8KvpNJ0NO74HWE2euAn61eEiyCXX/oteoVzTVSN8mpLgDjaxBf2btj5/nUllSUgpyd6IH6g==",
       "license": "MIT",
       "dependencies": {
         "@remix-run/web-stream": "^1.1.0",
@@ -1461,6 +1471,8 @@
     },
     "node_modules/@remix-run/web-fetch": {
       "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/@remix-run/web-fetch/-/web-fetch-4.4.2.tgz",
+      "integrity": "sha512-jgKfzA713/4kAW/oZ4bC3MoLWyjModOVDjFPNseVqcJKSafgIscrYL9G50SurEYLswPuoU3HzSbO0jQCMYWHhA==",
       "license": "MIT",
       "dependencies": {
         "@remix-run/web-blob": "^3.1.0",
@@ -1478,6 +1490,8 @@
     },
     "node_modules/@remix-run/web-file": {
       "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@remix-run/web-file/-/web-file-3.1.0.tgz",
+      "integrity": "sha512-dW2MNGwoiEYhlspOAXFBasmLeYshyAyhIdrlXBi06Duex5tDr3ut2LFKVj7tyHLmn8nnNwFf1BjNbkQpygC2aQ==",
       "license": "MIT",
       "dependencies": {
         "@remix-run/web-blob": "^3.1.0"
@@ -1485,6 +1499,8 @@
     },
     "node_modules/@remix-run/web-form-data": {
       "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@remix-run/web-form-data/-/web-form-data-3.1.0.tgz",
+      "integrity": "sha512-NdeohLMdrb+pHxMQ/Geuzdp0eqPbea+Ieo8M8Jx2lGC6TBHsgHzYcBvr0LyPdPVycNRDEpWpiDdCOdCryo3f9A==",
       "license": "MIT",
       "dependencies": {
         "web-encoding": "1.1.5"
@@ -1492,36 +1508,12 @@
     },
     "node_modules/@remix-run/web-stream": {
       "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@remix-run/web-stream/-/web-stream-1.1.0.tgz",
+      "integrity": "sha512-KRJtwrjRV5Bb+pM7zxcTJkhIqWWSy+MYsIxHK+0m5atcznsf15YwUBWHWulZerV2+vvHH1Lp1DD7pw6qKW8SgA==",
       "license": "MIT",
       "dependencies": {
         "web-streams-polyfill": "^3.1.1"
       }
-    },
-    "node_modules/@rollup/rollup-android-arm-eabi": {
-      "version": "4.36.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.36.0.tgz",
-      "integrity": "sha512-jgrXjjcEwN6XpZXL0HUeOVGfjXhPyxAbbhD0BlXUB+abTOpbPiN5Wb3kOT7yb+uEtATNYF5x5gIfwutmuBA26w==",
-      "cpu": [
-        "arm"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "android"
-      ]
-    },
-    "node_modules/@rollup/rollup-android-arm64": {
-      "version": "4.36.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.36.0.tgz",
-      "integrity": "sha512-NyfuLvdPdNUfUNeYKUwPwKsE5SXa2J6bCt2LdB/N+AxShnkpiczi3tcLJrm5mA+eqpy0HmaIY9F6XCa32N5yzg==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "android"
-      ]
     },
     "node_modules/@rollup/rollup-darwin-arm64": {
       "version": "4.36.0",
@@ -1535,71 +1527,6 @@
         "darwin"
       ]
     },
-    "node_modules/@rollup/rollup-darwin-x64": {
-      "version": "4.36.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.36.0.tgz",
-      "integrity": "sha512-6c6wMZa1lrtiRsbDziCmjE53YbTkxMYhhnWnSW8R/yqsM7a6mSJ3uAVT0t8Y/DGt7gxUWYuFM4bwWk9XCJrFKA==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "darwin"
-      ]
-    },
-    "node_modules/@rollup/rollup-freebsd-arm64": {
-      "version": "4.36.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.36.0.tgz",
-      "integrity": "sha512-KXVsijKeJXOl8QzXTsA+sHVDsFOmMCdBRgFmBb+mfEb/7geR7+C8ypAml4fquUt14ZyVXaw2o1FWhqAfOvA4sg==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "freebsd"
-      ]
-    },
-    "node_modules/@rollup/rollup-freebsd-x64": {
-      "version": "4.36.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.36.0.tgz",
-      "integrity": "sha512-dVeWq1ebbvByI+ndz4IJcD4a09RJgRYmLccwlQ8bPd4olz3Y213uf1iwvc7ZaxNn2ab7bjc08PrtBgMu6nb4pQ==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "freebsd"
-      ]
-    },
-    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
-      "version": "4.36.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.36.0.tgz",
-      "integrity": "sha512-bvXVU42mOVcF4le6XSjscdXjqx8okv4n5vmwgzcmtvFdifQ5U4dXFYaCB87namDRKlUL9ybVtLQ9ztnawaSzvg==",
-      "cpu": [
-        "arm"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
-      "version": "4.36.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.36.0.tgz",
-      "integrity": "sha512-JFIQrDJYrxOnyDQGYkqnNBtjDwTgbasdbUiQvcU8JmGDfValfH1lNpng+4FWlhaVIR4KPkeddYjsVVbmJYvDcg==",
-      "cpu": [
-        "arm"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
     "node_modules/@rollup/rollup-linux-arm64-gnu": {
       "version": "4.36.0",
       "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.36.0.tgz",
@@ -1607,71 +1534,7 @@
       "cpu": [
         "arm64"
       ],
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@rollup/rollup-linux-arm64-musl": {
-      "version": "4.36.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.36.0.tgz",
-      "integrity": "sha512-QiGnhScND+mAAtfHqeT+cB1S9yFnNQ/EwCg5yE3MzoaZZnIV0RV9O5alJAoJKX/sBONVKeZdMfO8QSaWEygMhw==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@rollup/rollup-linux-loongarch64-gnu": {
-      "version": "4.36.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loongarch64-gnu/-/rollup-linux-loongarch64-gnu-4.36.0.tgz",
-      "integrity": "sha512-1ZPyEDWF8phd4FQtTzMh8FQwqzvIjLsl6/84gzUxnMNFBtExBtpL51H67mV9xipuxl1AEAerRBgBwFNpkw8+Lg==",
-      "cpu": [
-        "loong64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@rollup/rollup-linux-powerpc64le-gnu": {
-      "version": "4.36.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-powerpc64le-gnu/-/rollup-linux-powerpc64le-gnu-4.36.0.tgz",
-      "integrity": "sha512-VMPMEIUpPFKpPI9GZMhJrtu8rxnp6mJR3ZzQPykq4xc2GmdHj3Q4cA+7avMyegXy4n1v+Qynr9fR88BmyO74tg==",
-      "cpu": [
-        "ppc64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
-      "version": "4.36.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.36.0.tgz",
-      "integrity": "sha512-ttE6ayb/kHwNRJGYLpuAvB7SMtOeQnVXEIpMtAvx3kepFQeowVED0n1K9nAdraHUPJ5hydEMxBpIR7o4nrm8uA==",
-      "cpu": [
-        "riscv64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@rollup/rollup-linux-s390x-gnu": {
-      "version": "4.36.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.36.0.tgz",
-      "integrity": "sha512-4a5gf2jpS0AIe7uBjxDeUMNcFmaRTbNv7NxI5xOCs4lhzsVyGR/0qBXduPnoWf6dGC365saTiwag8hP1imTgag==",
-      "cpu": [
-        "s390x"
-      ],
-      "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
@@ -1690,58 +1553,6 @@
         "linux"
       ]
     },
-    "node_modules/@rollup/rollup-linux-x64-musl": {
-      "version": "4.36.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.36.0.tgz",
-      "integrity": "sha512-sycrYZPrv2ag4OCvaN5js+f01eoZ2U+RmT5as8vhxiFz+kxwlHrsxOwKPSA8WyS+Wc6Epid9QeI/IkQ9NkgYyQ==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@rollup/rollup-win32-arm64-msvc": {
-      "version": "4.36.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.36.0.tgz",
-      "integrity": "sha512-qbqt4N7tokFwwSVlWDsjfoHgviS3n/vZ8LK0h1uLG9TYIRuUTJC88E1xb3LM2iqZ/WTqNQjYrtmtGmrmmawB6A==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "win32"
-      ]
-    },
-    "node_modules/@rollup/rollup-win32-ia32-msvc": {
-      "version": "4.36.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.36.0.tgz",
-      "integrity": "sha512-t+RY0JuRamIocMuQcfwYSOkmdX9dtkr1PbhKW42AMvaDQa+jOdpUYysroTF/nuPpAaQMWp7ye+ndlmmthieJrQ==",
-      "cpu": [
-        "ia32"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "win32"
-      ]
-    },
-    "node_modules/@rollup/rollup-win32-x64-msvc": {
-      "version": "4.36.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.36.0.tgz",
-      "integrity": "sha512-aRXd7tRZkWLqGbChgcMMDEHjOKudo1kChb1Jt1IfR8cY/KIpgNviLeJy5FUb9IpSuQj8dU2fAYNMPW/hLKOSTw==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "win32"
-      ]
-    },
     "node_modules/@rtsao/scc": {
       "version": "1.1.0",
       "dev": true,
@@ -1757,6 +1568,8 @@
     },
     "node_modules/@types/cookie": {
       "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/@types/cookie/-/cookie-0.6.0.tgz",
+      "integrity": "sha512-4Kh9a6B2bQciAhf7FSuMRRkUWecJgJu9nPnx3yzpsfXX/c50REIqpHY4C82bXP90qrLtXtkDxTZosYO3UpOwlA==",
       "license": "MIT"
     },
     "node_modules/@types/debug": {
@@ -2625,15 +2438,21 @@
     },
     "node_modules/@web3-storage/multipart-parser": {
       "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@web3-storage/multipart-parser/-/multipart-parser-1.0.0.tgz",
+      "integrity": "sha512-BEO6al7BYqcnfX15W2cnGR+Q566ACXAT9UQykORCWW80lmkpWsnEob6zJS1ZVBKsSJC8+7vJkHwlp+lXG1UCdw==",
       "license": "(Apache-2.0 AND MIT)"
     },
     "node_modules/@zxing/text-encoding": {
       "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/@zxing/text-encoding/-/text-encoding-0.9.0.tgz",
+      "integrity": "sha512-U/4aVJ2mxI0aDNI8Uq0wEhMgY+u4CNtEb0om3+y3+niDAsoTCOB33UF0sxpzqzdqXLqmvc+vZyAt4O8pPdfkwA==",
       "license": "(Unlicense OR Apache-2.0)",
       "optional": true
     },
     "node_modules/abort-controller": {
       "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
+      "integrity": "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==",
       "license": "MIT",
       "dependencies": {
         "event-target-shim": "^5.0.0"
@@ -3485,7 +3304,9 @@
       "license": "MIT"
     },
     "node_modules/cookie": {
-      "version": "0.6.0",
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
@@ -3493,6 +3314,8 @@
     },
     "node_modules/cookie-signature": {
       "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.2.2.tgz",
+      "integrity": "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==",
       "license": "MIT",
       "engines": {
         "node": ">=6.6.0"
@@ -3563,6 +3386,8 @@
     },
     "node_modules/data-uri-to-buffer": {
       "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-3.0.1.tgz",
+      "integrity": "sha512-WboRycPNsVw3B3TL559F7kuBUM4d8CgMEvk6xEJlOp7OBPjt6G7z8WMWlD2rOFZLk6OYfFIUGsCOWzcQH9K2og==",
       "license": "MIT",
       "engines": {
         "node": ">= 6"
@@ -3617,7 +3442,9 @@
       }
     },
     "node_modules/debug": {
-      "version": "4.4.0",
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
       "license": "MIT",
       "dependencies": {
         "ms": "^2.1.3"
@@ -4002,7 +3829,9 @@
       }
     },
     "node_modules/es-module-lexer": {
-      "version": "1.6.0",
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
+      "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
       "dev": true,
       "license": "MIT"
     },
@@ -4111,8 +3940,6 @@
     },
     "node_modules/esbuild/node_modules/@esbuild/darwin-arm64": {
       "version": "0.17.6",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.17.6.tgz",
-      "integrity": "sha512-bsDRvlbKMQMt6Wl08nHtFz++yoZHsyTOxnjfB2Q95gato+Yi4WnRl13oC2/PJJA9yLCoRv9gqT/EYX0/zDsyMA==",
       "cpu": [
         "arm64"
       ],
@@ -4803,6 +4630,8 @@
     },
     "node_modules/event-target-shim": {
       "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
+      "integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==",
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -5132,6 +4961,8 @@
     },
     "node_modules/fs-constants": {
       "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
+      "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==",
       "dev": true,
       "license": "MIT"
     },
@@ -6381,6 +6212,8 @@
     },
     "node_modules/is-arguments": {
       "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/is-arguments/-/is-arguments-1.2.0.tgz",
+      "integrity": "sha512-7bVbi0huj/wrIAOzb8U1aszg9kdi3KN/CyU19CTI7tAoZYEZoL9yCDXpbXN+uPsuWnP02cyug1gleqq+TU+YCA==",
       "license": "MIT",
       "dependencies": {
         "call-bound": "^1.0.2",
@@ -7160,8 +6993,6 @@
     },
     "node_modules/lucide-react": {
       "version": "0.542.0",
-      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-0.542.0.tgz",
-      "integrity": "sha512-w3hD8/SQB7+lzU2r4VdFyzzOzKnUjTZIF/MQJGSSvni7Llewni4vuViRppfRAa2guOsY5k4jZyxw/i9DQHv+dw==",
       "license": "ISC",
       "peerDependencies": {
         "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
@@ -8197,6 +8028,8 @@
     },
     "node_modules/mkdirp-classic": {
       "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
+      "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==",
       "dev": true,
       "license": "MIT"
     },
@@ -8246,6 +8079,8 @@
     },
     "node_modules/mrmime": {
       "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/mrmime/-/mrmime-1.0.1.tgz",
+      "integrity": "sha512-hzzEagAgDyoU1Q6yg5uI+AorQgdvMCur3FcKf7NhMKWsaYg+RnbTyHRa/9IlLF9rf455MOCtcqqrQQ83pPP7Uw==",
       "license": "MIT",
       "engines": {
         "node": ">=10"
@@ -9937,10 +9772,12 @@
       }
     },
     "node_modules/react-router": {
-      "version": "6.30.0",
+      "version": "6.30.3",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.30.3.tgz",
+      "integrity": "sha512-XRnlbKMTmktBkjCLE8/XcZFlnHvr2Ltdr1eJX4idL55/9BbORzyZEaIkBFDhFGCEWBBItsVrDxwx3gnisMitdw==",
       "license": "MIT",
       "dependencies": {
-        "@remix-run/router": "1.23.0"
+        "@remix-run/router": "1.23.2"
       },
       "engines": {
         "node": ">=14.0.0"
@@ -9950,11 +9787,13 @@
       }
     },
     "node_modules/react-router-dom": {
-      "version": "6.30.0",
+      "version": "6.30.3",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.30.3.tgz",
+      "integrity": "sha512-pxPcv1AczD4vso7G4Z3TKcvlxK7g7TNt3/FNGMhfqyntocvYKj+GCatfigGDjbLozC4baguJ0ReCigoDJXb0ag==",
       "license": "MIT",
       "dependencies": {
-        "@remix-run/router": "1.23.0",
-        "react-router": "6.30.0"
+        "@remix-run/router": "1.23.2",
+        "react-router": "6.30.3"
       },
       "engines": {
         "node": ">=14.0.0"
@@ -10493,7 +10332,9 @@
       }
     },
     "node_modules/set-cookie-parser": {
-      "version": "2.7.1",
+      "version": "2.7.2",
+      "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.7.2.tgz",
+      "integrity": "sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw==",
       "license": "MIT"
     },
     "node_modules/set-function-length": {
@@ -10660,6 +10501,8 @@
     },
     "node_modules/source-map-support": {
       "version": "0.5.21",
+      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz",
+      "integrity": "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==",
       "license": "MIT",
       "dependencies": {
         "buffer-from": "^1.0.0",
@@ -10668,6 +10511,8 @@
     },
     "node_modules/source-map-support/node_modules/source-map": {
       "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
@@ -10740,6 +10585,8 @@
     },
     "node_modules/stream-slice": {
       "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/stream-slice/-/stream-slice-0.1.2.tgz",
+      "integrity": "sha512-QzQxpoacatkreL6jsxnVb7X5R/pGw9OUv2qWTYWnmLpg4NdN31snPy/f3TdQE1ZUXaThRvj1Zw4/OGg0ZkaLMA==",
       "license": "MIT"
     },
     "node_modules/string_decoder": {
@@ -11123,7 +10970,9 @@
       }
     },
     "node_modules/tar-fs": {
-      "version": "2.1.2",
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.4.tgz",
+      "integrity": "sha512-mDAjwmZdh7LTT6pNleZ05Yt65HC3E+NiQzl672vQG38jIrehtJk/J3mNwIg+vShQPcLF/LV7CMnDW6vjj6sfYQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -11135,11 +10984,15 @@
     },
     "node_modules/tar-fs/node_modules/chownr": {
       "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
+      "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
       "dev": true,
       "license": "ISC"
     },
     "node_modules/tar-fs/node_modules/pump": {
-      "version": "3.0.2",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.3.tgz",
+      "integrity": "sha512-todwxLMY7/heScKmntwQG8CXVkWUOdYxIvY2s0VWAAMh/nd8SoYiRaKjlr7+iCs984f2P8zvrfWcDDYVb73NfA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -11149,6 +11002,8 @@
     },
     "node_modules/tar-stream": {
       "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz",
+      "integrity": "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -11390,7 +11245,9 @@
       }
     },
     "node_modules/turbo-stream": {
-      "version": "2.4.0",
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/turbo-stream/-/turbo-stream-2.4.1.tgz",
+      "integrity": "sha512-v8kOJXpG3WoTN/+at8vK7erSzo6nW6CIaeOvNOkHQVDajfz1ZVeSxCbc6tOH4hrGZW7VUCV0TOXd8CPzYnYkrw==",
       "license": "ISC"
     },
     "node_modules/type-check": {
@@ -11532,7 +11389,9 @@
       }
     },
     "node_modules/undici": {
-      "version": "6.21.2",
+      "version": "6.23.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.23.0.tgz",
+      "integrity": "sha512-VfQPToRA5FZs/qJxLIinmU59u0r7LXqoJkCzinq3ckNJp3vKEh7jTWN589YQ5+aoAC/TGRLyJLCPKcLQbM8r9g==",
       "license": "MIT",
       "engines": {
         "node": ">=18.17"
@@ -11746,6 +11605,8 @@
     },
     "node_modules/util": {
       "version": "0.12.5",
+      "resolved": "https://registry.npmjs.org/util/-/util-0.12.5.tgz",
+      "integrity": "sha512-kZf/K6hEIrWHI6XqOFUiiMa+79wE/D8Q+NCNAWclkyg3b4d2k7s0QGepNjiABc+aR3N1PAyHL7p6UcLY6LmrnA==",
       "license": "MIT",
       "dependencies": {
         "inherits": "^2.0.3",
@@ -11786,7 +11647,9 @@
       }
     },
     "node_modules/valibot": {
-      "version": "0.41.0",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/valibot/-/valibot-1.2.0.tgz",
+      "integrity": "sha512-mm1rxUsmOxzrwnX5arGS+U4T25RdvpPjPN4yR0u9pUBov9+zGVtO84tif1eY4r6zWxVxu3KzIyknJy3rxfRZZg==",
       "dev": true,
       "license": "MIT",
       "peerDependencies": {
@@ -11922,15 +11785,17 @@
       }
     },
     "node_modules/vite-node": {
-      "version": "3.0.0-beta.2",
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-3.2.4.tgz",
+      "integrity": "sha512-EbKSKh+bh1E1IFxeO0pg1n4dvoOTt0UDiXMd/qn++r98+jPO1xtJilvXldeuQ8giIB5IkpjCgMleHMNEsGH6pg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "cac": "^6.7.14",
-        "debug": "^4.4.0",
-        "es-module-lexer": "^1.5.4",
-        "pathe": "^1.1.2",
-        "vite": "^5.0.0 || ^6.0.0"
+        "debug": "^4.4.1",
+        "es-module-lexer": "^1.7.0",
+        "pathe": "^2.0.3",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
       },
       "bin": {
         "vite-node": "vite-node.mjs"
@@ -11941,6 +11806,13 @@
       "funding": {
         "url": "https://opencollective.com/vitest"
       }
+    },
+    "node_modules/vite-node/node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/vite-tsconfig-paths": {
       "version": "4.3.2",
@@ -12315,6 +12187,8 @@
     },
     "node_modules/web-encoding": {
       "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/web-encoding/-/web-encoding-1.1.5.tgz",
+      "integrity": "sha512-HYLeVCdJ0+lBYV2FvNZmv3HJ2Nt0QYXqZojk3d9FJOLkwnuhzM9tmamh8d7HPM8QqjKH8DeHkFTx+CFlWpZZDA==",
       "license": "MIT",
       "dependencies": {
         "util": "^0.12.3"
@@ -12325,6 +12199,8 @@
     },
     "node_modules/web-streams-polyfill": {
       "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.3.3.tgz",
+      "integrity": "sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==",
       "license": "MIT",
       "engines": {
         "node": ">= 8"

--- a/config_portal/frontend/package.json
+++ b/config_portal/frontend/package.json
@@ -11,8 +11,8 @@
     "typecheck": "tsc"
   },
   "dependencies": {
-    "@remix-run/node": "^2.16.2",
-    "@remix-run/react": "^2.16.2",
+    "@remix-run/node": "2.17.4",
+    "@remix-run/react": "2.17.4",
     "isbot": "^4",
     "lucide-react": "^0.542.0",
     "react": "^18.2.0",
@@ -20,7 +20,7 @@
     "react-markdown": "^10.1.0"
   },
   "devDependencies": {
-    "@remix-run/dev": "^2.16.2",
+    "@remix-run/dev": "2.17.4",
     "@types/react": "^18.2.20",
     "@types/react-dom": "^18.2.7",
     "@typescript-eslint/eslint-plugin": "^6.7.4",


### PR DESCRIPTION
## Summary
- Update `@remix-run/node`, `@remix-run/react`, `@remix-run/dev` from 2.16.2 to 2.17.4 (fixes CVEs in react-router, cookie, mdast-util-to-hast, @remix-run/router, @remix-run/server-runtime)
- Update `react-router-dom` from 7.9.3 to 7.12.0 (fixes 4 security issues)

**Note:** The `urllib3` vulnerability (2.6.0 → 2.6.3) cannot be fixed in this PR because `solace-ai-connector==3.2.0` pins `urllib3==2.6.0`. This will require an upstream update to solace-ai-connector.

## Test plan
- [ ] Verify npm install succeeds in config_portal/frontend
- [ ] Verify npm install succeeds in client/webui/frontend
- [ ] Run existing tests to ensure no regressions