### PR TITLE
fix(DATAGO-122579): Update the landing page url

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ The result? A fully asynchronous, event-driven and decoupled AI agent architectu
 - **[Agent-to-Agent Communication](https://solacelabs.github.io/solace-agent-mesh/docs/documentation/getting-started/architecture)** – Agents can discover and delegate tasks to each other seamlessly using the Agent2Agent (A2A) Protocol
 - **[Dynamic Embeds](https://solacelabs.github.io/solace-agent-mesh/docs/documentation/components/builtin-tools/embeds)** – Embed dynamic content like real-time data, calculations and file contents in responses
 
-📚 **Want to know more?** Check out the full Solace Agent Mesh [documentation](https://solacelabs.github.io/solace-agent-mesh/docs/documentation/getting-started/introduction/).
+📚 **Want to know more?** Check out the full Solace Agent Mesh [documentation](https://solacelabs.github.io/solace-agent-mesh/).
 
 ---
 


### PR DESCRIPTION
### What is the purpose of this change?
The README is referring to a wrong landing page url.

### How was this change implemented?
Set the correct landing page url in README file.

### Key Design Decisions

### How was this change tested?

- [x] Manual testing: Verified that the README refers to the correct landing page.
- [ ] Unit tests: [new/modified tests]
- [ ] Integration tests: [if applicable]
- [ ] Known limitations: [what wasn't tested]

### Is there anything the reviewers should focus on/be aware of?
Is the landing page set anywhere else?
