### PR TITLE
fix(DATAGO-122579): Refer to a valid home page of documents

### DIFF
--- a/docs/docs/documentation/getting-started/getting-started.md
+++ b/docs/docs/documentation/getting-started/getting-started.md
@@ -1,6 +1,7 @@
 ---
 title: Getting Started
 sidebar_position: 12
+slug: /
 ---
 
 # Get Started with Agent Mesh

--- a/docs/docusaurus.config.ts
+++ b/docs/docusaurus.config.ts
@@ -33,7 +33,9 @@ const config: Config = {
         docs: {
           sidebarPath: "./sidebars.ts",
           editUrl: "https://github.com/SolaceLabs/solace-agent-mesh/edit/main/docs",
+          routeBasePath: '/',
         },
+        blog: false,
       } satisfies Preset.Options,
     ],
   ],
@@ -51,7 +53,7 @@ const config: Config = {
       logo: {
         alt: "Solace Agent Mesh Logo",
         src: "img/logo.png",
-        href: "/docs/documentation/getting-started",
+        href: "/",
       },
       items: [
         {
@@ -81,7 +83,7 @@ const config: Config = {
           items: [
             {
               label: "Documentation",
-              to: "/docs/documentation/getting-started",
+              to: "/",
             },
             {
               label: "GitHub",


### PR DESCRIPTION
### What is the purpose of this change?
The home page of document refers to a blank "Page Not Found".

### How was this change implemented?
Redirected the main route `/solace-agent-mesh/` to the `Get Started` page of documents.

### Key Design Decisions

### How was this change tested?

- [x] Manual testing: Opened the home page of the document and verified the page.
- [ ] Unit tests: [new/modified tests]
- [ ] Integration tests: [if applicable]
- [ ] Known limitations: [what wasn't tested]

### Is there anything the reviewers should focus on/be aware of?
Nothing
