### PR TITLE
fix(DATAGO-124893): ensure chat input scrolls

### DIFF
--- a/client/webui/frontend/src/lib/components/chat/ChatInputArea.tsx
+++ b/client/webui/frontend/src/lib/components/chat/ChatInputArea.tsx
@@ -947,7 +947,7 @@ export const ChatInputArea: React.FC<{ agents: AgentCardInfo[]; scrollToBottom?:
                 mentionMap={mentionMap}
                 disambiguatedIds={disambiguatedIds}
                 placeholder={isRecording ? "Recording..." : mentionsEnabled ? "How can I help you today? (Type '/' to insert a prompt, '@' to mention someone)" : "How can I help you today? (Type '/' to insert a prompt)"}
-                className="field-sizing-content max-h-50 min-h-0 resize-none rounded-2xl border-none p-3 text-base/normal shadow-none focus-visible:outline-none"
+                className="max-h-50 resize-none overflow-y-auto rounded-2xl border-none p-3 text-base/normal shadow-none focus-visible:outline-none"
                 onPaste={handlePaste}
                 disabled={isRecording}
                 onKeyDown={event => {

--- a/client/webui/frontend/src/lib/components/ui/chat/MentionContentEditable.tsx
+++ b/client/webui/frontend/src/lib/components/ui/chat/MentionContentEditable.tsx
@@ -365,10 +365,6 @@ const MentionContentEditable = React.forwardRef<HTMLDivElement, MentionContentEd
                 data-testid="chat-input"
                 data-placeholder={placeholder}
                 suppressContentEditableWarning
-                style={{
-                    minHeight: "inherit",
-                    maxHeight: "inherit",
-                }}
             />
 
             {/* Show placeholder when empty */}

--- a/client/webui/frontend/src/stories/chat/ChatPage.stories.tsx
+++ b/client/webui/frontend/src/stories/chat/ChatPage.stories.tsx
@@ -83,6 +83,35 @@ export const WithLoadingMessage: Story = {
     },
 };
 
+export const WithLongInput: Story = {
+    parameters: {
+        chatContext: {
+            sessionId: "mock-session-id",
+            messages: mockMessages,
+            isResponding: false,
+            isCancelling: false,
+            selectedAgentName: "OrchestratorAgent",
+            isSidePanelCollapsed: true,
+            activeSidePanelTab: "files",
+        },
+        configContext: {
+            persistenceEnabled: false,
+        },
+    },
+    play: async ({ canvasElement }) => {
+        const canvas = within(canvasElement);
+        const chatInput = await canvas.findByTestId("chat-input");
+
+        const longContent = Array(25).fill("This is a line of text to test the input area scrolling behavior.").join("\n");
+
+        chatInput.textContent = longContent;
+        chatInput.dispatchEvent(new InputEvent("input", { bubbles: true }));
+
+        // Verify the input has overflow-y-auto and max-h-50 working
+        expect(chatInput.scrollHeight).toBeGreaterThan(chatInput.clientHeight);
+    },
+};
+
 export const WithSidePanelOpen: Story = {
     parameters: {
         chatContext: {


### PR DESCRIPTION
### What is the purpose of this change?

Long chat input was no longer scrolling causing the chat page to become unusuable.

### How was this change implemented?

Adding scroll.

### How was this change tested?

- [x] Manual testing: [describe scenarios]
- [x] Unit tests: [new/modified tests]
- [ ] Integration tests: [if applicable]
- [ ] Known limitations: [what wasn't tested]

### Is there anything the reviewers should focus on/be aware of?

Storybook test:
<img width="2554" height="1111" alt="image" src="https://github.com/user-attachments/assets/b372a978-8551-43bd-a4c9-62189a371477" />

BEFORE (with a prompt input)

https://github.com/user-attachments/assets/c4e476a3-9766-4722-8b0b-3896315feb8d


AFTER (with same input)

https://github.com/user-attachments/assets/b81cdab9-e7a8-497e-ae21-8c1113f5029f

With Mentions:
<img width="621" height="448" alt="Screenshot 2026-02-10 at 10 03 01 AM" src="https://github.com/user-attachments/assets/5f43b2c1-ebe0-453b-9d76-e94edff193e2" />
