### PR TITLE
fix(DATAGO-123240): filter out discovery messages and in-progress updates in visualization streams (PR 1/2)

### DIFF
--- a/src/solace_agent_mesh/gateway/http_sse/component.py
+++ b/src/solace_agent_mesh/gateway/http_sse/component.py
@@ -758,10 +758,10 @@ class WebUIBackendComponent(BaseGatewayComponent):
 
                 is_working_state = payload_dict.get("result", {}).get("status", {}).get('state') == "working"
                 parts = payload_dict.get("result", {}).get("status", {}).get("message", {}).get("parts", [])
-                is_in_progress_data = all(
+                is_in_progress_data = bool(parts) and all(
                     part.get("data", {}).get("status") == "in-progress" for part in parts
                 )
-                is_text_update = all(part.get("kind") == "text" for part in parts)
+                is_text_update = bool(parts) and all(part.get("kind") == "text" for part in parts)
 
                 # Ignoring discovery messages and in-progress updates for files and LLM stream to reduce noise in visualization streams
                 if ("/a2a/v1/discovery/" in topic) or (


### PR DESCRIPTION
### What is the purpose of this change?

This change improves visualization streams by filtering out unnecessary messages that create noise in the UI, specifically discovery messages and in-progress updates for files and LLM streams.

### How was this change implemented?

- Added filtering logic in `WebUIBackendComponent` to identify and exclude:
  - Discovery messages (already being filtered)
  - Working state messages that contain in-progress data updates
  - Text updates that are still in progress
- `fix: filter out discovery messages and in-progress updates in visualization streams`

### How was this change tested?

- [ ] Manual testing: Verified visualization streams display only relevant messages without intermediate updates
- [ ] Unit tests: N/A
- [ ] Integration tests: N/A
- [ ] Known limitations: May need additional filtering for other message types in the future

### Is there anything the reviewers should focus on/be aware of?

Ensure this filtering doesn't hide important progress information that users might expect to see in the UI.