### PR TITLE
fix(DATAGO-124683): filter out gateway cards for agent registry 

### DIFF
--- a/src/solace_agent_mesh/agent/protocol/event_handlers.py
+++ b/src/solace_agent_mesh/agent/protocol/event_handlers.py
@@ -47,6 +47,7 @@ from ...common.a2a import (
     get_discovery_subscription_topic,
     get_sam_events_subscription_topic,
     get_text_from_message,
+    is_gateway_card,
     topic_matches_subscription,
     translate_a2a_to_adk_content,
 )
@@ -1215,6 +1216,16 @@ def handle_agent_card_message(component, message: SolaceMessage):
         self_agent_name = component.get_config("agent_name")
 
         if agent_name == self_agent_name:
+            message.call_acknowledgements()
+            return
+
+        # Filter out gateway cards
+        if is_gateway_card(agent_card):
+            log.debug(
+                "%s Ignoring gateway card '%s'",
+                component.log_identifier,
+                agent_name,
+            )
             message.call_acknowledgements()
             return
 


### PR DESCRIPTION
### What is the purpose of this change?

Newly added dynamic gateways in enterprise publish cards similar to agents, these cards need to be filtered out for peer agent discovery.


### Key Design Decisions _(optional - delete if not applicable)_

A filtering approach was taken due to the change being required immediately but I am going to explore narrowing down the topic subscription in a subsequent issue. 

### How was this change tested?

- [x] Manual testing: [describe scenarios]
- [ ] Unit tests: [new/modified tests]
- [ ] Integration tests: [if applicable]
- [ ] Known limitations: [what wasn't tested]

### Is there anything the reviewers should focus on/be aware of?

    Special attention areas, potential risks, or open questions
