### PR TITLE
chore(DATAGO-124068): Add experimental blurb to prompts docs

### DIFF
--- a/docs/docs/documentation/components/prompts.md
+++ b/docs/docs/documentation/components/prompts.md
@@ -5,6 +5,10 @@ sidebar_position: 290
 
 # Prompt Library
 
+:::warning Experimental Feature
+The Prompt Library is currently an experimental feature. While functional, the configuration options and API may change in future releases.
+:::
+
 The Prompt Library is a powerful feature that enables you to create, manage, and reuse prompt templates across your AI conversations. Instead of retyping common instructions or workflows, you can save them as reusable templates with variable placeholders, making your interactions with AI agents more efficient and consistent.
 
 :::tip[In one sentence]


### PR DESCRIPTION
This pull request adds an experimental feature warning to the Prompt Library documentation to inform users that the feature and its API may change in future releases.

Documentation updates:

* Added an "Experimental Feature" warning callout at the top of the Prompt Library documentation in `docs/docs/documentation/components/prompts.md` to clarify the feature's status and potential for changes.