### PR TITLE
fix(DATAGO-124046): fix nested agent visualization in activity flow

### DIFF
--- a/client/webui/frontend/src/lib/components/activities/taskVisualizerProcessor.ts
+++ b/client/webui/frontend/src/lib/components/activities/taskVisualizerProcessor.ts
@@ -840,46 +840,53 @@ export const processTaskForVisualization = (
 
                                     const delegationInfos: DelegationInfo[] = [];
                                     const claimedSubTaskIds = new Set<string>();
+                                    // Look for matching sub-tasks for ALL tool calls, not just those with peer_/workflow_ prefix
+                                    // If a matching sub-task is found, it's a peer delegation regardless of tool name
                                     decisions.forEach(decision => {
-                                        if (decision.isPeerDelegation) {
-                                            let peerAgentActualName = decision.toolName;
-                                            if (decision.toolName.startsWith("peer_")) {
-                                                peerAgentActualName = decision.toolName.substring(5);
-                                            } else if (decision.toolName.startsWith("workflow_")) {
-                                                peerAgentActualName = decision.toolName.substring(9);
-                                            }
+                                        // Determine the agent name (strip peer_/workflow_ prefix if present)
+                                        let peerAgentActualName = decision.toolName;
+                                        if (decision.toolName.startsWith("peer_")) {
+                                            peerAgentActualName = decision.toolName.substring(5);
+                                        } else if (decision.toolName.startsWith("workflow_")) {
+                                            peerAgentActualName = decision.toolName.substring(9);
+                                        }
 
-                                            for (const stId in allMonitoredTasks) {
-                                                const candSubTask = allMonitoredTasks[stId];
-                                                if (claimedSubTaskIds.has(candSubTask.taskId)) continue;
+                                        // Search for a sub-task that matches this function call
+                                        for (const stId in allMonitoredTasks) {
+                                            const candSubTask = allMonitoredTasks[stId];
+                                            if (claimedSubTaskIds.has(candSubTask.taskId)) continue;
 
-                                                const candSubTaskParentId = getParentTaskIdFromTaskObject(candSubTask);
+                                            const candSubTaskParentId = getParentTaskIdFromTaskObject(candSubTask);
 
-                                                if (candSubTaskParentId === currentEventOwningTaskId && candSubTask.events && candSubTask.events.length > 0) {
-                                                    const subTaskCreationRequest = candSubTask.events.find(e => e.direction === "request" && e.full_payload?.params?.message?.metadata?.function_call_id === decision.functionCallId);
-                                                    if (subTaskCreationRequest) {
-                                                        // Validate timestamp if available, but don't fail if timestamp is undefined
-                                                        // (request events may not have result.status.timestamp, causing getEventTimestamp to return undefined)
-                                                        const subTaskTimestamp = getEventTimestamp(subTaskCreationRequest);
-                                                        const eventTimestampMs = new Date(eventTimestamp).getTime();
-                                                        const subTaskTimestampMs = subTaskTimestamp ? new Date(subTaskTimestamp).getTime() : NaN;
-                                                        // If we can't determine the sub-task timestamp (NaN), trust the function_call_id match
-                                                        // Otherwise, require the sub-task to be created at or after the LLM response
-                                                        const isValidMatch = Number.isNaN(subTaskTimestampMs) || subTaskTimestampMs >= eventTimestampMs;
-                                                        if (isValidMatch) {
-                                                            const delInfo: DelegationInfo = {
-                                                                functionCallId: decision.functionCallId,
-                                                                peerAgentName: peerAgentActualName,
-                                                                subTaskId: candSubTask.taskId,
-                                                            };
-                                                            delegationInfos.push(delInfo);
-                                                            functionCallIdToDelegationInfoMap.set(decision.functionCallId, delInfo);
-                                                            if (candSubTask.taskId) {
-                                                                subTaskToFunctionCallIdMap.set(candSubTask.taskId, decision.functionCallId);
-                                                                claimedSubTaskIds.add(candSubTask.taskId);
-                                                            }
-                                                            break;
+                                            if (candSubTaskParentId === currentEventOwningTaskId && candSubTask.events && candSubTask.events.length > 0) {
+                                                const subTaskCreationRequest = candSubTask.events.find(e => {
+                                                    const fcId = e.full_payload?.params?.message?.metadata?.function_call_id;
+                                                    return e.direction === "request" && fcId === decision.functionCallId;
+                                                });
+                                                if (subTaskCreationRequest) {
+                                                    // Validate timestamp if available, but don't fail if timestamp is undefined
+                                                    // (request events may not have result.status.timestamp, causing getEventTimestamp to return undefined)
+                                                    const subTaskTimestamp = getEventTimestamp(subTaskCreationRequest);
+                                                    const eventTimestampMs = new Date(eventTimestamp).getTime();
+                                                    const subTaskTimestampMs = subTaskTimestamp ? new Date(subTaskTimestamp).getTime() : NaN;
+                                                    // If we can't determine the sub-task timestamp (NaN), trust the function_call_id match
+                                                    // Otherwise, require the sub-task to be created at or after the LLM response
+                                                    const isValidMatch = Number.isNaN(subTaskTimestampMs) || subTaskTimestampMs >= eventTimestampMs;
+                                                    if (isValidMatch) {
+                                                        // Found a matching sub-task - this is a peer delegation
+                                                        decision.isPeerDelegation = true;
+                                                        const delInfo: DelegationInfo = {
+                                                            functionCallId: decision.functionCallId,
+                                                            peerAgentName: peerAgentActualName,
+                                                            subTaskId: candSubTask.taskId,
+                                                        };
+                                                        delegationInfos.push(delInfo);
+                                                        functionCallIdToDelegationInfoMap.set(decision.functionCallId, delInfo);
+                                                        if (candSubTask.taskId) {
+                                                            subTaskToFunctionCallIdMap.set(candSubTask.taskId, decision.functionCallId);
+                                                            claimedSubTaskIds.add(candSubTask.taskId);
                                                         }
+                                                        break;
                                                     }
                                                 }
                                             }
@@ -954,15 +961,17 @@ export const processTaskForVisualization = (
                                 break;
                             }
                             case "tool_invocation_start": {
+                                // Get delegation info first - if it exists, this is a peer agent invocation
+                                const delegationInfo = functionCallIdToDelegationInfoMap.get(signalData.function_call_id);
+
                                 const invocationData: ToolInvocationStartData = {
                                     functionCallId: signalData.function_call_id,
                                     toolName: signalData.tool_name,
                                     toolArguments: signalData.tool_args,
-                                    isPeerInvocation: signalData.tool_name?.startsWith("peer_") || signalData.tool_name?.startsWith("workflow_"),
+                                    // Peer invocation if: tool_name has peer_/workflow_ prefix, OR delegation info exists (agent was invoked)
+                                    isPeerInvocation: signalData.tool_name?.startsWith("peer_") || signalData.tool_name?.startsWith("workflow_") || !!delegationInfo,
                                     parallelGroupId: signalData.parallel_group_id,
                                 };
-
-                                const delegationInfo = functionCallIdToDelegationInfoMap.get(signalData.function_call_id);
 
                                 visualizerSteps.push({
                                     id: `vstep-toolinvokestart-${visualizerSteps.length}-${eventId}`,


### PR DESCRIPTION
### What is the purpose of this change?
Fixes the activity flow visualization where nested agent nodes (like SupportTicketAgent) were not appearing correctly. The agent would be missing from the diagram and its tools would incorrectly appear directly under the parent Orchestrator.

### How was this change implemented?

**taskVisualizerProcessor.ts:**
- Search all tool calls for matching sub-tasks (not just those with `peer_`/`workflow_` prefix) to properly detect delegation relationships
- Trust function_call_id match when timestamp is unavailable (request events don't have `result.status.timestamp`)

**layoutEngine.ts:**
- `handleUserRequest`: Insert User node at beginning with `unshift()` to ensure it always appears first; check for existing agent before creating duplicates
- `handleLLMCall`: Create parent agent on-demand if not found when processing LLM call steps
- `handleToolInvocation`: Create parent agent on-demand for peer invocations if not found

These changes handle cases where steps arrive out of order (e.g., tool invocation before USER_REQUEST) which can happen when loading historical task events.

### How was this change tested?
- [x] Manual testing: Loaded stim files with nested agent calls (SupportTicketAgent under Orchestrator) and verified correct visualization
- [ ] Unit tests: N/A - visualization logic is complex to unit test
- [x] Known limitations: Visual regression testing would be beneficial

### Is there anything the reviewers should focus on?
The on-demand agent creation in `handleLLMCall` and `handleToolInvocation` - ensure this doesn't cause issues with normal real-time event processing where steps typically arrive in order.