### PR TITLE
chore(DATAGO-121927): FE | Enhance UI/UX of workflow visualization through vibe coding

### DIFF
--- a/client/webui/frontend/src/lib/components/workflowVisualization/nodes/WorkflowRefNode.tsx
+++ b/client/webui/frontend/src/lib/components/workflowVisualization/nodes/WorkflowRefNode.tsx
@@ -1,31 +1,18 @@
 import type { MouseEvent } from "react";
-import { Workflow, ExternalLink } from "lucide-react";
-import { useNavigate } from "react-router-dom";
+import { Workflow } from "lucide-react";
 import { NODE_BASE_STYLES, NODE_HIGHLIGHT_CLASSES, NODE_SELECTED_CLASS, type NodeProps } from "../utils/types";
-import { Button } from "@/lib/components/ui";
-import { buildWorkflowNavigationUrl } from "../WorkflowVisualizationPage";
 
 /**
  * Workflow reference node - Rectangle with workflow icon, name, and "Workflow" badge
  * Clicking navigates to the referenced workflow's visualization
  * Supports highlighting when referenced in expressions
  */
-const WorkflowRefNode: React.FC<NodeProps> = ({ node, isSelected, isHighlighted, onClick, currentWorkflowName, parentPath = [] }) => {
-    const navigate = useNavigate();
+const WorkflowRefNode: React.FC<NodeProps> = ({ node, isSelected, isHighlighted, onClick }) => {
     const workflowName = node.data.workflowName || node.data.agentName || node.data.label;
 
     const handleClick = (e: MouseEvent) => {
         e.stopPropagation();
         onClick?.(node);
-    };
-
-    const handleNavigate = (e: MouseEvent) => {
-        e.stopPropagation();
-        if (workflowName) {
-            // Build new parent path: current workflow becomes closest parent
-            const newParentPath = currentWorkflowName ? [currentWorkflowName, ...parentPath] : parentPath;
-            navigate(buildWorkflowNavigationUrl(workflowName, newParentPath));
-        }
     };
 
     return (
@@ -42,9 +29,6 @@ const WorkflowRefNode: React.FC<NodeProps> = ({ node, isSelected, isHighlighted,
                 <span className="truncate text-sm font-semibold">{workflowName}</span>
             </div>
             <span className="ml-2 flex-shrink-0 rounded px-2 py-0.5 text-sm font-medium text-[var(--color-secondary-text-wMain)]">Workflow</span>
-            <Button onClick={handleNavigate} variant="ghost" size="icon" className="h-8 w-8" tooltip="Open workflow">
-                <ExternalLink className="h-3.5 w-3.5" />
-            </Button>
         </div>
     );
 };


### PR DESCRIPTION
Feedback from UX was to remove this open workflow button.

Remove the "Open workflow" button from workflow reference nodes in the visualization diagram. Clicking the node itself already navigates to the workflow, making the button redundant. Simplifies the UI and reduces visual clutter per UX feedback.

Before:
<img width="311" height="82" alt="image" src="https://github.com/user-attachments/assets/8db57535-a3df-47c3-b877-68ce53efef5c" />

After:
<img width="310" height="90" alt="image" src="https://github.com/user-attachments/assets/1fa12e00-5e8d-496e-9b6c-a38072cdddd4" />


