### PR TITLE
fix(DATAGO-123310): Fix GPT-4 class models with AI Assistance in Agent Builder

### DIFF
--- a/src/solace_agent_mesh/agent/adk/models/lite_llm.py
+++ b/src/solace_agent_mesh/agent/adk/models/lite_llm.py
@@ -911,6 +911,10 @@ class LiteLlm(BaseLlm):
             # Setting parallel_tool_calls without any tools causes an error from Anthropic.
             completion_args.pop("parallel_tool_calls")
 
+        # Remove stream_options when not streaming (Azure doesn't support it)
+        if not stream:
+            completion_args.pop("stream_options", None)
+
         if stream:
             text = ""
             function_calls = {}  # index -> {name, args, id}


### PR DESCRIPTION
### What is the purpose of this change?

Fixes an issue where GPT-4 class models (Azure OpenAI) fail when using AI Assistance in Agent Builder. The `stream_options` parameter was being passed to non-streaming API calls, but Azure doesn't support this parameter.

### How was this change implemented?

Modified `src/solace_agent_mesh/agent/adk/models/lite_llm.py` to remove the `stream_options` parameter from completion arguments when not streaming.

### How was this change tested?

- [x] Manual testing: Verified AI Assistance works with GPT-4 models after the fix
- [ ] Unit tests: Not applicable - configuration-level fix
- [ ] Integration tests: Not applicable

### Is there anything the reviewers should focus on/be aware of?

This is a minimal, targeted fix. The `stream_options` parameter is only relevant when streaming, so removing it for non-streaming calls should have no side effects.