### PR TITLE
fix: normalize user ID to lowercase to prevent duplicate sessions

### DIFF
--- a/src/solace_agent_mesh/gateway/http_sse/session_manager.py
+++ b/src/solace_agent_mesh/gateway/http_sse/session_manager.py
@@ -53,6 +53,8 @@ class SessionManager:
         if hasattr(request.state, "user") and request.state.user:
             user_id = request.state.user.get("id")
             if user_id:
+                if isinstance(user_id, str):
+                    user_id = user_id.lower()
                 log.debug(
                     "Using authenticated user ID from request.state: %s",
                     user_id,
@@ -65,6 +67,8 @@ class SessionManager:
 
         user_id = self.get_user_id(request)
         if user_id:
+            if isinstance(user_id, str):
+                user_id = user_id.lower()
             log.debug(
                 "Using authenticated user_id from session as A2A Client ID: %s",
                 user_id,

--- a/src/solace_agent_mesh/shared/auth/middleware.py
+++ b/src/solace_agent_mesh/shared/auth/middleware.py
@@ -141,6 +141,9 @@ async def _create_user_state(
         final_user_id = "sam_dev_user"
         log.warning("AuthMiddleware: Had to use fallback user ID due to invalid identifier")
 
+    if isinstance(final_user_id, str):
+        final_user_id = final_user_id.lower()
+
     return {
         "id": final_user_id,
         "email": email_from_auth or final_user_id,
@@ -274,9 +277,13 @@ def create_oauth_middleware(component):
                             "Cannot resolve scopes for sam_access_token."
                         )
 
+                    user_id = claims["sub"]
+                    if isinstance(user_id, str):
+                        user_id = user_id.lower()
+
                     request.state.user = {
-                        "id": claims["sub"],
-                        "email": claims.get("email", claims["sub"]),
+                        "id": user_id,
+                        "email": claims.get("email", user_id),
                         "name": claims.get("name", claims["sub"]),
                         "authenticated": True,
                         "auth_method": "sam_access_token",


### PR DESCRIPTION
## Summary
- Normalizes user IDs to lowercase in the middleware and session manager
- Prevents duplicate user sessions caused by inconsistent email casing from OAuth providers
- Breaks the cycle where old mixed-case JWTs propagate to new JWTs

## Problem
OAuth providers (like Azure AD) can return email addresses with inconsistent casing:

This was causing:
1. Duplicate user sessions in the database
2. Split task history across different user ID variants
3. Self-perpetuating issue: old JWTs with mixed-case `sub` claims would create new JWTs with the same mixed-case

## Solution
Normalize user IDs to lowercase at multiple layers for defense in depth:

1. **Middleware (`middleware.py`)**:
   - `sam_access_token` path: lowercase `claims["sub"]` before setting `request.state.user["id"]`
   - IdP validation path (`_create_user_state`): lowercase `final_user_id`

2. **Session Manager (`session_manager.py`)**:
   - `_get_or_create_client_id`: lowercase user ID when reading from `request.state.user` or session

This complements the existing fix in the enterprise OAuth provider (PR #534).

## Test plan
- [ ] Deploy to staging environment
- [ ] Verify no new mixed-case entries appear in database
- [ ] Wait for old JWTs to expire (up to 24 hours)
- [ ] Clean up existing mixed-case entries from database

Related: DATAGO-121972

🤖 Generated with [Claude Code](https://claude.ai/code)