### PR TITLE
fix(DATAGO-124095):remove breadcrumb navigation from newly opened workflow tabs

### DIFF
--- a/client/webui/frontend/src/lib/components/workflowVisualization/WorkflowNodeDetailPanel.tsx
+++ b/client/webui/frontend/src/lib/components/workflowVisualization/WorkflowNodeDetailPanel.tsx
@@ -21,17 +21,13 @@ interface WorkflowNodeDetailPanelProps {
     knownNodeIds?: Set<string>;
     /** Callback to navigate/pan to a node when clicking the navigation icon */
     onNavigateToNode?: (nodeId: string) => void;
-    /** Current workflow name - used for building sub-workflow navigation URLs */
-    currentWorkflowName?: string;
-    /** Parent workflow path (for breadcrumb navigation) */
-    parentPath?: string[];
 }
 
 /**
  * WorkflowNodeDetailPanel - Shows details for the selected workflow node
  * Includes input/output schemas, code view toggle, and agent information
  */
-const WorkflowNodeDetailPanel: React.FC<WorkflowNodeDetailPanelProps> = ({ node, workflowConfig: _workflowConfig, agents, onHighlightNodes, knownNodeIds, onNavigateToNode, currentWorkflowName, parentPath = [] }) => {
+const WorkflowNodeDetailPanel: React.FC<WorkflowNodeDetailPanelProps> = ({ node, workflowConfig: _workflowConfig, agents, onHighlightNodes, knownNodeIds, onNavigateToNode }) => {
     // workflowConfig is available for future use (e.g., accessing workflow-level output_mapping)
     void _workflowConfig;
     const [showCodeView, setShowCodeView] = useState(false);
@@ -76,14 +72,14 @@ const WorkflowNodeDetailPanel: React.FC<WorkflowNodeDetailPanelProps> = ({ node,
         setShowCodeView(false);
     }, []);
 
-    // Navigate to nested workflow with parent path tracking for breadcrumbs
+    // Navigate to nested workflow in a new tab
+    // When opening in a new tab, don't include parent path - the new tab should start fresh
+    // without breadcrumb navigation back to the previous workflow
     const handleOpenWorkflow = useCallback(() => {
         if (node?.data.workflowName) {
-            // Build new parent path: current workflow becomes closest parent
-            const newParentPath = currentWorkflowName ? [currentWorkflowName, ...parentPath] : parentPath;
-            window.open("/#" + buildWorkflowNavigationUrl(node.data.workflowName, newParentPath), "_blank");
+            window.open("/#" + buildWorkflowNavigationUrl(node.data.workflowName), "_blank");
         }
-    }, [node?.data.workflowName, currentWorkflowName, parentPath]);
+    }, [node?.data.workflowName]);
 
     if (!node) {
         return null;

--- a/client/webui/frontend/src/lib/components/workflowVisualization/WorkflowVisualizationPage.tsx
+++ b/client/webui/frontend/src/lib/components/workflowVisualization/WorkflowVisualizationPage.tsx
@@ -334,16 +334,7 @@ export function WorkflowVisualizationPage() {
                 {/* Floating node detail popover (shown when node selected) */}
                 {selectedNode && (
                     <div className={`absolute top-4 right-4 bottom-4 z-10 overflow-hidden rounded-lg border shadow-lg ${shouldAnimate ? "animate-in slide-in-from-right duration-300" : ""}`} style={{ width: panelWidth }}>
-                        <WorkflowNodeDetailPanel
-                            node={selectedNode}
-                            workflowConfig={config}
-                            agents={agents}
-                            onHighlightNodes={handleHighlightNodes}
-                            knownNodeIds={knownNodeIds}
-                            onNavigateToNode={handleNavigateToNode}
-                            currentWorkflowName={workflow.name}
-                            parentPath={parentPath}
-                        />
+                        <WorkflowNodeDetailPanel node={selectedNode} workflowConfig={config} agents={agents} onHighlightNodes={handleHighlightNodes} knownNodeIds={knownNodeIds} onNavigateToNode={handleNavigateToNode} />
                     </div>
                 )}
 


### PR DESCRIPTION
### What is the purpose of this change?
When opening a nested workflow in a new tab, the breadcrumb navigation was showing the parent workflow hierarchy, which was confusing for users. This fix removes the breadcrumb navigation to the previous workflow when opening in a new tab, so the new tab starts fresh with only the standard breadcrumb path (Agents > Workflows > [Current Workflow Name]).

### How was this change implemented?
Modified `WorkflowNodeDetailPanel.tsx` to not pass the parent path when opening a workflow in a new tab via `window.open()`. The `buildWorkflowNavigationUrl()` function is now called without the parent path parameter, which results in a clean URL without the `?from=` query parameter.

Also cleaned up the unused `currentWorkflowName` and `parentPath` props from the component interface since they are no longer needed.

### Key Design Decisions
- When opening in a new tab, users expect a fresh context without navigation back to where they came from
- The breadcrumb navigation is still preserved for in-page navigation (clicking through nested workflows within the same tab)

### How was this change tested?
- [x] Manual testing: Verified that opening a nested workflow in a new tab no longer shows breadcrumb navigation to the parent workflow
- [x] Build verification: TypeScript compilation and build succeeded
- [ ] Unit tests: No existing tests for this component

### Is there anything the reviewers should focus on?
The change is minimal and focused - only the `handleOpenWorkflow` function was modified to not pass the parent path when opening in a new tab.

BEFORE:
<img width="1059" height="605" alt="image" src="https://github.com/user-attachments/assets/40912404-919e-4da6-9c76-2413640cc950" />

AFTER:
<img width="1059" height="605" alt="image" src="https://github.com/user-attachments/assets/da34223f-946c-42ac-a526-5917c75b8ff8" />


