### PR TITLE
fix: enable task_logging in webui config template

### DIFF
--- a/examples/gateways/webui_gateway_example.yaml
+++ b/examples/gateways/webui_gateway_example.yaml
@@ -83,6 +83,27 @@ apps:
       frontend_collect_feedback: true
       frontend_logo_url: "${WEBUI_FRONTEND_LOGO_URL}"
 
+      task_logging:
+        enabled: true
+        log_status_updates: true
+        log_artifact_events: true
+        log_file_parts: true
+        max_file_part_size_bytes: 10240
+
+      feedback_publishing:
+        enabled: true
+        topic: "${NAMESPACE}/sam/feedback/v1"
+        include_task_info: "stim" # Options: "none", "summary", "stim"
+        max_payload_size_bytes: 9000000 # 9MB default, safety margin below 10MB broker limit
+
+      # --- Frontend Feature Enablement ---
+      frontend_feature_enablement:
+        background_tasks: ${BACKGROUND_TASKS_ENABLED, true} # NOTE: task_logging must also be enabled for background tasks to work
+
+      # --- Background Tasks Configuration ---
+      background_tasks:
+        default_timeout_ms: ${BACKGROUND_TASKS_TIMEOUT_MS, 3600000}  # 1 hour default timeout
+
       # # --- Speech Configuration (STT/TTS) ---
       # # Uncomment the following sections to enable STT and TTS in the UI
       # speech:
@@ -201,23 +222,6 @@ apps:
       #       playbackRate: 1.0
       #       cacheTTS: true
 
-      task_logging:
-        enabled: true
-        log_status_updates: true
-        log_artifact_events: true
-        log_file_parts: true
-        max_file_part_size_bytes: 10240
-
-      feedback_publishing:
-        enabled: true
-        topic: "${NAMESPACE}/sam/feedback/v1"
-        include_task_info: "stim" # Options: "none", "summary", "stim"
-        max_payload_size_bytes: 9000000 # 9MB default, safety margin below 10MB broker limit
-
-      # --- Background Tasks Configuration ---
-      background_tasks:
-        enabled: ${BACKGROUND_TASKS_ENABLED, true}  # Enable background task execution for all tasks
-        default_timeout_ms: ${BACKGROUND_TASKS_TIMEOUT_MS, 3600000}  # 1 hour default timeout
 
       # --- Data Retention Configuration ---
       # Automatically cleans up old tasks, task events, and feedback to prevent unbounded database growth

--- a/templates/webui.yaml
+++ b/templates/webui.yaml
@@ -60,6 +60,13 @@ apps:
       frontend_bot_name: __FRONTEND_BOT_NAME__
       frontend_collect_feedback: __FRONTEND_COLLECT_FEEDBACK__
       frontend_logo_url: __FRONTEND_LOGO_URL__
+
+      task_logging:
+        enabled: true
+        log_status_updates: true
+        log_artifact_events: true
+        log_file_parts: true
+        max_file_part_size_bytes: 10240
       
       # --- Frontend Feature Flags ---
       # Uncomment to control speech features in the UI
@@ -68,7 +75,7 @@ apps:
       #   textToSpeech: true   # Set to false to hide Text-to-Speech settings & speaker button
       #   projects: true
       #   promptLibrary: true
-        background_tasks: true  # Enable background task execution
+        background_tasks: true  # NOTE: task_logging must also be enabled for background tasks to work
 
       # --- Background Tasks Configuration ---
       background_tasks:


### PR DESCRIPTION
This pull request updates configuration files for the web UI gateway example and template, improving the structure and clarity of feature enablement and background task settings. The main changes involve reorganizing configuration sections, clarifying dependencies between features, and ensuring consistent default values.

Configuration restructuring and clarity:

* Moved `task_logging` and `feedback_publishing` settings earlier in the `apps:` section of `webui_gateway_example.yaml` for better visibility and organization.
* Added comments and clarified that `task_logging` must be enabled for background tasks to work in both `webui_gateway_example.yaml` and `webui.yaml`. [[1]](diffhunk://#diff-f1ac30e8129641b9d670bd61bc5cf96a026eb43efa52b4e1804768a3ecf3d923R86-R106) [[2]](diffhunk://#diff-7bca0157a79bca5b8db31d8d473de52a2bd2311f5e2f95565b977ea03319b93aR64-R78)

Background tasks configuration:

* Changed the `background_tasks` section in `webui_gateway_example.yaml` to remove the explicit `enabled` flag, instead using a feature flag under `frontend_feature_enablement` to control background task execution. [[1]](diffhunk://#diff-f1ac30e8129641b9d670bd61bc5cf96a026eb43efa52b4e1804768a3ecf3d923R86-R106) [[2]](diffhunk://#diff-f1ac30e8129641b9d670bd61bc5cf96a026eb43efa52b4e1804768a3ecf3d923L204-L220)
* Updated the default timeout for background tasks to remain at 1 hour, now set via `${BACKGROUND_TASKS_TIMEOUT_MS, 3600000}` in both files. [[1]](diffhunk://#diff-f1ac30e8129641b9d670bd61bc5cf96a026eb43efa52b4e1804768a3ecf3d923R86-R106) [[2]](diffhunk://#diff-f1ac30e8129641b9d670bd61bc5cf96a026eb43efa52b4e1804768a3ecf3d923L204-L220)

Feature enablement and defaults:

* Ensured that feature flags and configuration values are consistently set and documented in both the example and template files, improving maintainability and reducing confusion for future updates. [[1]](diffhunk://#diff-f1ac30e8129641b9d670bd61bc5cf96a026eb43efa52b4e1804768a3ecf3d923R86-R106) [[2]](diffhunk://#diff-7bca0157a79bca5b8db31d8d473de52a2bd2311f5e2f95565b977ea03319b93aR64-R78)