### PR TITLE
fix(DATAGO-124791): Fix '<' not supported between instances of 'int' and 'str' error in deep_research_tools.py

### DIFF
--- a/src/solace_agent_mesh/agent/tools/deep_research_tools.py
+++ b/src/solace_agent_mesh/agent/tools/deep_research_tools.py
@@ -1624,8 +1624,10 @@ async def deep_research(
     
     # Resolve max_iterations
     if max_iterations is None:
-        max_iterations = config.get("max_iterations")
-        if max_iterations is not None:
+        config_max_iterations = config.get("max_iterations")
+        if config_max_iterations is not None:
+            # Convert to int in case config value is a string
+            max_iterations = int(config_max_iterations)
             log.info("%s Using max_iterations from tool_config: %d", log_identifier, max_iterations)
         else:
             # Fallback to research_type translation
@@ -1636,15 +1638,17 @@ async def deep_research(
                 max_iterations = 3
                 log.info("%s Using max_iterations from research_type 'quick': %d", log_identifier, max_iterations)
     else:
+        max_iterations = int(max_iterations)
         log.info("%s Using explicit max_iterations parameter: %d", log_identifier, max_iterations)
     
     # Resolve max_runtime_seconds (with priority: max_runtime_minutes > max_runtime_seconds > tool_config > research_type)
     # First, check if max_runtime_minutes was provided (LLM-friendly parameter)
     if max_runtime_minutes is not None:
-        max_runtime_seconds = max_runtime_minutes * 60
+        max_runtime_seconds = int(max_runtime_minutes) * 60
         log.info("%s Using explicit max_runtime_minutes parameter: %d minutes (%d seconds)",
                 log_identifier, max_runtime_minutes, max_runtime_seconds)
     elif max_runtime_seconds is not None:
+        max_runtime_seconds = int(max_runtime_seconds)
         log.info("%s Using explicit max_runtime_seconds parameter: %d", log_identifier, max_runtime_seconds)
     else:
         # Check tool_config (support both seconds and minutes)
@@ -1652,10 +1656,10 @@ async def deep_research(
         config_duration_minutes = config.get("duration_minutes")
         
         if config_duration is not None:
-            max_runtime_seconds = config_duration
+            max_runtime_seconds = int(config_duration)
             log.info("%s Using max_runtime_seconds from tool_config: %d", log_identifier, max_runtime_seconds)
         elif config_duration_minutes is not None:
-            max_runtime_seconds = config_duration_minutes * 60
+            max_runtime_seconds = int(config_duration_minutes) * 60
             log.info("%s Using duration_minutes from tool_config: %d minutes (%d seconds)",
                     log_identifier, config_duration_minutes, max_runtime_seconds)
         else:


### PR DESCRIPTION
This pull request improves the robustness of parameter handling in the `deep_research` tool by ensuring that all iteration and runtime limit parameters are explicitly converted to integers. This prevents potential issues when configuration values are provided as strings.

Parameter handling improvements:

* All sources for `max_iterations`, including configuration and explicit parameters, are now cast to integers to avoid type errors. [[1]](diffhunk://#diff-9d65b8868ca3c3c80933c60c5ca04b98d75f0f22d76472fa90f0116b6b8fe1a6L1627-R1630) [[2]](diffhunk://#diff-9d65b8868ca3c3c80933c60c5ca04b98d75f0f22d76472fa90f0116b6b8fe1a6R1641-R1662)
* All runtime limit parameters (`max_runtime_minutes`, `max_runtime_seconds`, and related config values) are also explicitly converted to integers before use.