### PR TITLE
chore(DATAGO-121448): WF PR 16 - Rename Activity view to avoid naming collision

### DIFF
--- a/client/webui/frontend/src/lib/components/chat/ChatMessage.tsx
+++ b/client/webui/frontend/src/lib/components/chat/ChatMessage.tsx
@@ -264,7 +264,7 @@ const getChatBubble = (message: MessageFE, chatContext: ChatContextValue, isLast
     const handleViewWorkflowClick = () => {
         if (message.taskId) {
             setTaskIdInSidePanel(message.taskId);
-            openSidePanelTab("workflow");
+            openSidePanelTab("activity");
         }
     };
 

--- a/client/webui/frontend/src/lib/components/chat/ChatSidePanel.tsx
+++ b/client/webui/frontend/src/lib/components/chat/ChatSidePanel.tsx
@@ -26,7 +26,7 @@ export const ChatSidePanel: React.FC<ChatSidePanelProps> = ({ onCollapsedToggle,
     // Track which task IDs we've already attempted to load to prevent duplicate loads
     const loadAttemptedRef = React.useRef<Set<string>>(new Set());
 
-    // Process task data for visualization when the selected workflow task ID changes
+    // Process task data for visualization when the selected activity task ID changes
     // or when monitoredTasks is updated with new data
     useEffect(() => {
         if (!taskIdInSidePanel) {
@@ -96,11 +96,11 @@ export const ChatSidePanel: React.FC<ChatSidePanelProps> = ({ onCollapsedToggle,
         }
     }, [taskIdInSidePanel]);
 
-    // Helper function to determine what to display in the workflow panel
-    const getWorkflowPanelContent = () => {
+    // Helper function to determine what to display in the activity panel
+    const getActivityPanelContent = () => {
         if (isLoadingTask) {
             return {
-                message: "Loading workflow data...",
+                message: "Loading activity data...",
                 showButton: false,
             };
         }
@@ -130,7 +130,7 @@ export const ChatSidePanel: React.FC<ChatSidePanelProps> = ({ onCollapsedToggle,
 
         if (!visualizedTask) {
             return {
-                message: "No workflow data available for the selected task",
+                message: "No activity data available for the selected task",
                 showButton: false,
             };
         }
@@ -144,7 +144,7 @@ export const ChatSidePanel: React.FC<ChatSidePanelProps> = ({ onCollapsedToggle,
         onCollapsedToggle(newCollapsed);
     };
 
-    const handleTabClick = (tab: "files" | "workflow") => {
+    const handleTabClick = (tab: "files" | "activity") => {
         if (tab === "files") {
             setPreviewArtifact(null);
         }
@@ -152,7 +152,7 @@ export const ChatSidePanel: React.FC<ChatSidePanelProps> = ({ onCollapsedToggle,
         setActiveSidePanelTab(tab);
     };
 
-    const handleIconClick = (tab: "files" | "workflow") => {
+    const handleIconClick = (tab: "files" | "activity") => {
         if (isSidePanelCollapsed) {
             setIsSidePanelCollapsed(false);
             onCollapsedToggle?.(false);
@@ -175,7 +175,7 @@ export const ChatSidePanel: React.FC<ChatSidePanelProps> = ({ onCollapsedToggle,
                     <FileText className="size-5" />
                 </Button>
 
-                <Button variant="ghost" size="sm" onClick={() => handleIconClick("workflow")} className="h-10 w-10 p-0" tooltip="Workflow">
+                <Button variant="ghost" size="sm" onClick={() => handleIconClick("activity")} className="h-10 w-10 p-0" tooltip="Activity">
                     <Network className="size-5" />
                 </Button>
             </div>
@@ -186,7 +186,7 @@ export const ChatSidePanel: React.FC<ChatSidePanelProps> = ({ onCollapsedToggle,
     return (
         <div className="bg-background flex h-full flex-col border-l">
             <div className="m-1 min-h-0 flex-1">
-                <Tabs value={activeSidePanelTab} onValueChange={value => handleTabClick(value as "files" | "workflow")} className="flex h-full flex-col">
+                <Tabs value={activeSidePanelTab} onValueChange={value => handleTabClick(value as "files" | "activity")} className="flex h-full flex-col">
                     <div className="flex gap-2 p-2">
                         <Button data-testid="collapsePanel" variant="ghost" onClick={toggleCollapsed} className="p-1" tooltip="Collapse Panel">
                             <PanelRightIcon className="size-5" />
@@ -202,12 +202,12 @@ export const ChatSidePanel: React.FC<ChatSidePanelProps> = ({ onCollapsedToggle,
                                 Files
                             </TabsTrigger>
                             <TabsTrigger
-                                value="workflow"
-                                title="Workflow"
+                                value="activity"
+                                title="Activity"
                                 className="border-border bg-muted data-[state=active]:bg-background relative cursor-pointer rounded-none rounded-r-md border border-l-0 data-[state=active]:z-10 data-[state=active]:border-l-0"
                             >
                                 <Network className="mr-2 h-4 w-4" />
-                                Workflow
+                                Activity
                             </TabsTrigger>
                         </TabsList>
                     </div>
@@ -218,10 +218,10 @@ export const ChatSidePanel: React.FC<ChatSidePanelProps> = ({ onCollapsedToggle,
                             </div>
                         </TabsContent>
 
-                        <TabsContent value="workflow" className="m-0 h-full">
+                        <TabsContent value="activity" className="m-0 h-full">
                             <div className="h-full">
                                 {(() => {
-                                    const emptyStateContent = getWorkflowPanelContent();
+                                    const emptyStateContent = getActivityPanelContent();
 
                                     if (!emptyStateContent && visualizedTask) {
                                         return (
@@ -236,7 +236,7 @@ export const ChatSidePanel: React.FC<ChatSidePanelProps> = ({ onCollapsedToggle,
                                         <div className="flex h-full items-center justify-center p-4">
                                             <div className="text-muted-foreground text-center">
                                                 <Network className="mx-auto mb-4 h-12 w-12" />
-                                                <div className="text-lg font-medium">Workflow</div>
+                                                <div className="text-lg font-medium">Activity</div>
                                                 <div className="mt-2 text-sm">{emptyStateContent?.message}</div>
                                                 {emptyStateContent?.showButton && (
                                                     <div className="mt-4">

--- a/client/webui/frontend/src/lib/components/pages/ChatPage.tsx
+++ b/client/webui/frontend/src/lib/components/pages/ChatPage.tsx
@@ -165,7 +165,7 @@ export function ChatPage() {
 
         return () => {
             setTaskIdInSidePanel(currentTaskId);
-            openSidePanelTab("workflow");
+            openSidePanelTab("activity");
         };
     }, [currentTaskId, setTaskIdInSidePanel, openSidePanelTab]);
 

--- a/client/webui/frontend/src/lib/components/ui/ViewWorkflowButton.tsx
+++ b/client/webui/frontend/src/lib/components/ui/ViewWorkflowButton.tsx
@@ -7,9 +7,9 @@ interface ViewWorkflowButtonProps {
     text?: string;
 }
 
-export const ViewWorkflowButton: React.FC<ViewWorkflowButtonProps> = ({ onClick, text = "View Agent Workflow" }) => {
+export const ViewWorkflowButton: React.FC<ViewWorkflowButtonProps> = ({ onClick, text = "View Activity" }) => {
     return (
-        <Button data-testid="viewAgentWorkflow" variant="ghost" size="sm" onClick={onClick} tooltip={text}>
+        <Button data-testid="viewActivity" variant="ghost" size="sm" onClick={onClick} tooltip={text}>
             <Network className="h-4 w-4" />
         </Button>
     );

--- a/client/webui/frontend/src/lib/contexts/ChatContext.ts
+++ b/client/webui/frontend/src/lib/contexts/ChatContext.ts
@@ -35,7 +35,7 @@ export interface ChatState {
     taskIdInSidePanel: string | null;
     // Side Panel Control State
     isSidePanelCollapsed: boolean;
-    activeSidePanelTab: "files" | "workflow";
+    activeSidePanelTab: "files" | "activity";
     // Delete Modal State
     isDeleteModalOpen: boolean;
     artifactToDelete: ArtifactInfo | null;
@@ -77,8 +77,8 @@ export interface ChatActions {
     uploadArtifactFile: (file: File, overrideSessionId?: string, description?: string, silent?: boolean) => Promise<{ uri: string; sessionId: string } | { error: string } | null>;
     /** Side Panel Control Actions */
     setIsSidePanelCollapsed: React.Dispatch<React.SetStateAction<boolean>>;
-    setActiveSidePanelTab: React.Dispatch<React.SetStateAction<"files" | "workflow">>;
-    openSidePanelTab: (tab: "files" | "workflow") => void;
+    setActiveSidePanelTab: React.Dispatch<React.SetStateAction<"files" | "activity">>;
+    openSidePanelTab: (tab: "files" | "activity") => void;
 
     openDeleteModal: (artifact: ArtifactInfo) => void;
     closeDeleteModal: () => void;

--- a/client/webui/frontend/src/lib/providers/ChatProvider.tsx
+++ b/client/webui/frontend/src/lib/providers/ChatProvider.tsx
@@ -128,7 +128,7 @@ export const ChatProvider: React.FC<ChatProviderProps> = ({ children }) => {
 
     // Side Panel Control State
     const [isSidePanelCollapsed, setIsSidePanelCollapsed] = useState<boolean>(true);
-    const [activeSidePanelTab, setActiveSidePanelTab] = useState<"files" | "workflow">("files");
+    const [activeSidePanelTab, setActiveSidePanelTab] = useState<"files" | "activity">("files");
 
     // Delete Modal State
     const [isDeleteModalOpen, setIsDeleteModalOpen] = useState(false);
@@ -774,7 +774,7 @@ export const ChatProvider: React.FC<ChatProviderProps> = ({ children }) => {
         [artifacts, previewedArtifactAvailableVersions, sessionId, activeProject?.id, setError]
     );
 
-    const openSidePanelTab = useCallback((tab: "files" | "workflow") => {
+    const openSidePanelTab = useCallback((tab: "files" | "activity") => {
         setIsSidePanelCollapsed(false);
         setActiveSidePanelTab(tab);
 


### PR DESCRIPTION
## Summary

- Renamed the "Workflow" tab in the chat side panel to "Activity" to avoid confusion with the new Workflows feature
- Updated all related type definitions, function names, and user-visible strings
- Changed the "View Agent Workflow" button tooltip to "View Activity"

## Files Changed

- `ChatContext.ts` - Updated type definitions
- `ChatProvider.tsx` - Updated state and function types
- `ChatSidePanel.tsx` - Updated tab labels, tooltips, and internal function names
- `ChatMessage.tsx` - Updated function call
- `ChatPage.tsx` - Updated function call
- `ViewWorkflowButton.tsx` - Updated default tooltip text

## Test plan

- [ ] Open the chat interface
- [ ] Collapse the side panel and hover over the Network icon - verify tooltip says "Activity"
- [ ] Expand the side panel - verify the tab says "Activity" (not "Workflow")
- [ ] Click on the Activity tab - verify empty state heading says "Activity"
- [ ] Send a message and wait for response - verify "View Activity" button appears
- [ ] Click "View Activity" button - verify the Activity tab opens with the task visualization