### PR TITLE
fix(DATAGO-124286): update prompt icon consistency

### DIFF
--- a/client/webui/frontend/src/lib/components/prompts/PromptDetailSidePanel.tsx
+++ b/client/webui/frontend/src/lib/components/prompts/PromptDetailSidePanel.tsx
@@ -55,7 +55,7 @@ export const PromptDetailSidePanel: React.FC<PromptDetailSidePanelProps> = ({ pr
             <div className="border-b p-4">
                 <div className="mb-2 flex items-center justify-between">
                     <div className="flex min-w-0 flex-1 items-center gap-2">
-                        <NotepadText className="text-muted-foreground h-5 w-5 flex-shrink-0" />
+                        <NotepadText className="h-6 w-6 flex-shrink-0 text-[var(--color-brand-wMain)]" />
                         <Tooltip delayDuration={300}>
                             <TooltipTrigger asChild>
                                 <h2 className="cursor-default truncate text-lg font-semibold">{prompt.name}</h2>


### PR DESCRIPTION
### What is the purpose of this change?
Fixes inconsistent prompt icons across the application. The side panel icon had different styling (color and size) compared to the card icon.

### How was this change implemented?
- Updated the `PromptDetailSidePanel` icon styling to match the `PromptCard` icon:
  - Size: Changed from `h-5 w-5` to `h-6 w-6`
  - Color: Changed from `text-muted-foreground` to `text-[var(--color-brand-wMain)]`

### How was this change tested?
- [x] Manual testing: Verified the side panel icon matches the card icon styling
- [x] Build verification: `npm run build` passes without errors

### Is there anything the reviewers should focus on?
The icon changes are purely visual. Reviewers should verify the icons look consistent across the prompt cards and side panel.

AFTER:
<img width="1482" height="394" alt="image" src="https://github.com/user-attachments/assets/5b40dce9-4c1b-4e5d-a575-83cf3ad15297" />
