### PR TITLE
chore(DATAGO-121629): Disable LLM prompt caching by default

### DIFF
--- a/docs/docs/documentation/installing-and-configuring/configurations.md
+++ b/docs/docs/documentation/installing-and-configuring/configurations.md
@@ -53,7 +53,7 @@ shared_config:
       # Enable parallel tool calls for planning model
       parallel_tool_calls: true
       # Prompt Caching Strategy
-      cache_strategy: "5m" # none, 5m, 1h
+      cache_strategy: ${LLM_CACHE_STRATEGY, "none"} # none, 5m, 1h
       # max_tokens: ${MAX_TOKENS, 16000} # Set a reasonable max token limit for planning
       # temperature: 0.1 # Lower temperature for more deterministic planning
     
@@ -132,7 +132,7 @@ Authentication typically requires an API key, but some providers use alternative
 | `api_base` | `LLM_SERVICE_ENDPOINT` | The base URL of the LLM provider's API endpoint. |
 | `api_key` | `LLM_SERVICE_API_KEY` | The API key for authenticating with the service. |
 | `parallel_tool_calls` |  | Enable parallel tool calls for the model. |
-| `cache_strategy` |  | Set the prompt caching strategy (one of: `none`, `5m`, `1h`). For more details check [LLM Configuration](./large_language_models.md#prompt-caching) page. |
+| `cache_strategy` | `LLM_CACHE_STRATEGY` | Set the prompt caching strategy (one of: `none`, `5m`, `1h`). For more details check [LLM Configuration](./large_language_models.md#prompt-caching) page. |
 | `max_tokens` | `MAX_TOKENS` | Set a reasonable max token limit for the model. |
 | `temperature` | `TEMPERATURE` | Lower temperature for more deterministic planning. |
 

--- a/docs/docs/documentation/installing-and-configuring/large_language_models.md
+++ b/docs/docs/documentation/installing-and-configuring/large_language_models.md
@@ -131,7 +131,7 @@ Agent Mesh provides three cache strategies that you can configure per model to o
 | `"1h"` | 1-hour extended cache | 1 hour | Burst patterns with gaps (3-10 calls/hour) |
 | `"none"` | Disable caching | N/A | Rarely-used agents (less than 2 calls/hour) |
 
-The default strategy is `"5m"` when not explicitly specified, providing optimal performance for most use cases without requiring configuration changes.
+The default strategy is `"none"` when not explicitly specified. To enable prompt caching for cost optimization, configure the appropriate strategy based on your agent's usage patterns.
 
 ### Configuration Examples
 

--- a/examples/shared_config.yaml
+++ b/examples/shared_config.yaml
@@ -23,7 +23,7 @@ shared_config:
       max_tokens: ${MAX_TOKENS, 16000} # Set a reasonable max token limit for planning
       temperature: 0.1 # Lower temperature for more deterministic planning
       # Prompt Caching Strategy
-      cache_strategy: "5m"  # none, 5m, 1h
+      cache_strategy: "none"  # none, 5m, 1h
 
 
     general: &general_model
@@ -35,7 +35,7 @@ shared_config:
       # 'api_key' provides authentication.
       api_key: ${LLM_SERVICE_API_KEY} # Use env var for API key 
       # Prompt Caching Strategy
-      cache_strategy: "5m" # none, 5m, 1h
+      cache_strategy: ${LLM_CACHE_STRATEGY, "none"} # none, 5m, 1h
 
     image_gen: &image_generation_model
       # This dictionary structure tells ADK to use the LiteLlm wrapper.

--- a/src/solace_agent_mesh/agent/adk/models/lite_llm.py
+++ b/src/solace_agent_mesh/agent/adk/models/lite_llm.py
@@ -531,7 +531,7 @@ def _message_to_generate_content_response(
 
 def _get_completion_inputs(
     llm_request: LlmRequest,
-    cache_strategy: str = "5m",
+    cache_strategy: str = "none",
 ) -> Tuple[
     List[Message],
     Optional[List[Dict]],
@@ -735,15 +735,15 @@ class LiteLlm(BaseLlm):
 
     _additional_args: Dict[str, Any] = None
     _oauth_token_manager: Optional[OAuth2ClientCredentialsTokenManager] = None
-    _cache_strategy: str = "5m"  # Default to 5-minute ephemeral cache
+    _cache_strategy: str = "none"  # Default to no caching
 
-    def __init__(self, model: str, cache_strategy: str = "5m", **kwargs):
+    def __init__(self, model: str, cache_strategy: str = "none", **kwargs):
         """Initializes the LiteLlm class.
 
         Args:
           model: The name of the LiteLlm model.
           cache_strategy: Cache strategy to use. Options: "none", "5m" (ephemeral), "1h" (extended).
-                         Defaults to "5m" for backward compatibility.
+                         Defaults to "none" (caching disabled).
           **kwargs: Additional arguments to pass to the litellm completion api.
                    Can include OAuth configuration parameters.
         """
@@ -759,11 +759,11 @@ class LiteLlm(BaseLlm):
         valid_strategies = ["none", "5m", "1h"]
         if cache_strategy not in valid_strategies:
             logger.warning(
-                "Invalid cache_strategy '%s'. Valid options are: %s. Defaulting to '5m'.",
+                "Invalid cache_strategy '%s'. Valid options are: %s. Defaulting to 'none'.",
                 cache_strategy,
                 valid_strategies,
             )
-            cache_strategy = "5m"
+            cache_strategy = "none"
         self._cache_strategy = cache_strategy
         logger.info("LiteLlm initialized with cache strategy: %s", self._cache_strategy)
 

--- a/templates/shared_config.yaml
+++ b/templates/shared_config.yaml
@@ -20,7 +20,7 @@ shared_config:
       # Enable parallel tool calls for planning model
       parallel_tool_calls: true 
       # Prompt Caching Strategy
-      cache_strategy: "5m" # none, 5m, 1h
+      cache_strategy: ${LLM_CACHE_STRATEGY, "none"} # none, 5m, 1h
 
       # max_tokens: ${MAX_TOKENS, 16000} # Set a reasonable max token limit for planning
       # temperature: 0.1 # Lower temperature for more deterministic planning
@@ -35,7 +35,7 @@ shared_config:
       # 'api_key' provides authentication.
       api_key: ${LLM_SERVICE_API_KEY} # Use env var for API key
       # Prompt Caching Strategy
-      cache_strategy: "5m" # none, 5m, 1h
+      cache_strategy: ${LLM_CACHE_STRATEGY, "none"} # none, 5m, 1h
 
     image_gen: &image_generation_model
       # This dictionary structure tells ADK to use the LiteLlm wrapper.

--- a/tests/unit/agent/adk/models/test_lite_llm_caching.py
+++ b/tests/unit/agent/adk/models/test_lite_llm_caching.py
@@ -33,9 +33,9 @@ class TestLiteLlmCacheStrategyInitialization:
     """Test cache strategy initialization and validation."""
 
     def test_init_with_default_cache_strategy(self):
-        """Test LiteLlm initializes with default 5m cache strategy."""
+        """Test LiteLlm initializes with default none cache strategy."""
         llm = LiteLlm(model="test-model")
-        assert llm._cache_strategy == "5m"
+        assert llm._cache_strategy == "none"
 
     def test_init_with_explicit_5m_strategy(self):
         """Test LiteLlm initializes with explicit 5m strategy."""
@@ -52,13 +52,13 @@ class TestLiteLlmCacheStrategyInitialization:
         llm = LiteLlm(model="test-model", cache_strategy="none")
         assert llm._cache_strategy == "none"
 
-    def test_init_with_invalid_strategy_defaults_to_5m(self):
-        """Test invalid cache strategy falls back to 5m with warning."""
+    def test_init_with_invalid_strategy_defaults_to_none(self):
+        """Test invalid cache strategy falls back to none with warning."""
         with patch("solace_agent_mesh.agent.adk.models.lite_llm.logger") as mock_logger:
             llm = LiteLlm(model="test-model", cache_strategy="invalid")
 
-            # Should default to 5m
-            assert llm._cache_strategy == "5m"
+            # Should default to none
+            assert llm._cache_strategy == "none"
 
             # Should log warning
             mock_logger.warning.assert_called_once()


### PR DESCRIPTION
### What is the purpose of this change?

Disable LLM prompt caching by default to avoid unexpected behavior for users who haven't explicitly opted into caching.

### How was this change implemented?

- Changed default `cache_strategy` from `"5m"` to `"none"` in `lite_llm.py`
- Added `LLM_CACHE_STRATEGY` environment variable to config templates
- Updated documentation to reflect the new default

### How was this change tested?

- [x] Unit tests: Updated existing caching tests to expect `"none"` as default
- [ ] Manual testing: Verify agents work correctly with caching disabled
- [ ] Manual testing: Verify `LLM_CACHE_STRATEGY=5m` enables caching

### Is there anything the reviewers should focus on/be aware of?

This is a behavior change - existing deployments that relied on the implicit `"5m"` default will now have caching disabled unless they explicitly set `cache_strategy` or `LLM_CACHE_STRATEGY`.