### PR TITLE
fix(DATAGO-124030): Fix prompt group update time

### DIFF
--- a/src/solace_agent_mesh/gateway/http_sse/routers/prompts.py
+++ b/src/solace_agent_mesh/gateway/http_sse/routers/prompts.py
@@ -946,7 +946,15 @@ async def update_prompt(
         # Update prompt text
         prompt.prompt_text = prompt_data.prompt_text
         prompt.updated_at = now_epoch_ms()
-        
+
+        # Update parent group timestamp
+        group = db.query(PromptGroupModel).filter(
+            PromptGroupModel.id == prompt.group_id
+        ).first()
+
+        if group:
+            group.updated_at = prompt.updated_at
+
         db.commit()
         db.refresh(prompt)
         


### PR DESCRIPTION
### What is the purpose of this change?

Updates the prompt group update time when a single prompt is updated without saving a new version.


### How was this change tested?

- [x] Manual testing: [describe scenarios]
- [ ] Unit tests: [new/modified tests]
- [ ] Integration tests: [if applicable]
- [ ] Known limitations: [what wasn't tested]

### Is there anything the reviewers should focus on/be aware of?

    Special attention areas, potential risks, or open questions
