### PR TITLE
fix(DATAGO-123235): Address issues with typing "/" in chat

### DIFF
--- a/client/webui/frontend/src/lib/components/chat/ChatInputArea.tsx
+++ b/client/webui/frontend/src/lib/components/chat/ChatInputArea.tsx
@@ -527,14 +527,13 @@ export const ChatInputArea: React.FC<{ agents: AgentCardInfo[]; scrollToBottom?:
 
         const cursorPosition = getCursorPosition();
         const textBeforeCursor = value.substring(0, cursorPosition);
-        const lastChar = textBeforeCursor[textBeforeCursor.length - 1];
-        const charBeforeLast = textBeforeCursor[textBeforeCursor.length - 2];
 
-        // Check if "/" is typed at start or after space
-        if (lastChar === "/" && (!charBeforeLast || charBeforeLast === " " || charBeforeLast === "\n")) {
+        // Check if "/" is typed as the first character (position 0)
+        // Only trigger prompt popover when "/" is at the very start of the input
+        if (textBeforeCursor === "/") {
             setShowPromptsCommand(true);
             setShowMentionsCommand(false); // Close mentions if open
-        } else if (showPromptsCommand && !textBeforeCursor.includes("/")) {
+        } else if (showPromptsCommand && !textBeforeCursor.startsWith("/")) {
             setShowPromptsCommand(false);
         }
 
@@ -903,6 +902,14 @@ export const ChatInputArea: React.FC<{ agents: AgentCardInfo[]; scrollToBottom?:
                 onPromptSelect={handlePromptSelect}
                 messages={messages}
                 onReservedCommand={handleChatCommand}
+                onBackspaceClose={() => {
+                    // Remove the "/" trigger character from the input
+                    // Since "/" only triggers at position 0, we just remove the first character
+                    if (inputValue.startsWith("/")) {
+                        setInputValue(inputValue.substring(1));
+                    }
+                    setShowPromptsCommand(false);
+                }}
             />
 
             {/* Mentions Command Popover */}

--- a/client/webui/frontend/src/lib/components/chat/PromptsCommand.tsx
+++ b/client/webui/frontend/src/lib/components/chat/PromptsCommand.tsx
@@ -36,9 +36,10 @@ interface PromptsCommandProps {
     onPromptSelect: (promptText: string) => void;
     messages?: MessageFE[];
     onReservedCommand?: (command: ChatCommand, context?: string) => void;
+    onBackspaceClose?: () => void; // Called when backspace closes the popover (to remove the "/" trigger)
 }
 
-export const PromptsCommand: React.FC<PromptsCommandProps> = ({ isOpen, onClose, textAreaRef, onPromptSelect, messages = [], onReservedCommand }) => {
+export const PromptsCommand: React.FC<PromptsCommandProps> = ({ isOpen, onClose, textAreaRef, onPromptSelect, messages = [], onReservedCommand, onBackspaceClose }) => {
     const navigate = useNavigate();
     const [searchValue, setSearchValue] = useState("");
     const [activeIndex, setActiveIndex] = useState(0);
@@ -203,11 +204,17 @@ export const PromptsCommand: React.FC<PromptsCommandProps> = ({ isOpen, onClose,
                     handleSelect(allItems[activeIndex]);
                 }
             } else if (e.key === "Backspace" && searchValue === "") {
-                onClose();
+                // Call onBackspaceClose to remove the "/" trigger character
+                if (onBackspaceClose) {
+                    onBackspaceClose();
+                } else {
+                    onClose();
+                }
+                setSearchValue("");
                 textAreaRef.current?.focus();
             }
         },
-        [allItems, activeIndex, searchValue, handleSelect, onClose, textAreaRef]
+        [allItems, activeIndex, searchValue, handleSelect, onClose, onBackspaceClose, textAreaRef]
     );
 
     // Auto-focus input when opened


### PR DESCRIPTION
This pull request improves the behavior of the prompt command ("/" trigger) in the chat input area, making the "/" command popover more intuitive and easier to dismiss. The most important changes are grouped below:

**Prompt Command Triggering and Dismissal Logic:**

* The prompt popover now only appears when "/" is typed as the very first character in the input, rather than after any space or newline. This makes the trigger behavior more predictable and less likely to appear unintentionally.
* The prompt popover is now dismissed if the input no longer starts with "/", ensuring the popover only stays open when appropriate.

**Popover Dismissal on Backspace:**

* Added a new `onBackspaceClose` prop to the `PromptsCommand` component, which is called when the user presses backspace with an empty prompt search (i.e., after typing "/"). This handler removes the "/" from the input and closes the popover, streamlining the UX for dismissing the prompt command. [[1]](diffhunk://#diff-bc94554d620a00e74c8fd7859ccbc086441ac7772c4a3dae72779aa5cc5de79dR39-R42) [[2]](diffhunk://#diff-bc94554d620a00e74c8fd7859ccbc086441ac7772c4a3dae72779aa5cc5de79dR207-R217) [[3]](diffhunk://#diff-8d133525d515e1506931bca68a08adc5460f6fadd75d45a64045faecb5f31936R905-R912)