### PR TITLE
fix(DATAGO-124044): Use consistent experimental note in docs

### DIFF
--- a/docs/docs/documentation/components/workflows.md
+++ b/docs/docs/documentation/components/workflows.md
@@ -4,8 +4,8 @@ sidebar_position: 245
 ---
 
 # Workflows
-:::note
-This feature is currently experimental.
+:::warning Experimental Feature
+Workflows is currently an experimental feature. Expect this feature to change and improve in future releases.
 :::
 
 Workflows orchestrate multiple agents through YAML configuration. Unlike the [orchestrator](./orchestrator.md), which uses AI to dynamically decide how to accomplish tasks, workflows follow explicit paths you define. Each step, branch, and iteration is specified in configuration.


### PR DESCRIPTION
Following up on https://github.com/SolaceLabs/solace-agent-mesh/pull/970, I notice that "Speech integration" and "Prompt library" already have a consistent way of declaring an experimental feature. Adding a consistent change for workflows.

<img width="1882" height="608" alt="Screenshot 2026-02-04 at 5 13 44 PM" src="https://github.com/user-attachments/assets/318d7f81-b659-413c-9752-a93572447e8b" />
