### PR TITLE
fix(DATAGO-124107): prevent empty parallelBlock nodes from rendering in activity flowchart

### DIFF
--- a/client/webui/frontend/src/lib/components/activities/FlowChart/nodes/AgentNode.tsx
+++ b/client/webui/frontend/src/lib/components/activities/FlowChart/nodes/AgentNode.tsx
@@ -41,6 +41,10 @@ const AgentNode: FC<AgentNodeProps> = ({ node, isSelected, onClick, onChildClick
             case "group":
                 return <WorkflowGroup key={child.id} {...childProps} onChildClick={onChildClick} />;
             case "parallelBlock":
+                // Don't render empty parallel blocks
+                if (child.children.length === 0) {
+                    return null;
+                }
                 // Render parallel block - children displayed side-by-side with bounding box
                 return (
                     <div key={child.id} className="flex flex-row items-start gap-4 rounded-lg border-2 border-dashed border-gray-300 bg-gray-50/50 p-4 dark:border-gray-600 dark:bg-gray-800/50">

--- a/client/webui/frontend/src/lib/components/activities/FlowChart/nodes/WorkflowGroup.tsx
+++ b/client/webui/frontend/src/lib/components/activities/FlowChart/nodes/WorkflowGroup.tsx
@@ -234,6 +234,10 @@ const WorkflowGroup: React.FC<WorkflowGroupProps> = ({ node, isSelected, onClick
                     </div>
                 );
             case "parallelBlock": {
+                // Don't render empty parallel blocks
+                if (child.children.length === 0) {
+                    return null;
+                }
                 // Group children by iterationIndex (branch index) for proper chain visualization
                 const branches = new Map<number, LayoutNode[]>();
                 for (const parallelChild of child.children) {


### PR DESCRIPTION
### What is the purpose of this change?

Fixes an issue where an empty dashed rectangle appeared in the activity flowchart when multiple sub-agents were called in parallel. This visual artifact was confusing users as it served no purpose.

### How was this change implemented?

**Root cause:** The code had two competing mechanisms for creating parallel block containers:
1. Pre-creation in `handleLLMResponse` based on analyzing tool decisions
2. On-demand creation in `handleToolInvocation` when the backend sends `parallelGroupId`

When both mechanisms ran, two different parallelBlocks were created with different keys. Agents were added to the backend's block, leaving the pre-created one empty but still rendered.

**Files changed:**
- `layoutEngine.ts`: Removed pre-creation of parallelBlocks in `handleLLMResponse`. Now it only tracks `functionCallIds` for legacy fallback detection. Updated legacy fallback in `handleToolInvocation` and `handleWorkflowStart` to create parallelBlocks on-demand.
- `AgentNode.tsx` & `WorkflowGroup.tsx`: Added defensive check to skip rendering parallelBlocks with no children.

### Key Design Decisions

Chose to create parallelBlocks on-demand rather than pre-creating them because:
- Avoids duplicate containers when backend provides `parallelGroupId`
- Ensures parallelBlocks only exist when they actually have children
- Maintains backward compatibility with legacy parallel detection

### How was this change tested?

- [x] Manual testing: Verified empty rectangle no longer appears when parallel sub-agents are invoked
- [ ] Unit tests: No new tests (existing rendering tests should cover this)
- [ ] Integration tests: N/A
- [ ] Known limitations: Only tested with peer delegation and workflow parallel calls

### Is there anything the reviewers should focus on?

- The defensive check in render components (`child.children.length === 0`) is kept as a safety net
- The legacy fallback code path is preserved for cases where backend doesn't send `parallelGroupId`