### PR TITLE
chore(DATAGO-121518): Refer to vibe coding in the Developing page of doc

### DIFF
--- a/docs/docs/documentation/developing/developing.md
+++ b/docs/docs/documentation/developing/developing.md
@@ -7,6 +7,10 @@ sidebar_position: 400
 
 Agent Mesh provides a framework for creating distributed AI applications using an event-driven architecture. You can build agents that communicate through the A2A (Agent-to-Agent) protocol, extend them with custom tools, integrate external systems through gateways, and create reusable components as plugins.
 
+:::tip
+Vibe coding is recommended for faster development of agents, plugins, tools, and gateways. For more details, see the [Vibe Coding guide](../vibe_coding.md).
+:::
+
 ## Understanding the Project Structure
 
 The framework uses YAML configuration files to define agents, gateways, and plugins, although you can extend functionality with custom Python components when needed. For a complete overview of project organization and component relationships, see [Project Structure](structure.md).


### PR DESCRIPTION
### What is the purpose of this change?
The `Developing with Agent Mesh` page explains how to build agents and related components. We should reference Vibe Coding on this page to help streamline and accelerate the development process.

### How was this change implemented?
Added a Tip to this page that refers to the vibe coding page.

### Key Design Decisions

### How was this change tested?

- [x] Manual testing: Built and reviewed the documents.
- [ ] Unit tests: [new/modified tests]
- [ ] Integration tests: [if applicable]
- [ ] Known limitations: [what wasn't tested]

### Is there anything the reviewers should focus on/be aware of?
Nothing
