### PR TITLE
chore: Claim Context7 Github repo

### DIFF
--- a/docs/context7.json
+++ b/docs/context7.json
@@ -1,0 +1,4 @@
+{
+  "url": "https://context7.com/websites/solacelabs_github_io_solace-agent-mesh",
+  "public_key": "pk_CQ4HCSwDcMynzefVFVFQR"
+}


### PR DESCRIPTION
Claiming this Context7 library so that we can remove it from the list: https://context7.com/websites/solacelabs_github_io_solace-agent-mesh and avoid confusion for developers using Context7. 

This is a temporary change. Once we have ownership, this file can be deleted. 