### PR TITLE
docs(DATAGO-119365): Revise S3 bucket documentation for OpenAPI connector

### DIFF
--- a/docs/docs/documentation/enterprise/connectors/openapi-connectors.md
+++ b/docs/docs/documentation/enterprise/connectors/openapi-connectors.md
@@ -37,7 +37,7 @@ Your platform administrator must configure the platform service with a publicly 
 
 If you are unsure whether the storage bucket is configured, contact your platform administrator. Without this configuration, you will not be able to create OpenAPI connectors.
 
-For platform administrators: Detailed setup instructions for configuring the connector specs bucket are available in the [Two-Bucket Setup for OpenAPI Connector](../../installing-and-configuring/artifact-storage.md#two-bucket-setup-for-openapi-connector) section of the Artifact Storage documentation. Kubernetes deployments handle this configuration automatically via Helm charts.
+For platform administrators: See [Infrastructure Setup: S3 Buckets for OpenAPI Connector Specs](../installation.md#infrastructure-setup-s3-buckets-for-openapi-connector-specs) in the enterprise installation guide for detailed setup instructions. Kubernetes deployments handle this configuration automatically via Helm charts.
 
 ### API Credentials (if required)
 

--- a/docs/docs/documentation/enterprise/installation.md
+++ b/docs/docs/documentation/enterprise/installation.md
@@ -199,6 +199,60 @@ The `SOLACE_DEV_MODE="false"` environment variable tells the container to connec
 
 </details>
 
+## Infrastructure Setup: S3 Buckets for OpenAPI Connector Specs
+
+Some enterprise features require additional infrastructure setup. If you plan to use the OpenAPI Connector feature, you must configure a dedicated S3 bucket for OpenAPI specification files. This is separate from artifact storage and is required for agents to download OpenAPI specs at startup.
+
+### When is a connector specs bucket required?
+- When using the OpenAPI Connector feature for REST API integrations
+- When deploying via Kubernetes (Helm charts handle this automatically)
+- When agents must access OpenAPI spec files at startup
+
+### Why a separate bucket?
+- **Public read access**: Agents must download OpenAPI specs without authentication
+- **Security isolation**: Keeps infrastructure files separate from user artifacts
+- **No secrets**: Only API schemas, endpoints, and models are stored (never credentials)
+
+### Setup Instructions
+
+1. **Create the connector specs S3 bucket** (public read, authenticated write):
+   ```bash
+   aws s3 mb s3://my-connector-specs-bucket --region us-west-2
+   ```
+
+2. **Apply a public read policy**:
+   Save as `connector-specs-policy.json`:
+   ```json
+   {
+     "Version": "2012-10-17",
+     "Statement": [{
+       "Sid": "PublicReadGetObject",
+       "Effect": "Allow",
+       "Principal": "*",
+       "Action": "s3:GetObject",
+       "Resource": "arn:aws:s3:::my-connector-specs-bucket/*"
+     }]
+   }
+   ```
+   Apply with:
+   ```bash
+   aws s3api put-bucket-policy \
+     --bucket my-connector-specs-bucket \
+     --policy file://connector-specs-policy.json
+   ```
+
+3. **IAM permissions for write access** (for the SAM service):
+   - Grant `s3:PutObject`, `s3:DeleteObject`, `s3:ListBucket` to the SAM platform's IAM user/role for this bucket.
+
+4. **Kubernetes deployments**: Use the `connectorSpecBucketName` value in your Helm chart.
+
+5. **Standalone deployments**: The platform manages the connector specs bucket; see your deployment guide.
+
+### Security Notes
+- Never store API keys, passwords, or secrets in OpenAPI spec files
+- Public read is safe for API schemas only
+- Write access should be restricted to the platform
+
 ## Accessing the Web UI
 
 After starting the container in either development or production mode, you can access the Agent Mesh Enterprise web interface through your browser. The UI provides a graphical interface for managing agents, monitoring activity, and configuring your deployment.

--- a/docs/docs/documentation/installing-and-configuring/artifact-storage.md
+++ b/docs/docs/documentation/installing-and-configuring/artifact-storage.md
@@ -44,31 +44,7 @@ For session storage configuration, see [Session Storage](./session-storage.md).
 
 ### Multiple S3 Buckets for OpenAPI Connector Feature
 
-If you're using the **OpenAPI Connector feature** or deploying SAM via Kubernetes, you will need to configure **two separate S3 buckets** instead of one:
-
-| Bucket Type | Purpose | Access Requirements | Features Enabled |
-|-------------|---------|---------------------|------------------|
-| **Artifacts** | Workflow artifacts, temporary files | Fully private (authenticated read/write only) | Core workflow functionality |
-| **Connector Specs** | OpenAPI specification files | Public read, authenticated write | OpenAPI Connector feature for automatic REST API integrations |
-
-**When do you need two buckets?**
-- Deploying SAM via Kubernetes (sam-kubernetes, solace-agent-mesh-docker-quickstart, maas-cloud-agent-k8s)
-- Using the OpenAPI Connector feature for REST API integrations
-- When agents need to access connector specification files during startup
-
-**Why two separate buckets?**
-- **Different access patterns**: Agents must download connector specs at startup without authentication, but workflow artifacts must remain private
-- **Security isolation**: Keeps temporary workflow data separate from long-lived infrastructure files
-- **Critical infrastructure**: Agents cannot start without access to connector specification files
-
-**Security note on public read access:**
-
-The connector specs bucket requires public read access so agents can download OpenAPI specification files during startup without authentication. This is safe because:
-- Connector specs contain only API schemas, endpoints, and data models (no credentials)
-- Write access remains restricted to the SAM service only (using S3 access keys)
-- Never store API keys, passwords, or secrets in connector specifications
-
-For Kubernetes deployments, this configuration is handled automatically by the Helm charts. For standalone deployments, see the configuration examples below.
+> **Note:** The S3 bucket used for OpenAPI connector specifications is not for user or chat artifacts. For details on configuring the public S3 bucket for connector specs, see [Infrastructure Setup: S3 Buckets for OpenAPI Connector Specs](../enterprise/installation.md#infrastructure-setup-s3-buckets-for-openapi-connector-specs).
 
 ## Artifact Scoping
 
@@ -378,75 +354,6 @@ For production deployments on AWS:
    export AWS_SECRET_ACCESS_KEY="your-secret"
    export AWS_REGION="us-west-2"
    ```
-
-#### Two-Bucket Setup for OpenAPI Connector
-
-If you're using the OpenAPI Connector feature, you need to create **two buckets**: one for artifacts (private) and one for connector specs (public read).
-
-1. **Create Both S3 Buckets:**
-   ```bash
-   # Create artifacts bucket (private)
-   aws s3 mb s3://my-artifacts-bucket --region us-west-2
-
-   # Create connector specs bucket (will configure public read next)
-   aws s3 mb s3://my-connector-specs-bucket --region us-west-2
-   ```
-
-2. **Apply Public Read Policy to Connector Specs Bucket:**
-
-   Save this policy as `connector-specs-policy.json`:
-   ```json
-   {
-     "Version": "2012-10-17",
-     "Statement": [{
-       "Sid": "PublicReadGetObject",
-       "Effect": "Allow",
-       "Principal": "*",
-       "Action": "s3:GetObject",
-       "Resource": "arn:aws:s3:::my-connector-specs-bucket/*"
-     }]
-   }
-   ```
-
-   Apply the policy:
-   ```bash
-   aws s3api put-bucket-policy \
-     --bucket my-connector-specs-bucket \
-     --policy file://connector-specs-policy.json
-   ```
-
-3. **Configure IAM User or Role** with required permissions for **both buckets**:
-
-   ```json
-   {
-     "Version": "2012-10-17",
-     "Statement": [
-       {
-         "Effect": "Allow",
-         "Action": [
-           "s3:GetObject",
-           "s3:PutObject",
-           "s3:DeleteObject",
-           "s3:ListBucket"
-         ],
-         "Resource": [
-           "arn:aws:s3:::my-artifacts-bucket",
-           "arn:aws:s3:::my-artifacts-bucket/*",
-           "arn:aws:s3:::my-connector-specs-bucket",
-           "arn:aws:s3:::my-connector-specs-bucket/*"
-         ]
-       }
-     ]
-   }
-   ```
-
-**Note:** The specific configuration mechanism for specifying the second bucket varies by deployment method:
-- **Kubernetes deployments**: Use the `connectorSpecBucketName` configuration in your Helm values (see sam-kubernetes documentation)
-- **Standalone deployments**: The connector specs bucket is currently managed by the SAM platform infrastructure
-
-**Security summary:**
-- Artifacts bucket: Fully private (no public access)
-- Connector specs bucket: Public read (anonymous GetObject), authenticated write (SAM service only)
 
 ### On-Premises or Private Cloud
 


### PR DESCRIPTION
### What is the purpose of this change?
Improve connector bucket docs structure per PR #786 comment

### How was this change implemented?
- Move the connector bucket details out of the Artifact Storage page to the enterprise installation page
- Add reference to this page in artifact storage page to clarify the difference
- Update connectors page to reference the new content location
