### PR TITLE
chore(DATAGO-115145): Add Identity service to `/config` api

### DIFF
--- a/src/solace_agent_mesh/gateway/http_sse/routers/config.py
+++ b/src/solace_agent_mesh/gateway/http_sse/routers/config.py
@@ -237,7 +237,6 @@ async def get_app_config(
         identity_service_config = component.get_config("identity_service", None)
         identity_service_type = identity_service_config.get("type") if identity_service_config else None
 
-
         # Manually check for the task_logging feature and add it
         task_logging_config = component.get_config("task_logging", {})
         if task_logging_config and task_logging_config.get("enabled", False):


### PR DESCRIPTION
This pull request updates the application configuration endpoint to include information about the identity service type in the frontend configuration response. The main changes are focused on extracting the identity service type from the component configuration and adding it to the returned configuration data.

Configuration enhancements:

* Extracted the `type` field from the `identity_service` configuration and assigned it to a new variable `identity_service_type` in `get_app_config` (`src/solace_agent_mesh/gateway/http_sse/routers/config.py`).
* Added `identity_service_type` to the configuration dictionary returned by `get_app_config`, making this information available to frontend consumers (`src/solace_agent_mesh/gateway/http_sse/routers/config.py`).


With Service Enabled
<img width="898" height="335" alt="CleanShot 2026-01-28 at 15 42 11" src="https://github.com/user-attachments/assets/d098d445-b0bc-4b25-acdf-890d2b0bf17b" />


Without Service Enabl
<img width="896" height="321" alt="CleanShot 2026-01-28 at 15 43 37" src="https://github.com/user-attachments/assets/deed2c57-c827-4eb1-881e-2470736ce1f4" />
ed

