### PR TITLE
fix(DATAGO-124129):  Workflows: “delay” setting not visible for Loop node in Properties panel

### DIFF
--- a/client/webui/frontend/src/lib/components/workflowVisualization/WorkflowNodeDetailPanel.tsx
+++ b/client/webui/frontend/src/lib/components/workflowVisualization/WorkflowNodeDetailPanel.tsx
@@ -302,6 +302,14 @@ const WorkflowNodeDetailPanel: React.FC<WorkflowNodeDetailPanelProps> = ({ node,
                             </div>
                         )}
 
+                        {/* Delay (for loop nodes) */}
+                        {node.data.delay && (
+                            <div className="mb-4">
+                                <label className="mb-1 block text-sm font-medium text-(--color-secondary-text-wMain)">Delay</label>
+                                <div className="text-sm">{node.data.delay}</div>
+                            </div>
+                        )}
+
                         {/* Condition (for loop nodes) */}
                         {node.data.condition && (
                             <div className="mb-4">

--- a/client/webui/frontend/src/lib/components/workflowVisualization/utils/layoutEngine.ts
+++ b/client/webui/frontend/src/lib/components/workflowVisualization/utils/layoutEngine.ts
@@ -388,6 +388,7 @@ function createLayoutNode(procNode: ProcessedNode, nodeMap: Map<string, Processe
             {
                 baseNode.data.condition = config.condition;
                 baseNode.data.maxIterations = config.max_iterations;
+                baseNode.data.delay = config.delay;
                 baseNode.data.childNodeId = config.node;
 
                 // Get child node if exists

--- a/client/webui/frontend/src/lib/components/workflowVisualization/utils/types.ts
+++ b/client/webui/frontend/src/lib/components/workflowVisualization/utils/types.ts
@@ -32,6 +32,7 @@ export interface LayoutNode {
         defaultCase?: string; // For switch default branch
         items?: string; // For map node
         maxIterations?: number; // For loop
+        delay?: string; // For loop
         childNodeId?: string; // For map/loop inner node reference
         // For condition pill nodes
         conditionLabel?: string; // The condition text to display

--- a/client/webui/frontend/src/lib/utils/agentUtils.ts
+++ b/client/webui/frontend/src/lib/utils/agentUtils.ts
@@ -32,6 +32,7 @@ export interface WorkflowNodeConfig {
     items?: string;
     condition?: string;
     max_iterations?: number;
+    delay?: string;
 }
 
 /**

--- a/client/webui/frontend/src/stories/workflowVisualization/WorkflowNodeDetailPanel.stories.tsx
+++ b/client/webui/frontend/src/stories/workflowVisualization/WorkflowNodeDetailPanel.stories.tsx
@@ -1,0 +1,71 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { expect, screen } from "storybook/test";
+import WorkflowNodeDetailPanel from "@/lib/components/workflowVisualization/WorkflowNodeDetailPanel";
+import type { LayoutNode } from "@/lib/components/workflowVisualization/utils/types";
+
+const meta: Meta<typeof WorkflowNodeDetailPanel> = {
+    title: "Workflow Visualization/WorkflowNodeDetailPanel",
+    component: WorkflowNodeDetailPanel,
+    tags: ["autodocs"],
+    decorators: [
+        Story => (
+            <div className="h-screen bg-white dark:bg-gray-900">
+                <Story />
+            </div>
+        ),
+    ],
+};
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+const createLoopNode = (delay?: string): LayoutNode => ({
+    id: "polling_loop",
+    type: "loop",
+    x: 0,
+    y: 0,
+    width: 200,
+    height: 60,
+    children: [],
+    data: {
+        label: "Polling Loop",
+        condition: "{{check_status.output.ready}} == false",
+        maxIterations: 10,
+        ...(delay && { delay }),
+    },
+});
+
+export const LoopNodeWithDelay: Story = {
+    args: {
+        node: createLoopNode("5s"),
+        workflowConfig: null,
+        agents: [],
+    },
+    play: async () => {
+        // Verify delay is rendered
+        expect(screen.getByText("Delay")).toBeInTheDocument();
+        expect(screen.getByText("5s")).toBeInTheDocument();
+    },
+};
+
+export const LoopNodeWithoutDelay: Story = {
+    args: {
+        node: createLoopNode(),
+        workflowConfig: null,
+        agents: [],
+    },
+    play: async () => {
+        // Verify node ID appears twice: once in title header, once in Node ID section
+        const pollingLoopElements = screen.getAllByText("polling_loop");
+        expect(pollingLoopElements.length).toBeGreaterThanOrEqual(2);
+
+        // Verify expected properties are rendered
+        expect(screen.getByText("Max Iterations")).toBeInTheDocument();
+        expect(screen.getByText("10")).toBeInTheDocument();
+        expect(screen.getByText("Condition")).toBeInTheDocument();
+
+        // Verify delay is NOT rendered
+        const delayLabel = screen.queryByText("Delay");
+        expect(delayLabel).not.toBeInTheDocument();
+    },
+};

--- a/src/solace_agent_mesh/workflow/component.py
+++ b/src/solace_agent_mesh/workflow/component.py
@@ -265,6 +265,8 @@ class WorkflowExecutorComponent(SamComponentBase):
                     node_dict["condition"] = node.condition
                 if node.max_iterations:
                     node_dict["max_iterations"] = node.max_iterations
+                if node.delay:
+                    node_dict["delay"] = node.delay
             elif node.type == "workflow":
                 node_dict["workflow_name"] = node.workflow_name
                 if node.input:


### PR DESCRIPTION
### What is the purpose of this change?

Add support for displaying the delay property on loop nodes in the workflow visualization UI. This allows users to see and configure the delay between loop iterations when viewing workflow details.

Below image shows Details Panel with the delay value set.
<img width="551" height="456" alt="image" src="https://github.com/user-attachments/assets/251108c9-3f6c-4145-83cf-67aa054b1800" />

### How was this change implemented?

Backend:

Modified src/solace_agent_mesh/workflow/component.py to serialize the delay property for loop nodes in the workflow config JSON (only includes delay when set, maintaining backward compatibility)

Frontend:

Added delay?: string to the LayoutNode data interface in utils/types.ts
Updated WorkflowNodeDetailPanel.tsx to display the delay property in the details view for loop nodes
Created comprehensive Storybook stories at stories/workflowVisualization/WorkflowNodeDetailPanel.stories.tsx with tests verifying delay rendering behavior

### Key Design Decisions _(optional - delete if not applicable)_

Optional delay property: The delay is only included in serialized config when explicitly set, maintaining backward compatibility with existing workflows
UI display strategy: For loop nodes, the component displays node ID in the title (not the label), consistent with how loop nodes are referenced elsewhere in the system

### How was this change tested?

- [x] Manual testing: [describe scenarios]
- [x] Unit tests: [new/modified tests]
- [ ] Integration tests: [if applicable]
- [ ] Known limitations: [what wasn't tested]

### Is there anything the reviewers should focus on/be aware of?


