### PR TITLE
fix(DATAGO-123680): Use node name for showing switch-case details

### DIFF
--- a/client/webui/frontend/src/lib/components/workflowVisualization/WorkflowNodeDetailPanel.tsx
+++ b/client/webui/frontend/src/lib/components/workflowVisualization/WorkflowNodeDetailPanel.tsx
@@ -21,17 +21,13 @@ interface WorkflowNodeDetailPanelProps {
     knownNodeIds?: Set<string>;
     /** Callback to navigate/pan to a node when clicking the navigation icon */
     onNavigateToNode?: (nodeId: string) => void;
-    /** Current workflow name - used for building sub-workflow navigation URLs */
-    currentWorkflowName?: string;
-    /** Parent workflow path (for breadcrumb navigation) */
-    parentPath?: string[];
 }
 
 /**
  * WorkflowNodeDetailPanel - Shows details for the selected workflow node
  * Includes input/output schemas, code view toggle, and agent information
  */
-const WorkflowNodeDetailPanel: React.FC<WorkflowNodeDetailPanelProps> = ({ node, workflowConfig, agents, onHighlightNodes, knownNodeIds, onNavigateToNode, currentWorkflowName, parentPath = [] }) => {
+const WorkflowNodeDetailPanel: React.FC<WorkflowNodeDetailPanelProps> = ({ node, workflowConfig, agents, onHighlightNodes, knownNodeIds, onNavigateToNode }) => {
     const [showCodeView, setShowCodeView] = useState(false);
     const [isCopied, setIsCopied] = useState(false);
     const [activeTab, setActiveTab] = useState<"input" | "output">("input");
@@ -81,7 +77,7 @@ const WorkflowNodeDetailPanel: React.FC<WorkflowNodeDetailPanelProps> = ({ node,
         if (node?.data.workflowName) {
             window.open("/#" + buildWorkflowNavigationUrl(node.data.workflowName), "_blank");
         }
-    }, [node?.data.workflowName, currentWorkflowName, parentPath]);
+    }, [node?.data.workflowName]);
 
     // Helper to get display name for a node ID (used in switch cases)
     // Must be defined before early return to comply with React Hooks rules


### PR DESCRIPTION
### What is the purpose of this change?
The detail side panel of switch-case node uses the node id to refer to nodes; however, node id is not meaningful for users.
<img width="848" height="1082" alt="image" src="https://github.com/user-attachments/assets/61dfd191-1580-4aa7-aefc-ad40d5709579" />


### How was this change implemented?
Added a handler to UI to retrieve the node name and use it in the panel.
<img width="1339" height="877" alt="Screenshot 2026-02-04 at 4 33 30 PM" src="https://github.com/user-attachments/assets/5279719c-a39a-456f-bf0b-6979f1c6b2c9" />


### Key Design Decisions 

### How was this change tested?

- [x] Manual testing: Built the project and loaded a switch-case example and checked the panel.
- [ ] Unit tests
- [ ] Integration tests
- [ ] Known limitations

### Is there anything the reviewers should focus on/be aware of?
Nothing
