### PR TITLE
fix(DATAGO-123803): Fix parallel workflow visualization showing empty container

### DIFF
--- a/client/webui/frontend/src/lib/components/activities/FlowChart/utils/types.ts
+++ b/client/webui/frontend/src/lib/components/activities/FlowChart/utils/types.ts
@@ -120,6 +120,14 @@ export interface BuildContext {
     // Track sub-workflow -> parent group relationships (for workflow node types)
     // Maps subTaskId -> parent workflow group node
     subWorkflowParentMap: Map<string, LayoutNode>;
+
+    // Track workflow tool invocations to their functionCallIds
+    // Maps subTaskId -> functionCallId (for finding parallel blocks)
+    workflowFunctionCallIdMap: Map<string, string>;
+
+    // Track workflow functionCallIds by their parent task
+    // Maps parentTaskId -> Set of workflow functionCallIds
+    workflowParentTaskFunctionCallIds: Map<string, Set<string>>;
 }
 
 /**


### PR DESCRIPTION
### What is the purpose of this change?

Fixes a bug where parallel workflow executions were displayed incorrectly in the Activity visualization. The parallel container was shown empty, with the workflows appearing sequentially after/outside it instead of being displayed side-by-side within the container.

### How was this change implemented?

Modified `layoutEngine.ts` and `types.ts` to properly link workflow tool invocations to their corresponding workflow execution starts.

**Root cause:** `handleWorkflowStart` was using `step.functionCallId` to find the parallel block, but this was `undefined` for workflow executions. The workflow tool invocation's `functionCallId` wasn't being linked to the workflow execution start event.

**Fix:**
1. Added a new map `workflowParentTaskFunctionCallIds` to track workflow `functionCallIds` by their `parentTaskId` (the orchestrator's task ID)
2. In `handleToolInvocation` for workflow tools: store the `functionCallId` keyed by the tool invocation's `owningTaskId`
3. In `handleWorkflowStart`: look up `functionCallIds` using the workflow's `parentTaskId`, then find and add the workflow to the correct parallel block

The key insight is that `tool_invocation.owningTaskId == workflow_start.parentTaskId` (both are the orchestrator's task ID).

### How was this change tested?

- [x] Manual testing: Verified parallel workflows now appear side-by-side within the parallel container
- [ ] Unit tests: No new tests - existing visualization tests cover the general flow
- [ ] Integration tests: N/A
- [ ] Known limitations: Only tested with two parallel workflows

### Is there anything the reviewers should focus on/be aware of?

The fix adds a second approach to finding the parallel block. The existing approach (via `subTaskId`) is preserved as a fallback. The new approach uses `parentTaskId` which is always available on workflow execution start events.