### PR TITLE
fix(DATAGO-124056): fix artifact showing deleted status on creation

### DIFF
--- a/client/webui/frontend/src/lib/components/chat/file/ArtifactMessage.tsx
+++ b/client/webui/frontend/src/lib/components/chat/file/ArtifactMessage.tsx
@@ -71,9 +71,15 @@ export const ArtifactMessage: React.FC<ArtifactMessageProps> = props => {
     const fileMimeType = fileAttachment?.mime_type;
 
     // Detect if artifact has been deleted: completed but not in artifacts list
+    // However, don't mark as deleted if we have a valid fileAttachment with a URI -
+    // that means the artifact exists on the backend but just hasn't been fetched into the local list yet
     const isDeleted = useMemo(() => {
-        return props.status === "completed" && !artifact;
-    }, [props.status, artifact]);
+        if (props.status !== "completed") return false;
+        if (artifact) return false; // Found in list, not deleted
+        // If we have a fileAttachment with a URI, the artifact exists on backend (just not fetched yet)
+        if (fileAttachment?.uri) return false;
+        return true; // Completed, not in list, no URI = likely deleted
+    }, [props.status, artifact, fileAttachment?.uri]);
 
     // Determine if this should auto-expand based on context
     const shouldAutoExpand = useMemo(() => {


### PR DESCRIPTION
### What is the purpose of this change?

Fixes a bug where artifacts displayed a "Deleted" status immediately upon creation, only showing the correct filename after the task completed.

### How was this change implemented?

**Root cause:** The `isDeleted` check in `ArtifactMessage.tsx` was too aggressive. It marked an artifact as deleted if:
- Status was "completed"
- Artifact was not found in the global artifacts list

However, there's a race condition: when a task completes, the artifact's status changes to "completed" but the global artifacts list hasn't been fetched/updated yet. This caused newly created artifacts to briefly show as "Deleted".

**Fix:** Updated the `isDeleted` logic to not mark an artifact as deleted if it has a valid `fileAttachment` with a URI. If we have a URI, the artifact exists on the backend - it just hasn't been fetched into the local list yet.

**File changed:**
- `ArtifactMessage.tsx`: Modified `isDeleted` useMemo to check for `fileAttachment?.uri` before marking as deleted

### How was this change tested?

- [x] Manual testing: Verified artifacts no longer show "Deleted" status on creation
- [ ] Unit tests: No new tests (logic change in existing component)
- [ ] Integration tests: N/A
- [ ] Known limitations: None identified

### Is there anything the reviewers should focus on?

The fix is minimal and surgical - only the `isDeleted` detection logic was changed. The key insight is that if we have a `fileAttachment.uri`, the artifact definitely exists on the backend.