### PR TITLE
fix(DATAGO-123802): Fix tool result display in Activity visualization for nested sub-agent calls

### DIFF
--- a/client/webui/frontend/src/lib/components/activities/FlowChart/utils/nodeDetailsHelper.ts
+++ b/client/webui/frontend/src/lib/components/activities/FlowChart/utils/nodeDetailsHelper.ts
@@ -265,10 +265,11 @@ function findToolNodeDetails(
     const requestStep = primaryStep.type === 'AGENT_TOOL_INVOCATION_START' ? primaryStep : undefined;
 
     // Find the result by matching functionCallId
-    // Check both the step's functionCallId and the data's functionCallId
+    // Use the tool's actual functionCallId from the data (preferred) for matching with tool_result
+    // The step.functionCallId is the parent tracking ID for sub-task relationships
     let resultStep: VisualizerStep | undefined;
 
-    const functionCallId = requestStep?.functionCallId || requestStep?.data.toolInvocationStart?.functionCallId;
+    const functionCallId = requestStep?.data.toolInvocationStart?.functionCallId || requestStep?.functionCallId;
 
     if (functionCallId) {
         resultStep = allSteps.find(


### PR DESCRIPTION
### What is the purpose of this change?

Fixes a bug where clicking on a tool node in the Activity visualization flowchart showed the wrong result when the tool was called by a sub-agent. Instead of showing the tool's actual result, it displayed the entire sub-agent's response.

### How was this change implemented?

Modified `nodeDetailsHelper.ts` to fix the `functionCallId` lookup order in `findToolNodeDetails()`.

The issue was that the code tried `requestStep?.functionCallId` first (which is the parent tracking ID for sub-task relationships) instead of `requestStep?.data.toolInvocationStart?.functionCallId` (which is the tool's actual functionCallId).

This caused the lookup to find the sub-agent's result instead of the nested tool's result when matching by `functionCallId`.

The fix reverses the order to match the correct pattern already used in `layoutEngine.ts:446-447`:
```typescript
// Before (incorrect):
const functionCallId = requestStep?.functionCallId || requestStep?.data.toolInvocationStart?.functionCallId;

// After (correct):
const functionCallId = requestStep?.data.toolInvocationStart?.functionCallId || requestStep?.functionCallId;
```

### How was this change tested?

- [x] Manual testing: Verified that clicking on tool nodes within sub-agents now correctly displays the tool's result instead of the sub-agent's response
- [ ] Unit tests: No new tests added - existing visualization tests cover the general flow
- [ ] Integration tests: N/A
- [ ] Known limitations: Only tested with single-level sub-agent nesting

### Is there anything the reviewers should focus on/be aware of?

The fix aligns the `functionCallId` lookup logic with how `layoutEngine.ts` already handles it (see comment at line 446-447). The pattern is: prefer the tool's actual `functionCallId` from the data, fall back to the step's `functionCallId` for parent tracking.