### PR TITLE
fix(DATAGO-124197): fix config resolver init

### DIFF
--- a/src/solace_agent_mesh/services/platform/component.py
+++ b/src/solace_agent_mesh/services/platform/component.py
@@ -154,7 +154,6 @@ class PlatformServiceComponent(SamComponentBase):
         self.uvicorn_server = None
         self.fastapi_thread = None
 
-        # Config resolver (permissive default - allows all features/scopes)
         self.config_resolver = MiddlewareRegistry.get_config_resolver()
 
         # Legacy router compatibility
@@ -663,13 +662,6 @@ class PlatformServiceComponent(SamComponentBase):
     def get_config_resolver(self) -> ConfigResolver:
         """
         Return the ConfigResolver instance.
-
-        The default ConfigResolver is permissive and allows all features/scopes.
-        This enables webui_backend routers (which use ValidatedUserConfig) to work
-        in platform mode without custom authorization logic.
-
-        Returns:
-            ConfigResolver instance.
         """
         return self.config_resolver
 


### PR DESCRIPTION
Fixes the platform service to use the middleware registry to get the correct config resolver. Previously it would always use the base ConfigResolver which is a stub that does not support authz