### PR TITLE
chore(DATAGO-121914): WF PR 15 - Fix breadcrumbs when navigating to sub-workflows

### DIFF
--- a/client/webui/frontend/src/lib/components/workflowVisualization/WorkflowDiagram.tsx
+++ b/client/webui/frontend/src/lib/components/workflowVisualization/WorkflowDiagram.tsx
@@ -61,6 +61,10 @@ interface WorkflowDiagramProps {
     canvasRef?: React.RefObject<PanZoomCanvasRef | null>;
     /** Callback when content size changes (for fit-to-view calculations) */
     onContentSizeChange?: (width: number, height: number) => void;
+    /** Current workflow name - used for building sub-workflow navigation URLs */
+    currentWorkflowName?: string;
+    /** Parent workflow path (for breadcrumb navigation) */
+    parentPath?: string[];
 }
 
 /**
@@ -78,6 +82,8 @@ const WorkflowDiagram: React.FC<WorkflowDiagramProps> = ({
     onTransformChange,
     canvasRef: externalCanvasRef,
     onContentSizeChange,
+    currentWorkflowName,
+    parentPath,
 }) => {
     const internalCanvasRef = useRef<PanZoomCanvasRef>(null);
     const canvasRef = externalCanvasRef || internalCanvasRef;
@@ -240,6 +246,8 @@ const WorkflowDiagram: React.FC<WorkflowDiagramProps> = ({
                         onHighlightNodes={handleHighlightNodes}
                         knownNodeIds={knownNodeIds}
                         nodeRefs={nodeRefs}
+                        currentWorkflowName={currentWorkflowName}
+                        parentPath={parentPath}
                     />
                 </div>
             </PanZoomCanvas>

--- a/client/webui/frontend/src/lib/components/workflowVisualization/WorkflowNodeDetailPanel.tsx
+++ b/client/webui/frontend/src/lib/components/workflowVisualization/WorkflowNodeDetailPanel.tsx
@@ -25,6 +25,7 @@ import { Tabs, TabsList, TabsTrigger, TabsContent } from "@/lib/components/ui/ta
 import { Button } from "@/lib/components/ui/button";
 import { JSONViewer } from "@/lib/components/jsonViewer";
 import InputMappingViewer from "./InputMappingViewer";
+import { buildWorkflowNavigationUrl } from "./WorkflowVisualizationPage";
 
 interface WorkflowNodeDetailPanelProps {
     node: LayoutNode | null;
@@ -37,6 +38,10 @@ interface WorkflowNodeDetailPanelProps {
     knownNodeIds?: Set<string>;
     /** Callback to navigate/pan to a node when clicking the navigation icon */
     onNavigateToNode?: (nodeId: string) => void;
+    /** Current workflow name - used for building sub-workflow navigation URLs */
+    currentWorkflowName?: string;
+    /** Parent workflow path (for breadcrumb navigation) */
+    parentPath?: string[];
 }
 
 /**
@@ -51,6 +56,8 @@ const WorkflowNodeDetailPanel: React.FC<WorkflowNodeDetailPanelProps> = ({
     onHighlightNodes,
     knownNodeIds,
     onNavigateToNode,
+    currentWorkflowName,
+    parentPath = [],
 }) => {
     // workflowConfig is available for future use (e.g., accessing workflow-level output_mapping)
     void _workflowConfig;
@@ -106,12 +113,16 @@ const WorkflowNodeDetailPanel: React.FC<WorkflowNodeDetailPanelProps> = ({
         setShowCodeView(false);
     }, []);
 
-    // Navigate to nested workflow
+    // Navigate to nested workflow with parent path tracking for breadcrumbs
     const handleOpenWorkflow = useCallback(() => {
         if (node?.data.workflowName) {
-            navigate(`/agents/workflows/${encodeURIComponent(node.data.workflowName)}`);
+            // Build new parent path: current workflow becomes closest parent
+            const newParentPath = currentWorkflowName
+                ? [currentWorkflowName, ...parentPath]
+                : parentPath;
+            navigate(buildWorkflowNavigationUrl(node.data.workflowName, newParentPath));
         }
-    }, [navigate, node?.data.workflowName]);
+    }, [navigate, node?.data.workflowName, currentWorkflowName, parentPath]);
 
     if (!node) {
         return null;

--- a/client/webui/frontend/src/lib/components/workflowVisualization/WorkflowNodeRenderer.tsx
+++ b/client/webui/frontend/src/lib/components/workflowVisualization/WorkflowNodeRenderer.tsx
@@ -19,6 +19,10 @@ interface WorkflowNodeRendererProps {
     onHighlightNodes?: (nodeIds: string[]) => void;
     knownNodeIds?: Set<string>;
     nodeRefs: React.MutableRefObject<Map<string, HTMLDivElement>>;
+    /** Current workflow name - used for building sub-workflow navigation URLs */
+    currentWorkflowName?: string;
+    /** Parent workflow path (for breadcrumb navigation) */
+    parentPath?: string[];
 }
 
 /**
@@ -35,6 +39,8 @@ const WorkflowNodeRenderer: React.FC<WorkflowNodeRendererProps> = ({
     onHighlightNodes,
     knownNodeIds,
     nodeRefs,
+    currentWorkflowName,
+    parentPath,
 }) => {
     // Track mounted node IDs for cleanup
     const mountedNodeIds = useRef<Set<string>>(new Set());
@@ -95,6 +101,8 @@ const WorkflowNodeRenderer: React.FC<WorkflowNodeRendererProps> = ({
             onCollapse,
             onHighlightNodes,
             knownNodeIds,
+            currentWorkflowName,
+            parentPath,
         };
 
         switch (node.type) {

--- a/client/webui/frontend/src/lib/components/workflowVisualization/index.ts
+++ b/client/webui/frontend/src/lib/components/workflowVisualization/index.ts
@@ -1,5 +1,5 @@
 // Workflow Visualization Components
-export { WorkflowVisualizationPage } from "./WorkflowVisualizationPage";
+export { WorkflowVisualizationPage, buildWorkflowNavigationUrl } from "./WorkflowVisualizationPage";
 export { default as WorkflowDiagram } from "./WorkflowDiagram";
 export { default as WorkflowNodeRenderer } from "./WorkflowNodeRenderer";
 export { default as WorkflowNodeDetailPanel } from "./WorkflowNodeDetailPanel";

--- a/client/webui/frontend/src/lib/components/workflowVisualization/nodes/WorkflowRefNode.tsx
+++ b/client/webui/frontend/src/lib/components/workflowVisualization/nodes/WorkflowRefNode.tsx
@@ -2,13 +2,21 @@ import React from "react";
 import { Workflow, ExternalLink } from "lucide-react";
 import { useNavigate } from "react-router-dom";
 import { NODE_HIGHLIGHT_CLASSES, NODE_SELECTED_CLASSES, type NodeProps } from "../utils/types";
+import { buildWorkflowNavigationUrl } from "../WorkflowVisualizationPage";
 
 /**
  * Workflow reference node - Rectangle with workflow icon, name, and "Workflow" badge
  * Clicking navigates to the referenced workflow's visualization
  * Supports highlighting when referenced in expressions
  */
-const WorkflowRefNode: React.FC<NodeProps> = ({ node, isSelected, isHighlighted, onClick }) => {
+const WorkflowRefNode: React.FC<NodeProps> = ({
+    node,
+    isSelected,
+    isHighlighted,
+    onClick,
+    currentWorkflowName,
+    parentPath = [],
+}) => {
     const navigate = useNavigate();
     const workflowName = node.data.workflowName || node.data.agentName || node.data.label;
 
@@ -20,7 +28,11 @@ const WorkflowRefNode: React.FC<NodeProps> = ({ node, isSelected, isHighlighted,
     const handleNavigate = (e: React.MouseEvent) => {
         e.stopPropagation();
         if (workflowName) {
-            navigate(`/agents/workflows/${encodeURIComponent(workflowName)}`);
+            // Build new parent path: current workflow becomes closest parent
+            const newParentPath = currentWorkflowName
+                ? [currentWorkflowName, ...parentPath]
+                : parentPath;
+            navigate(buildWorkflowNavigationUrl(workflowName, newParentPath));
         }
     };
 

--- a/client/webui/frontend/src/lib/components/workflowVisualization/utils/types.ts
+++ b/client/webui/frontend/src/lib/components/workflowVisualization/utils/types.ts
@@ -98,6 +98,10 @@ export interface NodeProps {
     onCollapse?: (nodeId: string) => void;
     onHighlightNodes?: (nodeIds: string[]) => void;
     knownNodeIds?: Set<string>;
+    /** Current workflow name - used for building sub-workflow navigation URLs */
+    currentWorkflowName?: string;
+    /** Parent workflow path (for breadcrumb navigation) */
+    parentPath?: string[];
 }
 
 /**


### PR DESCRIPTION
## Summary

- Fixed breadcrumb navigation when clicking on sub-workflows from the workflow visualization page
- Added URL-based parent workflow path tracking (`?from=parent1,parent2,...`)
- Dynamic breadcrumbs now show the full navigation chain: `Agents → Workflows → [Parent] → [Sub-Workflow]`
- Each parent workflow in breadcrumbs is clickable and preserves navigation context

## Test plan

- [ ] Open a workflow that contains sub-workflow nodes
- [ ] Click on a sub-workflow node's external link icon to navigate to it
- [ ] Verify breadcrumbs show: `Agents > Workflows > [Parent Workflow] > [Sub-Workflow]`
- [ ] Click on the parent workflow breadcrumb to navigate back
- [ ] Verify the parent workflow loads correctly
- [ ] Test with deeply nested workflows (grandchild) to verify full path tracking