### PR TITLE
fix(DATAGO-122579): Redirect the landing page

### DIFF
--- a/docs/src/pages/index.tsx
+++ b/docs/src/pages/index.tsx
@@ -1,0 +1,6 @@
+import React from 'react';
+import { Redirect } from '@docusaurus/router';
+
+export default function Home(): JSX.Element {
+  return <Redirect to="/solace-agent-mesh/docs/documentation/getting-started" />;
+}


### PR DESCRIPTION
### What is the purpose of this change?
We need to redirect the blank landing page of documents to the Get Started page to shorten the landing page URL.

### How was this change implemented?
Added an `index.tsx` with no content that redirects the landing page to the Get Started page.

### Key Design Decisions
We do not need to update hardcoded URLs in documents. This solution keeps the current URLs as they are.

### How was this change tested?

- [x] Manual testing: Built and explored document pages and landing page in local system.
- [ ] Unit tests: [new/modified tests]
- [ ] Integration tests: [if applicable]
- [ ] Known limitations: [what wasn't tested]

### Is there anything the reviewers should focus on/be aware of?
Nothing
