### PR TITLE
fix(DATAGO-122352): Add a link to the workflow document

### DIFF
--- a/client/webui/frontend/src/lib/components/workflows/WorkflowOnboardingBanner.tsx
+++ b/client/webui/frontend/src/lib/components/workflows/WorkflowOnboardingBanner.tsx
@@ -33,7 +33,7 @@ export const WorkflowOnboardingBanner: React.FC = () => {
                     <span className="font-semibold">Workflows</span> can automate complex multi-agent tasks by orchestrating agents in a defined sequence. Define your workflows in YAML and deploy them to the Agent Mesh.
                 </p>
 
-                <a href="#" className="mt-2 inline-flex items-center gap-1 text-sm font-medium text-[var(--color-brand-wMain)] hover:underline">
+                <a href="https://solacelabs.github.io/solace-agent-mesh/docs/documentation/components/workflows" target="_blank" rel="noopener noreferrer" className="mt-2 inline-flex items-center gap-1 text-sm font-medium text-[var(--color-brand-wMain)] hover:underline">
                     Learn how to create workflows
                     <ExternalLink size={14} />
                 </a>


### PR DESCRIPTION
### What is the purpose of this change?
The workflow tab needs to refer to a valid page of documents.
[
<img width="387" height="471" alt="Screenshot 2026-01-20 at 2 59 08 PM" src="https://github.com/user-attachments/assets/9f6a23e5-60b1-48eb-b63f-7b4abb9d27ed" />
](url)

### How was this change implemented?
Added the link to the document.

### Key Design Decisions 

### How was this change tested?

- [x] Manual testing: Built SAM, runs documents via 'npm start' and verified the link.
- [ ] Unit tests: [new/modified tests]
- [ ] Integration tests: [if applicable]
- [ ] Known limitations: [what wasn't tested]

### Is there anything the reviewers should focus on/be aware of?
Nothing
