### PR TITLE
fix(DATAGO-117615): Add warning when default project does not exist in projects

### DIFF
--- a/client/webui/frontend/src/lib/components/projects/DefaultAgentSection.tsx
+++ b/client/webui/frontend/src/lib/components/projects/DefaultAgentSection.tsx
@@ -4,6 +4,7 @@ import { Bot, Pencil } from "lucide-react";
 import { Button, Select, SelectContent, SelectItem, SelectTrigger, SelectValue, Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle } from "@/lib/components/ui";
 import type { Project } from "@/lib/types/projects";
 import { useChatContext } from "@/lib/hooks";
+import { MessageBanner } from "../common";
 
 interface DefaultAgentSectionProps {
     project: Project;
@@ -41,6 +42,11 @@ export const DefaultAgentSection: React.FC<DefaultAgentSectionProps> = ({ projec
                         <Pencil className="h-4 w-4" />
                     </Button>
                 </div>
+                {agentNameDisplayNameMap[project.defaultAgentId ?? ""] === undefined && project.defaultAgentId !== null && (
+                    <div className="mb-3 px-4">
+                        <MessageBanner variant="warning" message="The Default Agent for this project has either been removed or renamed." />
+                    </div>
+                )}
 
                 <div className="px-4">
                     <div className="text-muted-foreground bg-muted flex items-center rounded-md p-2.5 text-sm">


### PR DESCRIPTION
This pull request adds a user-facing warning to the `DefaultAgentSection` component to inform users when the project's default agent has been removed or renamed. Additionally, it imports the `MessageBanner` component to support this new functionality.

**User experience improvements:**

* Added a warning banner to `DefaultAgentSection` that appears if the project's default agent has been removed or renamed, using the `MessageBanner` component.

**Codebase changes:**

* Imported the `MessageBanner` component into `DefaultAgen

<img width="687" height="173" alt="CleanShot 2026-01-19 at 10 53 40" src="https://github.com/user-attachments/assets/a14e20c4-c5ef-4246-be89-a4863cc0e9a4" />
tSection.tsx` to enable displaying warning messages.

