### PR TITLE
fix(DATAGO-124020): Move edit button out of action menu

### DIFF
--- a/client/webui/frontend/src/lib/components/prompts/VersionHistoryPage.tsx
+++ b/client/webui/frontend/src/lib/components/prompts/VersionHistoryPage.tsx
@@ -222,29 +222,31 @@ export const VersionHistoryPage: React.FC<VersionHistoryPageProps> = ({ group, o
                                 {/* Header with actions */}
                                 <div className="flex items-center justify-between">
                                     <h2 className="text-lg font-semibold">Version {selectedVersion.version} Details</h2>
-                                    <DropdownMenu>
-                                        <DropdownMenuTrigger asChild>
-                                            <Button variant="ghost" size="sm">
-                                                <MoreHorizontal className="h-4 w-4" />
-                                            </Button>
-                                        </DropdownMenuTrigger>
-                                        <DropdownMenuContent align="end">
-                                            <DropdownMenuItem onClick={handleEditVersion}>
-                                                <Pencil size={14} className="mr-2" />
-                                                Edit Version
-                                            </DropdownMenuItem>
-                                            {!isActiveVersion && (
-                                                <DropdownMenuItem onClick={handleRestoreVersion}>
-                                                    <Check size={14} className="mr-2" />
-                                                    Make Active Version
+                                    <div className="flex items-center gap-2">
+                                        <Button variant="ghost" size="sm" onClick={handleEditVersion}>
+                                            <Pencil className="h-4 w-4" />
+                                            Edit
+                                        </Button>
+                                        <DropdownMenu>
+                                            <DropdownMenuTrigger asChild>
+                                                <Button variant="ghost" size="sm">
+                                                    <MoreHorizontal className="h-4 w-4" />
+                                                </Button>
+                                            </DropdownMenuTrigger>
+                                            <DropdownMenuContent align="end">
+                                                {!isActiveVersion && (
+                                                    <DropdownMenuItem onClick={handleRestoreVersion}>
+                                                        <Check size={14} className="mr-2" />
+                                                        Make Active Version
+                                                    </DropdownMenuItem>
+                                                )}
+                                                <DropdownMenuItem onClick={handleDeleteVersion}>
+                                                    <Trash2 size={14} className="mr-2" />
+                                                    Delete Version
                                                 </DropdownMenuItem>
-                                            )}
-                                            <DropdownMenuItem onClick={handleDeleteVersion}>
-                                                <Trash2 size={14} className="mr-2" />
-                                                Delete Version
-                                            </DropdownMenuItem>
-                                        </DropdownMenuContent>
-                                    </DropdownMenu>
+                                            </DropdownMenuContent>
+                                        </DropdownMenu>
+                                    </div>
                                 </div>
 
                                 {/* Read-only version details - use versioned fields from selectedVersion, fallback to group */}
@@ -252,14 +254,14 @@ export const VersionHistoryPage: React.FC<VersionHistoryPageProps> = ({ group, o
                                     {/* Template Name */}
                                     <div className="space-y-2">
                                         <Label className="text-[var(--color-secondaryText-wMain)]">Name</Label>
-                                        <div className="rounded p-3 text-sm">{selectedVersion.name || currentGroup.name}</div>
+                                        <div className="rounded p-3 text-sm break-words whitespace-pre-wrap">{selectedVersion.name || currentGroup.name}</div>
                                     </div>
 
                                     {/* Description */}
                                     {(selectedVersion.description || currentGroup.description) && (
                                         <div className="space-y-2">
                                             <Label className="text-[var(--color-secondaryText-wMain)]">Description</Label>
-                                            <div className="rounded p-3 text-sm">{selectedVersion.description || currentGroup.description}</div>
+                                            <div className="rounded p-3 text-sm break-words whitespace-pre-wrap">{selectedVersion.description || currentGroup.description}</div>
                                         </div>
                                     )}
 


### PR DESCRIPTION
This pull request updates the `VersionHistoryPage` component to improve the user experience and display formatting. The most important changes include moving the "Edit" action out of the dropdown menu for easier access and updating how version details are displayed for better readability.

**UI/UX Improvements:**

* Added a dedicated "Edit" button next to the version header, making the edit action more prominent and accessible instead of nesting it inside the dropdown menu.

**Display and Formatting Enhancements:**

* Updated the display of the version name and description fields to use `break-words` and `whitespace-pre-wrap` CSS classes, ensuring that long text wraps and maintains formatting for improved readability.

**Before**
<img width="1208" height="305" alt="CleanShot 2026-02-04 at 15 24 11" src="https://github.com/user-attachments/assets/342622f8-87da-4447-ac26-98b1de7424b6" />

**After** 
<img width="1196" height="411" alt="CleanShot 2026-02-04 at 15 35 24" src="https://github.com/user-attachments/assets/0eec3c56-f401-4d65-ba2d-2d1941f91655" />
