### PR TITLE
fix(DATAGO-123348): Background task monitoring not using authenticated userID when available

### DIFF
--- a/client/webui/frontend/src/lib/providers/ChatProvider.tsx
+++ b/client/webui/frontend/src/lib/providers/ChatProvider.tsx
@@ -9,7 +9,7 @@ const v4 = () => uuidv4({});
 
 import { api } from "@/lib/api";
 import { ChatContext, type ChatContextValue, type PendingPromptData } from "@/lib/contexts";
-import { useConfigContext, useArtifacts, useAgentCards, useErrorDialog, useTitleGeneration, useBackgroundTaskMonitor, useArtifactPreview, useArtifactOperations } from "@/lib/hooks";
+import { useConfigContext, useArtifacts, useAgentCards, useErrorDialog, useTitleGeneration, useBackgroundTaskMonitor, useArtifactPreview, useArtifactOperations, useAuthContext } from "@/lib/hooks";
 import { useProjectContext, registerProjectDeletedCallback } from "@/lib/providers";
 import { getErrorMessage, fileToBase64, migrateTask, CURRENT_SCHEMA_VERSION, getApiBearerToken, internalToDisplayText } from "@/lib/utils";
 
@@ -47,6 +47,7 @@ export const ChatProvider: React.FC<ChatProviderProps> = ({ children }) => {
     const { configWelcomeMessage, persistenceEnabled, configCollectFeedback, backgroundTasksEnabled, backgroundTasksDefaultTimeoutMs, autoTitleGenerationEnabled } = useConfigContext();
     const { activeProject, setActiveProject, projects } = useProjectContext();
     const { ErrorDialog, setError } = useErrorDialog();
+    const { userInfo } = useAuthContext();
 
     // State Variables from useChat
     const [sessionId, setSessionId] = useState<string>("");
@@ -194,6 +195,9 @@ export const ChatProvider: React.FC<ChatProviderProps> = ({ children }) => {
         closePreview,
     });
 
+    // Get the authenticated user's ID for background task monitoring
+    const authenticatedUserId = typeof userInfo?.username === "string" ? userInfo.username : null;
+
     const {
         backgroundTasks,
         notifications: backgroundNotifications,
@@ -203,7 +207,7 @@ export const ChatProvider: React.FC<ChatProviderProps> = ({ children }) => {
         isTaskRunningInBackground,
         checkTaskStatus,
     } = useBackgroundTaskMonitor({
-        userId: "sam_dev_user",
+        userId: authenticatedUserId,
         currentSessionId: sessionId,
         onTaskCompleted: useCallback(
             async (taskId: string, taskSessionId: string) => {


### PR DESCRIPTION
This pull request updates how the background task monitor determines which user it is tracking in the chat provider. Instead of using a hardcoded user ID, it now dynamically uses the authenticated user's ID from the authentication context. This ensures that background tasks are properly associated with the currently logged-in user.

**Authentication integration:**

* Imported `useAuthContext` from `@/lib/hooks` and accessed `userInfo` to retrieve the authenticated user's information. [[1]](diffhunk://#diff-d33c8017d7b1273101dabad6b9fb45a9a00f0312bada8b8ec387b325a21bc2f7L12-R12) [[2]](diffhunk://#diff-d33c8017d7b1273101dabad6b9fb45a9a00f0312bada8b8ec387b325a21bc2f7R50)
* Added logic to extract the authenticated user's username and use it as the `userId` for background task monitoring.

**Background task monitoring update:**

* Updated the `useBackgroundTaskMonitor` hook to use the authenticated user's ID instead of a hardcoded value, ensuring tasks are tracked per user session.