### PR TITLE
chore(DATAGO-121930): WF PR 17 - Make workflow list table consistent with enterprise connector table

### DIFF
--- a/client/webui/frontend/src/lib/components/workflowVisualization/CanvasControls.tsx
+++ b/client/webui/frontend/src/lib/components/workflowVisualization/CanvasControls.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { ZoomIn, ZoomOut, Maximize2 } from "lucide-react";
+import { ZoomIn, ZoomOut, Home } from "lucide-react";
 
 export interface CanvasControlsProps {
     /** Current zoom level as a decimal (e.g., 0.83 for 83%) */
@@ -43,7 +43,7 @@ export const CanvasControls: React.FC<CanvasControlsProps> = ({
                 className="flex h-8 w-8 items-center justify-center rounded p-0 text-gray-600 hover:bg-gray-100 hover:text-gray-900 dark:text-gray-400 dark:hover:bg-gray-700 dark:hover:text-gray-100"
                 title="Fit diagram to view"
             >
-                <Maximize2 className="h-4 w-4" />
+                <Home className="h-4 w-4" />
             </button>
 
             {/* Separator */}

--- a/client/webui/frontend/src/lib/components/workflows/WorkflowList.tsx
+++ b/client/webui/frontend/src/lib/components/workflows/WorkflowList.tsx
@@ -1,22 +1,17 @@
-import React, { useState, useMemo, useEffect, useRef, useCallback } from "react";
+import React, { useState, useMemo, useEffect } from "react";
 import { useNavigate } from "react-router-dom";
+import { Search, Workflow } from "lucide-react";
 
 import type { AgentCardInfo } from "@/lib/types";
 import { getWorkflowConfig } from "@/lib/utils/agentUtils";
-import { SearchInput } from "@/lib/components/ui";
 import { EmptyState } from "@/lib/components/common";
+import { Button } from "@/lib/components/ui/button";
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/lib/components/ui/table";
 import { Pagination, PaginationContent, PaginationItem, PaginationLink, PaginationNext, PaginationPrevious, PaginationEllipsis } from "@/lib/components/ui/pagination";
-import { Workflow } from "lucide-react";
 import { WorkflowDetailPanel } from "./WorkflowDetailPanel";
 import { WorkflowOnboardingBanner } from "./WorkflowOnboardingBanner";
 
-// Panel width configuration (pixels)
-const DETAIL_PANEL_WIDTHS = { default: 400, min: 280, max: 800 };
-
 const WorkflowImage = <Workflow className="text-muted-foreground" size={64} />;
-
-const ITEMS_PER_PAGE = 20;
 
 interface WorkflowListProps {
     workflows: AgentCardInfo[];
@@ -24,73 +19,58 @@ interface WorkflowListProps {
 
 export const WorkflowList: React.FC<WorkflowListProps> = ({ workflows }) => {
     const navigate = useNavigate();
-    const [searchQuery, setSearchQuery] = useState<string>("");
+    const [searchTerm, setSearchTerm] = useState<string>("");
     const [currentPage, setCurrentPage] = useState<number>(1);
+    const [screenHeight, setScreenHeight] = useState<number>(typeof window !== "undefined" ? window.innerHeight : 768);
     const [selectedWorkflow, setSelectedWorkflow] = useState<AgentCardInfo | null>(null);
-    const [panelWidth, setPanelWidth] = useState<number>(DETAIL_PANEL_WIDTHS.default);
-    const [shouldAnimate, setShouldAnimate] = useState(false);
-    const prevSelectedRef = useRef<AgentCardInfo | null>(null);
-    const containerRef = useRef<HTMLDivElement>(null);
-    const isResizing = useRef(false);
+    const [isSidePanelOpen, setIsSidePanelOpen] = useState<boolean>(false);
 
-    // Track when panel opens to trigger animation only on initial open
+    // Responsive itemsPerPage based on screen height
+    const itemsPerPage = screenHeight >= 900 ? 20 : 10;
+
+    // Handle screen resize
     useEffect(() => {
-        if (selectedWorkflow && !prevSelectedRef.current) {
-            // Panel just opened
-            setShouldAnimate(true);
-            const timer = setTimeout(() => setShouldAnimate(false), 300);
-            return () => clearTimeout(timer);
-        }
-        prevSelectedRef.current = selectedWorkflow;
-    }, [selectedWorkflow]);
-
-    // Handle resize drag
-    const handleResizeStart = useCallback((e: React.MouseEvent) => {
-        e.preventDefault();
-        isResizing.current = true;
-        document.body.style.cursor = "col-resize";
-        document.body.style.userSelect = "none";
-
-        const handleMouseMove = (e: MouseEvent) => {
-            if (!isResizing.current || !containerRef.current) return;
-            const containerRect = containerRef.current.getBoundingClientRect();
-            const newWidth = containerRect.right - e.clientX;
-            setPanelWidth(Math.max(DETAIL_PANEL_WIDTHS.min, Math.min(DETAIL_PANEL_WIDTHS.max, newWidth)));
+        const handleResize = () => {
+            if (typeof window !== "undefined") {
+                setScreenHeight(window.innerHeight);
+            }
         };
 
-        const handleMouseUp = () => {
-            isResizing.current = false;
-            document.body.style.cursor = "";
-            document.body.style.userSelect = "";
-            document.removeEventListener("mousemove", handleMouseMove);
-            document.removeEventListener("mouseup", handleMouseUp);
-        };
-
-        document.addEventListener("mousemove", handleMouseMove);
-        document.addEventListener("mouseup", handleMouseUp);
+        window.addEventListener("resize", handleResize);
+        return () => window.removeEventListener("resize", handleResize);
     }, []);
 
+    // Filter and sort workflows
     const filteredWorkflows = useMemo(() => {
-        return workflows.filter(workflow => (workflow.displayName || workflow.name)?.toLowerCase().includes(searchQuery.toLowerCase()));
-    }, [workflows, searchQuery]);
+        if (!workflows || workflows.length === 0) return [];
 
-    const totalPages = Math.ceil(filteredWorkflows.length / ITEMS_PER_PAGE);
-    const startIndex = (currentPage - 1) * ITEMS_PER_PAGE;
-    const endIndex = startIndex + ITEMS_PER_PAGE;
-    const paginatedWorkflows = filteredWorkflows.slice(startIndex, endIndex);
+        let result = searchTerm.trim()
+            ? workflows.filter(workflow => (workflow.displayName || workflow.name)?.toLowerCase().includes(searchTerm.toLowerCase()))
+            : workflows;
 
-    const handleRowClick = (workflow: AgentCardInfo) => {
-        setSelectedWorkflow(workflow);
-    };
+        return result.slice().sort((a, b) => (a.displayName || a.name).localeCompare(b.displayName || b.name));
+    }, [workflows, searchTerm]);
 
-    const handleNameClick = (e: React.MouseEvent, workflow: AgentCardInfo) => {
-        e.stopPropagation(); // Prevent row click from selecting workflow
-        navigate(`/agents/workflows/${encodeURIComponent(workflow.name)}`);
-    };
+    // Calculate pagination
+    const totalPages = Math.ceil(filteredWorkflows.length / itemsPerPage);
+    const effectiveCurrentPage = Math.min(currentPage, Math.max(totalPages, 1));
+    const startIndex = (effectiveCurrentPage - 1) * itemsPerPage;
+    const endIndex = startIndex + itemsPerPage;
+    const currentWorkflows = filteredWorkflows.slice(startIndex, endIndex);
 
-    const handleClosePanel = () => {
-        setSelectedWorkflow(null);
-    };
+    // Reset to page 1 when search changes
+    useEffect(() => {
+        setCurrentPage(1);
+    }, [searchTerm]);
+
+    // Close side panel when workflows list changes (e.g., workflow removed)
+    useEffect(() => {
+        if (!selectedWorkflow) return;
+        if (workflows?.some(workflow => workflow.name === selectedWorkflow.name) === false) {
+            setIsSidePanelOpen(false);
+            setSelectedWorkflow(null);
+        }
+    }, [workflows, selectedWorkflow]);
 
     const handlePageChange = (page: number) => {
         if (page >= 1 && page <= totalPages) {
@@ -98,13 +78,29 @@ export const WorkflowList: React.FC<WorkflowListProps> = ({ workflows }) => {
         }
     };
 
+    const handleSelectWorkflow = (workflow: AgentCardInfo | null) => {
+        if (workflow) {
+            setSelectedWorkflow(workflow);
+            setIsSidePanelOpen(true);
+        }
+    };
+
+    const handleCloseSidePanel = () => {
+        setSelectedWorkflow(null);
+        setIsSidePanelOpen(false);
+    };
+
+    const handleViewWorkflow = (workflow: AgentCardInfo) => {
+        navigate(`/agents/workflows/${encodeURIComponent(workflow.name)}`);
+    };
+
     const getWorkflowDescription = (workflow: AgentCardInfo): string => {
         const config = getWorkflowConfig(workflow);
         return config?.description || workflow.description || "No description";
     };
 
-    const renderPaginationNumbers = () => {
-        const pages: (number | "ellipsis")[] = [];
+    const getPageNumbers = () => {
+        const pages: (number | string)[] = [];
         const maxVisiblePages = 5;
 
         if (totalPages <= maxVisiblePages) {
@@ -112,85 +108,137 @@ export const WorkflowList: React.FC<WorkflowListProps> = ({ workflows }) => {
                 pages.push(i);
             }
         } else {
-            pages.push(1);
-            if (currentPage > 3) {
+            if (effectiveCurrentPage <= 3) {
+                for (let i = 1; i <= 4; i++) {
+                    pages.push(i);
+                }
                 pages.push("ellipsis");
-            }
-            const start = Math.max(2, currentPage - 1);
-            const end = Math.min(totalPages - 1, currentPage + 1);
-            for (let i = start; i <= end; i++) {
-                pages.push(i);
-            }
-            if (currentPage < totalPages - 2) {
+                pages.push(totalPages);
+            } else if (effectiveCurrentPage >= totalPages - 2) {
+                pages.push(1);
                 pages.push("ellipsis");
+                for (let i = totalPages - 3; i <= totalPages; i++) {
+                    pages.push(i);
+                }
+            } else {
+                pages.push(1);
+                pages.push("ellipsis");
+                for (let i = effectiveCurrentPage - 1; i <= effectiveCurrentPage + 1; i++) {
+                    pages.push(i);
+                }
+                pages.push("ellipsis");
+                pages.push(totalPages);
             }
-            pages.push(totalPages);
         }
 
-        return pages.map((page, index) =>
-            page === "ellipsis" ? (
-                <PaginationItem key={`ellipsis-${index}`}>
-                    <PaginationEllipsis />
-                </PaginationItem>
-            ) : (
-                <PaginationItem key={page}>
-                    <PaginationLink onClick={() => handlePageChange(page)} isActive={currentPage === page} className="cursor-pointer">
-                        {page}
-                    </PaginationLink>
-                </PaginationItem>
-            )
-        );
+        return pages;
     };
 
     if (workflows.length === 0) {
         return <EmptyState image={WorkflowImage} title="No workflows found" subtitle="No workflows discovered in the current namespace." />;
     }
 
-    return (
-        <div ref={containerRef} className="bg-muted flex h-full dark:bg-[var(--color-bg-wMain)]">
-            {/* Left side: banner + table - shrinks when panel opens */}
-            <div className="flex min-h-0 min-w-0 flex-1 flex-col">
-                <WorkflowOnboardingBanner />
-                {/* Table section */}
-                <div className="flex min-h-0 min-w-0 flex-1 flex-col px-6 pt-6">
-                    <SearchInput value={searchQuery} onChange={setSearchQuery} placeholder="Filter by name..." testid="workflowSearchInput" className="mb-4 w-xs" />
+    // Pagination controls component
+    const PaginationControls = () => {
+        if (totalPages <= 1) return null;
 
-                    {filteredWorkflows.length === 0 && searchQuery ? (
-                        <EmptyState variant="notFound" title="No Workflows Match Your Filter" subtitle="Try adjusting your filter terms." buttons={[{ text: "Clear Filter", variant: "default", onClick: () => setSearchQuery("") }]} />
-                    ) : (
-                        <div className="flex min-h-0 flex-1 flex-col pb-6">
-                            <div className="bg-background flex min-h-0 flex-1 flex-col overflow-auto rounded-sm border">
+        return (
+            <div className="border-border bg-background mt-4 flex flex-shrink-0 justify-center border-t pt-4 pb-2">
+                <Pagination>
+                    <PaginationContent>
+                        <PaginationItem>
+                            <PaginationPrevious
+                                onClick={() => handlePageChange(effectiveCurrentPage - 1)}
+                                className={effectiveCurrentPage === 1 ? "pointer-events-none opacity-50" : "cursor-pointer"}
+                            />
+                        </PaginationItem>
+
+                        {getPageNumbers().map((page, index) => (
+                            <PaginationItem key={index}>
+                                {page === "ellipsis" ? (
+                                    <PaginationEllipsis />
+                                ) : (
+                                    <PaginationLink
+                                        onClick={() => handlePageChange(page as number)}
+                                        isActive={effectiveCurrentPage === page}
+                                        className="cursor-pointer"
+                                    >
+                                        {page}
+                                    </PaginationLink>
+                                )}
+                            </PaginationItem>
+                        ))}
+
+                        <PaginationItem>
+                            <PaginationNext
+                                onClick={() => handlePageChange(effectiveCurrentPage + 1)}
+                                className={effectiveCurrentPage === totalPages ? "pointer-events-none opacity-50" : "cursor-pointer"}
+                            />
+                        </PaginationItem>
+                    </PaginationContent>
+                </Pagination>
+            </div>
+        );
+    };
+
+    return (
+        <div className="flex h-full w-full overflow-hidden">
+            {/* Main content container */}
+            <div className="flex flex-1 flex-col">
+                <WorkflowOnboardingBanner />
+                {/* Search Bar */}
+                <div className="mb-4 flex items-center justify-between p-6">
+                    <div className="flex w-full max-w-md flex-shrink-0 items-center gap-4">
+                        <div className="relative flex-1">
+                            <Search className="text-muted-foreground absolute top-1/2 left-3 h-4 w-4 -translate-y-1/2" />
+                            <input
+                                type="text"
+                                placeholder="Filter by name..."
+                                value={searchTerm}
+                                onChange={e => setSearchTerm(e.target.value)}
+                                data-testid="workflowSearchInput"
+                                className="border-input bg-background placeholder:text-muted-foreground focus:border-ring w-full rounded-sm border px-10 py-2 text-sm focus:outline-none"
+                            />
+                        </div>
+                    </div>
+                </div>
+
+                {/* Workflows table area */}
+                <div className="min-h-0 flex-1 overflow-y-auto pr-2 pl-6">
+                    <div className="h-full">
+                        {currentWorkflows.length > 0 ? (
+                            <div className="rounded-xs border">
                                 <Table>
                                     <TableHeader>
                                         <TableRow>
-                                            <TableHead className="w-[250px]">Name</TableHead>
-                                            <TableHead className="w-[100px]">Version</TableHead>
-                                            <TableHead className="w-[100px]">Status</TableHead>
-                                            <TableHead>Description</TableHead>
+                                            <TableHead className="font-semibold">
+                                                <div className="pl-4">Name</div>
+                                            </TableHead>
+                                            <TableHead className="w-[100px] font-semibold">Version</TableHead>
+                                            <TableHead className="w-[100px] font-semibold">Status</TableHead>
+                                            <TableHead className="font-semibold">Description</TableHead>
                                         </TableRow>
                                     </TableHeader>
                                     <TableBody>
-                                        {paginatedWorkflows.map(workflow => (
+                                        {currentWorkflows.map(workflow => (
                                             <TableRow
                                                 key={workflow.name}
-                                                onClick={() => handleRowClick(workflow)}
-                                                className={`cursor-pointer ${selectedWorkflow?.name === workflow.name ? "bg-gray-100 dark:bg-gray-700" : ""}`}
+                                                onClick={() => handleSelectWorkflow(workflow)}
+                                                className="hover:bg-muted/50 cursor-pointer"
+                                                data-state={selectedWorkflow?.name === workflow.name ? "selected" : undefined}
                                             >
-                                                <TableCell className="font-medium">
-                                                    <span
-                                                        onClick={e => handleNameClick(e, workflow)}
-                                                        className="cursor-pointer text-[var(--color-brand-wMain)] hover:underline"
-                                                        role="link"
-                                                        tabIndex={0}
-                                                        onKeyDown={e => {
-                                                            if (e.key === "Enter" || e.key === " ") {
-                                                                e.preventDefault();
-                                                                handleNameClick(e as unknown as React.MouseEvent, workflow);
-                                                            }
+                                                <TableCell>
+                                                    <Button
+                                                        testid={`workflow-name-${workflow.name}`}
+                                                        title={workflow.displayName || workflow.name}
+                                                        variant="link"
+                                                        onClick={e => {
+                                                            e.stopPropagation();
+                                                            handleViewWorkflow(workflow);
                                                         }}
                                                     >
                                                         {workflow.displayName || workflow.name}
-                                                    </span>
+                                                    </Button>
                                                 </TableCell>
                                                 <TableCell className="text-muted-foreground">{workflow.version || "N/A"}</TableCell>
                                                 <TableCell>
@@ -205,43 +253,26 @@ export const WorkflowList: React.FC<WorkflowListProps> = ({ workflows }) => {
                                     </TableBody>
                                 </Table>
                             </div>
-
-                            {totalPages > 1 && (
-                                <div className="bg-background mt-4 flex flex-shrink-0 justify-center border-t pt-4 pb-2">
-                                    <Pagination>
-                                        <PaginationContent>
-                                            <PaginationItem>
-                                                <PaginationPrevious onClick={() => handlePageChange(currentPage - 1)} className={currentPage === 1 ? "pointer-events-none opacity-50" : "cursor-pointer"} />
-                                            </PaginationItem>
-                                            {renderPaginationNumbers()}
-                                            <PaginationItem>
-                                                <PaginationNext onClick={() => handlePageChange(currentPage + 1)} className={currentPage === totalPages ? "pointer-events-none opacity-50" : "cursor-pointer"} />
-                                            </PaginationItem>
-                                        </PaginationContent>
-                                    </Pagination>
-                                </div>
-                            )}
-                        </div>
-                    )}
+                        ) : (
+                            <div className="flex h-full min-h-[300px] items-center justify-center">
+                                <EmptyState
+                                    variant="notFound"
+                                    title="No workflows found"
+                                    subtitle="Try adjusting your search terms"
+                                    buttons={[{ text: "Clear Filter", variant: "default", onClick: () => setSearchTerm("") }]}
+                                />
+                            </div>
+                        )}
+                    </div>
                 </div>
+                <PaginationControls />
             </div>
 
-            {/* Detail panel (side-by-side, full height) */}
+            {/* Side panel wrapper */}
             {selectedWorkflow && (
-                <div
-                    className={`bg-background flex flex-shrink-0 ${shouldAnimate ? "animate-in slide-in-from-right duration-300" : ""}`}
-                    style={{ width: panelWidth }}
-                >
-                    {/* Resize handle */}
-                    <div
-                        className="relative flex w-1 cursor-col-resize items-center justify-center"
-                        onMouseDown={handleResizeStart}
-                    >
-                        <div className="absolute inset-y-0 left-0 w-px bg-border" />
-                    </div>
-                    {/* Panel content */}
-                    <div className="min-w-0 flex-1">
-                        <WorkflowDetailPanel workflow={selectedWorkflow} onClose={handleClosePanel} />
+                <div className={`h-full overflow-hidden transition-all duration-500 ease-in-out ${isSidePanelOpen ? "w-1/4 min-w-[400px]" : "w-0"}`}>
+                    <div className={`h-full transition-opacity duration-500 ${isSidePanelOpen ? "opacity-100" : "pointer-events-none opacity-0"}`}>
+                        <WorkflowDetailPanel workflow={selectedWorkflow} onClose={handleCloseSidePanel} />
                     </div>
                 </div>
             )}


### PR DESCRIPTION
## Summary
- Update WorkflowList table styling to match enterprise ConnectorsView pattern:
  - Responsive items per page (20 for tall screens, 10 for shorter)
  - Animated side panel with fixed width (1/4 width, min 400px)
  - Button with `variant="link"` for name column
  - `data-state="selected"` pattern for row selection
  - Search bar with icon inside input
  - Sorted workflows by name
- Fix workflow diagram to only close node detail panel on single click (not drag or double-click)
- Change reset zoom icon from expand to home icon

## Test plan
- [ ] Verify workflow list table matches connector table styling
- [ ] Verify side panel animation works correctly
- [ ] Verify clicking and dragging on diagram doesn't close the detail panel
- [ ] Verify double-clicking on diagram doesn't close the detail panel
- [ ] Verify single click on background closes the detail panel
- [ ] Verify home icon shows for reset zoom button

**Jira:** [DATAGO-121930](https://sol-jira.atlassian.net/browse/DATAGO-121930)

[DATAGO-121930]: https://sol-jira.atlassian.net/browse/DATAGO-121930?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ