### PR TITLE
fix(DATAGO-124054): prevent workflow arrow heads from being cut off by nodes

### DIFF
--- a/client/webui/frontend/src/lib/components/workflowVisualization/WorkflowDiagram.tsx
+++ b/client/webui/frontend/src/lib/components/workflowVisualization/WorkflowDiagram.tsx
@@ -152,6 +152,10 @@ const WorkflowDiagram: React.FC<WorkflowDiagramProps> = ({
         // Build flat map of all node positions from layout tree
         const nodePositions = buildNodePositionMap(layout.nodes);
 
+        // Offset to ensure arrowheads are visible above nodes
+        // The arrowhead marker is 12px tall, so we end edges slightly above the node
+        const arrowheadOffset = 4;
+
         // Calculate edges based on layout positions
         const edges: Edge[] = [];
         for (const edge of layout.edges) {
@@ -164,7 +168,8 @@ const WorkflowDiagram: React.FC<WorkflowDiagramProps> = ({
                     sourceX: sourcePos.x + sourcePos.width / 2,
                     sourceY: sourcePos.y + sourcePos.height,
                     targetX: targetPos.x + targetPos.width / 2,
-                    targetY: targetPos.y,
+                    // End edge slightly above the node so arrowhead is fully visible
+                    targetY: targetPos.y - arrowheadOffset,
                 });
             }
         }


### PR DESCRIPTION
### What is the purpose of this change?
Fixes the issue where workflow arrow heads are being cut off by the nodes beneath them in the workflow diagram view.

### How was this change implemented?
Added a 4-pixel offset to the edge target Y position in `WorkflowDiagram.tsx`. This ensures the arrowheads are rendered slightly above the target nodes, making them fully visible instead of being obscured by the node elements.

The change is in the `calculatedEdges` computation where edges are positioned based on layout node positions.

### Key Design Decisions
- Used a small 4-pixel offset which is enough to make the arrowhead visible without creating a noticeable gap between the arrow and the node
- The arrowhead marker is 12px tall with refX=9, so the tip extends 3px past the path endpoint - the 4px offset ensures the full arrowhead is visible

### How was this change tested?
- [x] Manual testing: Verified workflow diagrams display arrows with fully visible arrowheads
- [x] Build verification: npm run build passes without errors

### Is there anything the reviewers should focus on?
The offset value (4px) was chosen to be minimal while still ensuring visibility. If the arrowheads still appear slightly cut off in some edge cases, this value could be increased.

AFTER:
<img width="562" height="541" alt="image" src="https://github.com/user-attachments/assets/983667a8-8791-4dee-a07d-414407591527" />
