### PR TITLE
feat(DATAGO-121398): Add custom health check support for agents and gateways

### DIFF
--- a/tests/unit/common/test_app_base.py
+++ b/tests/unit/common/test_app_base.py
@@ -694,10 +694,10 @@ class TestSamAppBaseCustomHealthChecks:
 
     @patch("solace_agent_mesh.common.app_base.importlib.import_module")
     @patch("solace_agent_mesh.common.app_base.App.__init__")
-    def test_custom_check_passes_component_to_function(
+    def test_custom_check_passes_app_to_function(
         self, mock_app_init, mock_import
     ):
-        """Custom check function receives the primary component."""
+        """Custom check function receives the application instance."""
         mock_app_init.return_value = None
 
         mock_func = MagicMock(return_value=True)
@@ -716,22 +716,12 @@ class TestSamAppBaseCustomHealthChecks:
                 "custom_ready_check": "mymodule:check_ready"
             }
         }
-
-        # Mock a component with get_config
-        mock_component = MagicMock()
-        mock_component.get_config = MagicMock()
-
-        mock_wrapper = MagicMock()
-        mock_wrapper.component = mock_component
-
-        mock_flow = MagicMock()
-        mock_flow.component_groups = [[mock_wrapper]]
-        app.flows = [mock_flow]
+        app.flows = []
 
         app._run_custom_check(CUSTOM_READY_CHECK_KEY)
 
-        # Verify the component was passed to the function
-        mock_func.assert_called_once_with(mock_component)
+        # Verify the application was passed to the function
+        mock_func.assert_called_once_with(app)
 
     @patch("solace_agent_mesh.common.app_base.importlib.import_module")
     @patch("solace_agent_mesh.common.app_base.App.__init__")


### PR DESCRIPTION
### What is the purpose of this change?

Enables users to define custom Python functions for health checks, allowing application-specific health validation logic. This supports scenarios like checking external service connectivity, verifying model availability, or custom business logic checks.

### How was this change implemented?

- Added `custom_startup_check` and `custom_ready_check` configuration options in the `health_check` YAML section
- Implemented dynamic module loading via `importlib.import_module()` for custom check functions
- Custom functions receive the component instance for context access
- Callable is cached after first load to avoid reimporting on every health check
- Format: `module.path:function_name` (e.g., `my_agent.health:check_ready`)

### Key Design Decisions

- Custom functions must accept a single `component` parameter and return a boolean
- Non-boolean return values are coerced to boolean with a warning
- Exceptions in custom checks are logged and treated as unhealthy (returns False)
- Loading failures are cached to avoid repeated import attempts

### How was this change tested?

- [x] Unit tests: 12 new tests in `test_app_base.py` covering custom health check scenarios
- [x] Tests cover: successful checks, failed checks, exceptions, invalid paths, non-callable attributes, caching behavior
- [x] Manual testing with custom health check module

### Is there anything the reviewers should focus on/be aware of?

This is part 3 of a stacked PR series for health checks:
- Part 1: Broker connection health checks
- Part 2: Database connectivity checks
- **Part 3 (this PR)**: Custom health check support

Example configuration:
```yaml
health_check:
  custom_startup_check: my_agent.health:check_startup
  custom_ready_check: my_agent.health:check_ready
```