### PR TITLE
fix(DATAGO-123535): Handle trailing / in A2A proxy agent url and fix fallback path

### DIFF
--- a/src/solace_agent_mesh/agent/proxies/a2a/component.py
+++ b/src/solace_agent_mesh/agent/proxies/a2a/component.py
@@ -335,9 +335,6 @@ class A2AProxyComponent(BaseProxyComponent):
             log.error("%s No URL configured for agent.", log_identifier)
             return None
 
-        # Strip trailing slash from URL to avoid double slashes when concatenating
-        agent_url = agent_url.rstrip("/")
-
         try:
             # Build headers based on configuration
             use_auth = agent_config.get("use_auth_for_agent_card", False)
@@ -978,8 +975,6 @@ class A2AProxyComponent(BaseProxyComponent):
         if not use_agent_card_url:
             # Override the agent card URL with the configured URL
             configured_url = agent_config.get("url")
-            # Strip trailing slash from URL to avoid double slashes when concatenating
-            configured_url = configured_url.rstrip("/")
             log.info(
                 "%s Overriding agent card URL with configured URL for agent '%s': %s",
                 self.log_identifier,

--- a/src/solace_agent_mesh/agent/proxies/base/component.py
+++ b/src/solace_agent_mesh/agent/proxies/base/component.py
@@ -77,6 +77,10 @@ class BaseProxyComponent(ComponentBase, ABC):
         super().__init__(info, **kwargs)
         self.namespace = self.get_config("namespace")
         self.proxied_agents_config = self.get_config("proxied_agents", [])
+        # Normalize URLs by stripping trailing slashes to avoid double slashes when concatenating paths
+        for agent_config in self.proxied_agents_config:
+            if "url" in agent_config and agent_config["url"]:
+                agent_config["url"] = agent_config["url"].rstrip("/")
         self.artifact_service_config = self.get_config(
             "artifact_service", {"type": "memory"}
         )
@@ -428,8 +432,6 @@ class BaseProxyComponent(ComponentBase, ABC):
                     )
                     continue
 
-                # Strip trailing slash from URL to avoid double slashes when concatenating
-                agent_url = agent_url.rstrip("/")
                 try:
                     # Build headers using common utility (sync context - OAuth2 not supported)
                     use_auth = agent_config.get("use_auth_for_agent_card", False)


### PR DESCRIPTION
### What is the purpose of this change?

If a user provided a url with a trailing / in the url, the agent would fail to get added as the url would be constructed with // in the middle.  The fallback path is also now aligned with the default in the config. 

### How was this change implemented?

component.py files were changed for the a2a proxy and the base component file for proxies

### How was this change tested?

- [x] Manual testing: Use an proxy url and leave in the trailing slash.
- [ ] Unit tests: [new/modified tests]
- [ ] Integration tests: [if applicable]
- [ ] Known limitations: [what wasn't tested]

### Is there anything the reviewers should focus on/be aware of?

Nothing
