### PR TITLE
ci(DATAGO-121651): fix idendical image digests

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -247,6 +247,12 @@ jobs:
           echo "AMD64 Tag: ${AMD_TAG}"
           echo "ARM64 Tag: ${ARM_TAG}"
 
+          # OCI annotations to ensure unique manifest digest per commit
+          # This allows Prisma Cloud and other tools to index each tag uniquely
+          # while still benefiting from layer caching
+          COMMIT_SHA="${{ needs.prepare-metadata.outputs.commit_hash }}"
+          BUILD_TIME="$(date -u +'%Y-%m-%dT%H:%M:%SZ')"
+
           # Convert comma-separated tags string to array and create manifest for each
           IFS=',' read -ra TAGS <<< "${{ steps.image_tags.outputs.tags }}"
           for TAG in "${TAGS[@]}"; do
@@ -255,6 +261,9 @@ jobs:
             TAG=$(echo "$TAG" | xargs)
             echo "Creating manifest for tag: $TAG"
             docker buildx imagetools create \
+              --annotation "index:org.opencontainers.image.revision=${COMMIT_SHA}" \
+              --annotation "index:org.opencontainers.image.created=${BUILD_TIME}" \
+              --annotation "index:org.opencontainers.image.source=https://github.com/${{ github.repository }}" \
               --tag "$TAG" \
               "$AMD_TAG" \
               "$ARM_TAG"


### PR DESCRIPTION
### What is the purpose of this change?

Fixes intermittent "No Image Scan Results Found" errors during release workflows by ensuring each commit produces a unique Docker manifest digest, even when Docker layer caching results in identical image content.

Previously, when builds fully utilized cache, multiple commits would create tags pointing to the same manifest digest. Prisma Cloud indexes images by digest and wouldn't recognize new tags pointing to already-scanned images, causing scan lookups to fail.

### How was this change implemented?

Modified the merge-manifest job in CI to add OCI annotations when creating multi-arch manifests:

- Added org.opencontainers.image.revision annotation with commit SHA
- Added org.opencontainers.image.created annotation with build timestamp
- Added org.opencontainers.image.source annotation with repository URL

These annotations are embedded in the manifest list JSON, creating a unique digest per commit while preserving full layer cache benefits.

### How was this change tested?

[ ] Manual testing: Will verify next main branch push creates unique manifest digest
[ ] Unit tests: N/A (workflow change)
[ ] Integration tests: Prisma scan should find results for new SHA-based tags
[ ] Known limitations: Existing tags pointing to same digest won't be retroactively fixed

### Is there anything the reviewers should focus on/be aware of?

    Special attention areas, potential risks, or open questions
