### PR TITLE
fix(DATAGO-123007): Place @ mention feature behind a feature flag for SAM Enterprise releases

### DIFF
--- a/src/solace_agent_mesh/gateway/http_sse/routers/config.py
+++ b/src/solace_agent_mesh/gateway/http_sse/routers/config.py
@@ -138,6 +138,45 @@ def _determine_auto_title_generation_enabled(
     return True
 
 
+def _determine_mentions_enabled(
+    component: "WebUIBackendComponent",
+    log_prefix: str
+) -> bool:
+    """
+    Determines if mentions (@user) feature should be enabled.
+    
+    Logic:
+    1. Check if identity_service is configured (required for user search)
+    2. Check explicit mentions.enabled config (must be explicitly enabled, defaults to False)
+    3. Check frontend_feature_enablement.mentions override
+    
+    Returns:
+        bool: True if mentions should be enabled
+    """
+    # Mentions require identity_service to be configured for user search
+    if component.identity_service is None:
+        log.debug("%s Mentions disabled: no identity_service configured", log_prefix)
+        return False
+    
+    # Check explicit mentions config - disabled by default
+    mentions_config = component.get_config("mentions", {})
+    explicitly_enabled = False
+    if isinstance(mentions_config, dict):
+        explicitly_enabled = mentions_config.get("enabled", False)
+    
+    # Check frontend_feature_enablement override
+    feature_flags = component.get_config("frontend_feature_enablement", {})
+    if "mentions" in feature_flags:
+        explicitly_enabled = feature_flags.get("mentions", False)
+    
+    if not explicitly_enabled:
+        log.debug("%s Mentions disabled: not explicitly enabled in config", log_prefix)
+        return False
+    
+    log.debug("%s Mentions enabled: identity_service configured and explicitly enabled", log_prefix)
+    return True
+
+
 def _determine_projects_enabled(
     component: "WebUIBackendComponent",
     api_config: Dict[str, Any],
@@ -309,13 +348,9 @@ async def get_app_config(
             log.debug("%s Background tasks feature flag is disabled.", log_prefix)
 
         # Determine if mentions (@user) should be enabled
-        # Mentions require identity_service to be configured for user search
-        mentions_enabled = component.identity_service is not None
+        # Mentions require identity_service AND explicit enablement (defaults to False)
+        mentions_enabled = _determine_mentions_enabled(component, log_prefix)
         feature_enablement["mentions"] = mentions_enabled
-        if mentions_enabled:
-            log.debug("%s Mentions feature flag is enabled (identity_service configured).", log_prefix)
-        else:
-            log.debug("%s Mentions feature flag is disabled (no identity_service configured).", log_prefix)
         
         # Determine if auto title generation should be enabled
         auto_title_generation_enabled = _determine_auto_title_generation_enabled(component, api_config, log_prefix)


### PR DESCRIPTION
This pull request refines how the "mentions" feature flag is determined in the backend configuration logic. Instead of simply enabling mentions when the `identity_service` is configured, the new logic requires explicit enablement via configuration and also considers frontend feature overrides. This makes the mentions feature opt-in and more configurable.

Feature flag logic improvements:

* Added a new `_determine_mentions_enabled` function in `config.py` to encapsulate the logic for enabling the mentions feature. This function checks for the presence of `identity_service`, explicit mentions configuration, and frontend feature overrides, defaulting to disabled unless explicitly enabled.
* Updated the `get_app_config` function to use the new `_determine_mentions_enabled` function, ensuring mentions are only enabled when all required conditions are met, and removed the old logic that enabled mentions solely based on the presence of `identity_service`.