### PR TITLE
feat(DATAGO-121451): Event-Mesh Gateway Workflow Execution with Results

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -255,6 +255,18 @@
             }
         },
         {
+            "name": "EM Gateway + Workflow",
+            "type": "debugpy",
+            "request": "launch",
+            "module": "cli.main",
+            "console": "integratedTerminal",
+            "args": "run examples/gateways/event_mesh_gateway_example.yaml examples/gateways/test_gateway_workflow.yaml examples/agents/all_node_types_workflow.yaml examples/agents/simple_nested_test.yaml examples/agents/orchestrator_example.yaml examples/gateways/webui_gateway_example.yaml",
+            "justMyCode": false,
+            "env": {
+                "LOGGING_CONFIG_PATH": "${workspaceFolder}/preset/logging_config.yaml"
+            }
+        },
+        {
             "name": "CLI",
             "type": "debugpy",
             "request": "launch",

--- a/examples/gateways/event_mesh_gateway_example.yaml
+++ b/examples/gateways/event_mesh_gateway_example.yaml
@@ -39,7 +39,7 @@ apps:
       event_handlers: # List of handlers for incoming Solace messages
         - name: "generic_json_event_handler"
           subscriptions:
-            - topic: "test/ed/>"
+            - topic: "acme/events/>"
               qos: 1
           input_expression: "template:Summarize this data: {{json://input.payload}}"
           payload_encoding: "utf-8"
@@ -53,35 +53,84 @@ apps:
           forward_context: # Optional: Forward data from input to output handlers
             correlation_id: "input.user_properties:correlation_id" # Example: forward a correlation ID
 
-  # Example of a second event handler, commented out
-  #       - name: "text_event_to_specific_agent"
-  #         subscriptions:
-  #           - topic: "external/systemB/events/text/>"
-  #         input_expression: "template:User query from System B: {{text://input.payload}}"
-  #         payload_encoding: "utf-8" # Or "none" if payload is already string
-  #         payload_format: "text"
-  #         on_success: "text_response_to_systemB"
-  #         target_agent_name_expression: "static:TextAnalysisAgent" # Example of static via expression
+        # Workflow handler - workflows use structured invocation automatically
+        # Use target_workflow_name instead of target_agent_name for workflows
+        - name: "order_workflow_handler"
+          subscriptions:
+            - topic: "acme/orders/>"
+              qos: 1
+          target_workflow_name: "OrderProcessingWorkflow"
+          input_expression: "input.payload"
+          payload_encoding: "utf-8"
+          payload_format: "json"
+          on_success: "workflow_success_handler"
+          on_error: "error_response_handler"
+          default_user_identity: "anonymous_event_mesh_user"
+          forward_context:
+            correlation_id: "input.user_properties:correlation_id"
 
-      output_handlers: # Optional: List of handlers for publishing A2A responses
+        # Structured invocation to a regular agent (gateway provides schemas)
+        # Use this when you want schema-validated input/output with a non-workflow agent
+        - name: "structured_agent_handler"
+          subscriptions:
+            - topic: "acme/data/validate/>"
+              qos: 1
+          target_agent_name: "DataValidationAgent"
+          structured_invocation:
+            input_schema:
+              type: object
+              properties:
+                data:
+                  type: object
+                  additionalProperties: true
+              required: [data]
+            output_schema:
+              type: object
+              properties:
+                valid:
+                  type: boolean
+                errors:
+                  type: array
+              required: [valid]
+          input_expression: "input.payload"
+          payload_encoding: "utf-8"
+          payload_format: "json"
+          on_success: "workflow_success_handler"
+          on_error: "error_response_handler"
+          default_user_identity: "anonymous_event_mesh_user"
+          forward_context:
+            correlation_id: "input.user_properties:correlation_id"
+
+        # Example of additional handlers - add more as needed for your use case
+        # - name: "text_event_to_specific_agent"
+        #   subscriptions:
+        #     - topic: "external/systemB/events/text/>"
+        #   input_expression: "template:User query from System B: {{text://input.payload}}"
+        #   payload_encoding: "utf-8" # Or "none" if payload is already string
+        #   payload_format: "text"
+        #   on_success: "text_response_to_systemB"
+        #   target_agent_name_expression: "static:TextAnalysisAgent" # Example of static via expression
+
+      output_handlers: # List of handlers for publishing A2A responses
         - name: "success_response_handler"
           max_file_size_for_base64_bytes: 5242880 # 5MB limit for embedded files
-          topic_expression: "template:test/responses/{{text://user_data.forward_context:correlation_id}}"
-          payload_expression: "task_response:text" # Use the simplified payload's text field
+          topic_expression: "template:acme/responses/{{text://user_data.forward_context:correlation_id}}"
+          payload_expression: "task_response:text" # Use the text field from the response
           payload_encoding: "utf-8"
           payload_format: "text"
-          # output_schema: # Optional: Embedded JSON schema for validation
-          #   type: "object"
-          #   properties:
-          #     processed_data: { "type": "string" }
-          #   required: ["processed_data"]
-          # on_validation_error: "log" # Or "drop"
+
         - name: "error_response_handler"
-          topic_expression: "template:test/errors/{{text://user_data.forward_context:correlation_id}}"
-          payload_expression: "task_response:a2a_task_response.error" # Send the full error object
+          topic_expression: "template:acme/errors/{{text://user_data.forward_context:correlation_id}}"
+          payload_expression: "task_response:a2a_task_response.error"
           payload_encoding: "utf-8"
           payload_format: "json"
 
+        # Output handler for structured responses (workflows and structured agent invocations)
+        - name: "workflow_success_handler"
+          topic_expression: "template:acme/responses/{{text://user_data.forward_context:correlation_id}}"
+          payload_expression: "input.payload:structured_output"  # Extract structured_output field
+          payload_encoding: "utf-8"
+          payload_format: "json"
 
       ############################
       # 1. UPDATE REQUIRED - END #

--- a/examples/gateways/test_gateway_workflow.yaml
+++ b/examples/gateways/test_gateway_workflow.yaml
@@ -1,0 +1,206 @@
+log:
+  stdout_log_level: INFO
+  log_file_level: DEBUG
+  log_file: test_gateway_workflow.log
+
+!include ../shared_config.yaml
+
+apps:
+  # Simple echo agent that just returns input as output
+  - name: simple_echo_agent
+    app_base_path: .
+    app_module: solace_agent_mesh.agent.sac.app
+    broker:
+      <<: *broker_connection
+
+    app_config:
+      namespace: ${NAMESPACE}
+      agent_name: "SimpleEchoAgent"
+      model: *planning_model
+
+      instruction: |
+        Echo back the input data.
+        1. Read the input data
+        2. Create a JSON artifact with the same data plus a "status" field set to "echoed"
+        3. End with: <<result:artifact=<artifact_name> status=success>>
+
+      input_schema:
+        type: object
+        additionalProperties: true
+
+      output_schema:
+        type: object
+        additionalProperties: true
+
+      tools:
+        - tool_type: builtin-group
+          group_name: "artifact_management"
+
+      session_service:
+        <<: *default_session_service
+      artifact_service:
+        <<: *default_artifact_service
+
+      agent_card:
+        description: "Echoes back the input data"
+        skills: [{id: "echo", name: "Echo", description: "Echoes input data", tags: ["echo", "test"]}]
+      agent_card_publishing: { interval_seconds: 10 }
+      agent_discovery: { enabled: false }
+
+  # Simple workflow that calls the echo agent
+  - name: simple_test_workflow
+    app_base_path: .
+    app_module: solace_agent_mesh.workflow.app
+    broker:
+      <<: *broker_connection
+
+    app_config:
+      namespace: ${NAMESPACE}
+      agent_name: "SimpleTestWorkflow"
+      display_name: "Simple Test Workflow"
+
+      workflow:
+        version: "1.0.0"
+        description: "A simple workflow for testing the gateway"
+        max_call_depth: 5
+
+        input_schema:
+          type: object
+          additionalProperties: true
+
+        output_schema:
+          type: object
+          additionalProperties: true
+
+        nodes:
+          - id: echo_step
+            type: agent
+            agent_name: "SimpleEchoAgent"
+            input:
+              data: "{{workflow.input}}"
+
+        output_mapping:
+          result: "{{echo_step.output}}"
+          input_received: "{{workflow.input}}"
+
+        skills:
+          - id: "test_workflow"
+            name: "Test Workflow"
+            description: "Simple workflow for gateway testing"
+            tags: ["test", "gateway"]
+
+      session_service:
+        <<: *default_session_service
+      artifact_service:
+        <<: *default_artifact_service
+
+      agent_card_publishing: { interval_seconds: 10 }
+      agent_discovery: { enabled: false }
+
+  # Agent that intentionally fails for error path testing
+  - name: error_agent
+    app_base_path: .
+    app_module: solace_agent_mesh.agent.sac.app
+    broker:
+      <<: *broker_connection
+
+    app_config:
+      namespace: ${NAMESPACE}
+      agent_name: "ErrorTestAgent"
+      model: *planning_model
+
+      instruction: |
+        You are an agent for testing error handling.
+
+        IMPORTANT: You MUST intentionally fail by using the result embed with status=error.
+
+        When you receive any input:
+        1. Read the input data to see what error message is requested (if any)
+        2. Always respond with: «result:artifact=none status=error message="Intentional test error: <reason>"»
+
+        If the input contains an "error_message" field, use that as the reason.
+        Otherwise, use "Default test failure" as the reason.
+
+        DO NOT create any artifacts. DO NOT succeed. Your job is to fail.
+
+      input_schema:
+        type: object
+        properties:
+          error_message:
+            type: string
+            description: "Custom error message to return"
+        additionalProperties: true
+
+      output_schema:
+        type: object
+        additionalProperties: true
+
+      tools:
+        - tool_type: builtin-group
+          group_name: "artifact_management"
+
+      session_service:
+        <<: *default_session_service
+      artifact_service:
+        <<: *default_artifact_service
+
+      agent_card:
+        description: "Agent that intentionally fails for error testing"
+        skills: [{id: "error_test", name: "Error Test", description: "Always fails with an error", tags: ["error", "test"]}]
+      agent_card_publishing: { interval_seconds: 10 }
+      agent_discovery: { enabled: false }
+
+  # Workflow that calls the error agent to test error handling
+  - name: error_test_workflow
+    app_base_path: .
+    app_module: solace_agent_mesh.workflow.app
+    broker:
+      <<: *broker_connection
+
+    app_config:
+      namespace: ${NAMESPACE}
+      agent_name: "ErrorTestWorkflow"
+      display_name: "Error Test Workflow"
+
+      workflow:
+        version: "1.0.0"
+        description: "A workflow that intentionally fails for testing error paths"
+        max_call_depth: 5
+
+        input_schema:
+          type: object
+          properties:
+            error_message:
+              type: string
+              description: "Custom error message to trigger"
+          additionalProperties: true
+
+        output_schema:
+          type: object
+          additionalProperties: true
+
+        nodes:
+          - id: trigger_error
+            type: agent
+            agent_name: "ErrorTestAgent"
+            input:
+              error_message: "{{workflow.input.error_message}}"
+              test_data: "{{workflow.input}}"
+
+        output_mapping:
+          result: "{{trigger_error.output}}"
+          input_received: "{{workflow.input}}"
+
+        skills:
+          - id: "error_test_workflow"
+            name: "Error Test Workflow"
+            description: "Workflow for testing error handling"
+            tags: ["error", "test"]
+
+      session_service:
+        <<: *default_session_service
+      artifact_service:
+        <<: *default_artifact_service
+
+      agent_card_publishing: { interval_seconds: 10 }
+      agent_discovery: { enabled: false }

--- a/src/solace_agent_mesh/common/sac/sam_component_base.py
+++ b/src/solace_agent_mesh/common/sac/sam_component_base.py
@@ -146,14 +146,6 @@ class SamComponentBase(ComponentBase, abc.ABC):
             message: SolaceMessage = event.data
             topic = message.get_topic()
 
-            # DEBUG: Log all incoming messages at process_event level
-            log.debug(
-                "%s [PROCESS_EVENT_DEBUG] MESSAGE event received | topic=%s | component=%s",
-                self.log_identifier,
-                topic,
-                self._get_component_id() if hasattr(self, '_get_component_id') else 'unknown'
-            )
-
             if not topic:
                 log.warning(
                     "%s Received message without topic. Ignoring.",
@@ -229,7 +221,7 @@ class SamComponentBase(ComponentBase, abc.ABC):
                     self.log_identifier,
                     timer_id,
                 )
-        elif event.event_type == EventType.CACHE_EXPIRY:  
+        elif event.event_type == EventType.CACHE_EXPIRY:
             import asyncio
             import inspect
 
@@ -240,13 +232,13 @@ class SamComponentBase(ComponentBase, abc.ABC):
             if inspect.iscoroutinefunction(handler):
                 # Schedule async handler on the event loop
                 if self._async_loop and self._async_loop.is_running():
+
                     async def handle_async():
                         await handler(cache_data)
 
                     try:
                         future = asyncio.run_coroutine_threadsafe(
-                            handle_async(),
-                            self._async_loop
+                            handle_async(), self._async_loop
                         )
 
                         def on_done(f):
@@ -257,19 +249,20 @@ class SamComponentBase(ComponentBase, abc.ABC):
                                     "%s Error in async cache expiry handler: %s",
                                     self.log_identifier,
                                     e,
-                                    exc_info=True
+                                    exc_info=True,
                                 )
+
                         future.add_done_callback(on_done)
                     except RuntimeError as e:
                         log.error(
                             "%s Failed to schedule async CACHE_EXPIRY handler (event loop may be stopping): %s",
                             self.log_identifier,
-                            e
+                            e,
                         )
                 else:
                     log.error(
                         "%s Cannot handle async CACHE_EXPIRY: event loop not available",
-                        self.log_identifier
+                        self.log_identifier,
                     )
             else:
                 handler(cache_data)
@@ -408,13 +401,13 @@ class SamComponentBase(ComponentBase, abc.ABC):
                 "%s [publish_a2a_message] Starting - topic: %s, payload keys: %s",
                 self.log_identifier,
                 topic,
-                list(payload.keys()) if isinstance(payload, dict) else "not_dict"
+                list(payload.keys()) if isinstance(payload, dict) else "not_dict",
             )
 
             # Create user_properties if it doesn't exist
             if user_properties is None:
                 user_properties = {}
-            
+
             user_properties["timestamp"] = int(time.time() * 1000)
 
             # Validate message size
@@ -444,7 +437,7 @@ class SamComponentBase(ComponentBase, abc.ABC):
             if app:
                 log.debug(
                     "%s [publish_a2a_message] Got app instance, about to call app.send_message",
-                    self.log_identifier
+                    self.log_identifier,
                 )
 
                 # Conditionally log to invocation monitor if it exists (i.e., on an agent)
@@ -459,23 +452,22 @@ class SamComponentBase(ComponentBase, abc.ABC):
                 if trace_logger.isEnabledFor(logging.DEBUG):
                     trace_logger.debug(
                         "%s [publish_a2a_message] About to call app.send_message on topic '%s'\nwith payload: %s\nwith user_properties: %s",
-                        self.log_identifier, topic, payload, user_properties
+                        self.log_identifier,
+                        topic,
+                        payload,
+                        user_properties,
                     )
                 else:
                     log.debug(
                         "%s [publish_a2a_message] About to call app.send_message on topic '%s' (for more details, enable TRACE logging)",
-                        self.log_identifier, topic
+                        self.log_identifier,
+                        topic,
                     )
 
                 app.send_message(
                     payload=payload, topic=topic, user_properties=user_properties
                 )
 
-                # DEBUG: Upgrade to INFO for troubleshooting message routing
-                log.info(
-                    "%s [MSG_DEBUG] Published message to topic: %s",
-                    self.log_identifier, topic
-                )
             else:
                 log.error(
                     "%s Cannot publish message: Not running within a SAC App context.",
@@ -570,14 +562,19 @@ class SamComponentBase(ComponentBase, abc.ABC):
             )
 
         # Monitor async initialization without blocking (critical for multi-agent processes)
-        if hasattr(self, '_async_init_future') and self._async_init_future is not None:
-            log.info("%s Setting up async initialization monitoring...", self.log_identifier)
+        if hasattr(self, "_async_init_future") and self._async_init_future is not None:
+            log.info(
+                "%s Setting up async initialization monitoring...", self.log_identifier
+            )
 
             def handle_init_completion(future):
                 """Non-blocking callback for initialization completion."""
                 try:
                     future.result()  # Raises if init failed
-                    log.info("%s Async initialization completed successfully.", self.log_identifier)
+                    log.info(
+                        "%s Async initialization completed successfully.",
+                        self.log_identifier,
+                    )
                 except Exception as init_error:
                     error_msg = f"{self.log_identifier} Async initialization failed: {init_error}"
                     log.error(error_msg, exc_info=init_error)
@@ -587,7 +584,10 @@ class SamComponentBase(ComponentBase, abc.ABC):
                     )
 
             self._async_init_future.add_done_callback(handle_init_completion)
-            log.info("%s Async initialization monitoring active (non-blocking).", self.log_identifier)
+            log.info(
+                "%s Async initialization monitoring active (non-blocking).",
+                self.log_identifier,
+            )
 
         super().run()
         log.info("%s SamComponentBase run method finished.", self.log_identifier)
@@ -716,9 +716,7 @@ class SamComponentBase(ComponentBase, abc.ABC):
                     add_timer_callback=self.add_timer,
                     event_loop=self.get_async_loop(),
                 )
-                log.info(
-                    "%s Initialized Trust Manager", self.log_identifier
-                )
+                log.info("%s Initialized Trust Manager", self.log_identifier)
             except Exception as e:
                 log.error(
                     "%s Failed to initialize Trust Manager: %s",


### PR DESCRIPTION
### What is the purpose of this change?

Enable the Event-Mesh Gateway to invoke workflows directly and receive structured results from workflow execution. This allows external systems to trigger SAM workflows via Solace events and get properly formatted responses back.

### How was this change implemented?

**Core Changes (for gateway-to-workflow invocation):**

1. **`handler.py`** - Fixed StructuredInvocationRequest extraction to scan all DataParts (not just the first) since the base gateway prepends a timestamp TextPart

2. **`component.py`** - Updated workflow response handling:
   - `_emit_workflow_completion_response`: Detect structured invocations (from gateways, not just sub-workflows) and include `StructuredInvocationResult` in responses
   - `_emit_error_response`: Include `StructuredInvocationResult` for proper error handling by gateway callers

3. **`event_handlers.py`** - Added detection of `StructuredInvocationRequest` in incoming messages, setting `is_structured_invocation` flag in a2a_context

4. **Examples updated:**
   - `event_mesh_gateway_example.yaml`: Shows `target_workflow_name` for workflow invocation and `structured_invocation` for schema-validated agent calls
   - `test_gateway_workflow.yaml` (new): Test agents and workflows for gateway testing

**Note:** This branch also includes the workflows feature stack (from the parent epic) which enables prescriptive workflow execution.

### Key Design Decisions

- Introduced `is_structured_invocation` flag in a2a_context to differentiate gateway calls from regular A2A calls, allowing workflows to format responses appropriately
- Scan all DataParts for structured invocation request rather than assuming position, making the system resilient to message format variations

### How was this change tested?

- [x] Manual testing: Tested gateway-to-workflow invocation using the example configurations, verified structured responses are returned correctly
- [x] Manual testing: Verified error paths return proper StructuredInvocationResult with error details
- [x] Unit tests: Existing workflow tests pass
- [x] Integration tests: Gateway integration tests to be added (DATAGO-121476)

### Is there anything the reviewers should focus on?

1. The changes in `handler.py` around DataPart scanning - ensure this doesn't break existing structured invocation flows
2. The `is_structured_invocation` flag propagation through the workflow execution path
3. The error response handling to ensure gateways can properly parse failure responses