### PR TITLE
fix(DATAGO-123656): Investigate and fix bug in Slack and Teams gateways

### DIFF
--- a/client/webui/frontend/src/lib/components/activities/taskVisualizerProcessor.ts
+++ b/client/webui/frontend/src/lib/components/activities/taskVisualizerProcessor.ts
@@ -400,7 +400,7 @@ export const processTaskForVisualization = (
                         if (data.type === "agent_progress_update") {
                             lastStatusText = data.status_text;
                         } else if (data.type === "artifact_creation_progress") {
-                            lastStatusText = `Saving artifact: ${data.filename} (${data.bytes_saved} bytes)`;
+                            lastStatusText = `Saving artifact: ${data.filename} (${data.bytes_transferred} bytes)`;
                         }
                     }
                     if (part.kind === "data") {


### PR DESCRIPTION
This pull request makes a minor update to the status message shown during artifact creation in the task visualizer. The message now displays the number of bytes transferred instead of bytes saved, providing more accurate progress information.

* Updated the status message in `processTaskForVisualization` to use `data.bytes_transferred` instead of `data.bytes_saved` when reporting artifact creation progress. (`client/webui/frontend/src/lib/components/activities/taskVisualizerProcessor.ts`)