### PR TITLE
fix(DATAGO-122233): handle string indices in deep_research sources selection

### DIFF
--- a/src/solace_agent_mesh/agent/tools/deep_research_tools.py
+++ b/src/solace_agent_mesh/agent/tools/deep_research_tools.py
@@ -179,7 +179,6 @@ class ReflectionResult:
     suggested_queries: List[str]  # New queries to explore gaps
     reasoning: str  # Explanation of the reflection
 
-
 def _get_model_for_phase(
     phase: str,
     tool_context: ToolContext,


### PR DESCRIPTION
This pull request improves the robustness of the `_select_sources_to_fetch` function by handling cases where the LLM returns indices as strings instead of integers. This change prevents errors and adds logging for invalid index values.

Error handling and logging improvements:

* Updated the loop that processes `selected_indices` to convert each index to an integer, handling cases where the LLM returns strings instead of integers, and logging a warning if the index is invalid.