### PR TITLE
fix(DATAGO-124182): Rename prompt section headers to 'AI Builder' and 'Preview' respectively

### DIFF
--- a/client/webui/frontend/src/lib/components/prompts/PromptBuilderChat.tsx
+++ b/client/webui/frontend/src/lib/components/prompts/PromptBuilderChat.tsx
@@ -286,7 +286,7 @@ export const PromptBuilderChat: React.FC<PromptBuilderChatProps> = ({ onConfigUp
                     <div className="bg-primary/10 flex h-8 w-8 items-center justify-center rounded-full">
                         <Sparkles className="text-primary h-4 w-4" />
                     </div>
-                    <h3 className="text-sm font-semibold">AI Template Builder</h3>
+                    <h3 className="text-sm font-semibold">AI Builder</h3>
                 </div>
             </div>
 

--- a/client/webui/frontend/src/lib/components/prompts/TemplatePreviewPanel.tsx
+++ b/client/webui/frontend/src/lib/components/prompts/TemplatePreviewPanel.tsx
@@ -113,7 +113,7 @@ export const TemplatePreviewPanel: React.FC<TemplatePreviewPanelProps> = ({ conf
                         <NotepadText className="text-muted-foreground h-4 w-4" />
                     </div>
                     <div>
-                        <h3 className="text-sm font-semibold">Template Preview</h3>
+                        <h3 className="text-sm font-semibold">Preview</h3>
                     </div>
                 </div>
             </div>


### PR DESCRIPTION
### What is the purpose of this change?

Renames headings for clarity.

### How was this change implemented?

Minor frontend edits.

### How was this change tested?

- [X] Manual testing: Visual tests, Storybook tests

<img width="1625" height="989" alt="changes" src="https://github.com/user-attachments/assets/5713223c-04c7-4908-abec-bcc8592d5347" />

