### PR TITLE
chore(DATAGO-122030): updating chat input

### DIFF
--- a/client/webui/frontend/cypress/e2e/chat-page.cy.ts
+++ b/client/webui/frontend/cypress/e2e/chat-page.cy.ts
@@ -38,9 +38,9 @@ describe("Chat Page - Messaging Functionality", { tags: ["@community"] }, () => 
     });
 
     it("should have a functioning chat input", () => {
-        cy.findByTestId("chat-input").should("be.visible").should("be.enabled");
+        cy.findByTestId("chat-input").should("be.visible");
         cy.findByTestId("chat-input").type("Test message");
-        cy.findByTestId("chat-input").should("have.value", "Test message");
+        cy.findByTestId("chat-input").should("have.text", "Test message");
     });
 
     it("should allow sending a message and show workflow", () => {


### PR DESCRIPTION
### What is the purpose of this change?

    Updating chat ui for changes falling from mention updates.

### How was this change implemented?
This pull request makes a small adjustment to the chat input test in the Cypress end-to-end test suite. The change modifies how the test checks the input's value after typing.

Testing update:

* In `client/webui/frontend/cypress/e2e/chat-page.cy.ts`, the assertion for the chat input was changed from checking its value (`should("have.value", ...)`) to checking its text content (`should("have.text", ...)`). Additionally, the test no longer asserts that the input is enabled.

### How was this change tested?

- [ ] Manual testing: [describe scenarios]
- [ ] Unit tests: [new/modified tests]
- [x] Integration tests: [if applicable]
- [ ] Known limitations: [what wasn't tested]

### Is there anything the reviewers should focus on/be aware of?

    Tests passing locally
    
<img width="693" height="413" alt="image" src="https://github.com/user-attachments/assets/6a57ae9e-afa7-4f96-953b-f0c4a8c0fd59" />

