### PR TITLE
ci: add ability to release exact version

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -184,7 +184,7 @@ jobs:
         id: prep
         uses: SolaceDev/solace-public-workflows/.github/actions/hatch-release-prep@main
         with:
-          version: ${{ github.event.inputs.exact_version != '' && github.event.inputs.exact_version || github.event.inputs.version }}
+          version: ${{ github.event.inputs.exact_version || github.event.inputs.version }}
 
       # Publish using Trusted Publishing - must be directly in workflow, not in composite action
       # See: https://docs.pypi.org/trusted-publishers/using-a-publisher/


### PR DESCRIPTION
### What is the purpose of this change?

 Need ability to release exact version to PYPI to fix a release workflow

### How was this change implemented?

Pass the exact version to the release workflow 

### How was this change tested?

can only validate during release 
