### PR TITLE
chore(DATAGO-122656): Export FileUpload component to npm

### DIFF
--- a/client/webui/frontend/src/lib/components/index.ts
+++ b/client/webui/frontend/src/lib/components/index.ts
@@ -7,7 +7,7 @@ export * from "./navigation";
 export * from "./chat";
 export * from "./settings";
 
-export { MarkdownHTMLConverter, MarkdownWrapper, MessageBanner, EmptyState, ErrorDialog, ConfirmationDialog, LoadingBlocker, messageColourVariants, StreamingMarkdown } from "./common";
+export * from "./common";
 
 export * from "./header";
 export * from "./pages";


### PR DESCRIPTION
### What is the purpose of this change?

Export all components from the `./common` folder to make them available in the `@SolaceLabs/solace-agent-mesh-ui` npm package.

### How was this change implemented?

Changed the explicit named export in `src/lib/components/index.ts` to `export * from "./common"`, which now includes `FileUpload`, `Footer`, `GridCard`, and `ErrorLabel` that were previously excluded.

### Is there anything the reviewers should focus on/be aware of?

This is a non-breaking change that adds new exports. Existing imports will continue to work.
