### PR TITLE
fix(DATAGO-125073): ensure projects are fetched fresh on projects page mount

### DIFF
--- a/client/webui/frontend/src/lib/api/projects/hooks.ts
+++ b/client/webui/frontend/src/lib/api/projects/hooks.ts
@@ -22,8 +22,12 @@ export function useProjects() {
     return useQuery({
         queryKey: projectKeys.lists(),
         queryFn: projectService.getProjects,
+        refetchOnMount: "always",
     });
 }
+
+/** Ensures projects are fetched fresh on component mount */
+export const useFetchProjectsOnMount = () => useProjects();
 
 export function useProjectArtifacts(projectId: string | null) {
     return useQuery({

--- a/client/webui/frontend/src/lib/components/projects/ProjectsPage.tsx
+++ b/client/webui/frontend/src/lib/components/projects/ProjectsPage.tsx
@@ -13,9 +13,10 @@ import type { Project } from "@/lib/types/projects";
 import { Button, Header } from "@/lib/components";
 import { downloadBlob, getErrorMessage } from "@/lib/utils";
 import { useChatContext, useIsProjectSharingEnabled } from "@/lib/hooks";
-import { useExportProject, useImportProject } from "@/lib/api/projects/hooks";
+import { useExportProject, useImportProject, useFetchProjectsOnMount } from "@/lib/api/projects/hooks";
 
 export const ProjectsPage: React.FC = () => {
+    useFetchProjectsOnMount();
     const navigate = useNavigate();
     const loaderData = useLoaderData<{ projectId?: string }>();
 


### PR DESCRIPTION
### What is the purpose of this change?

   `/projects` api is only being called once on app render. This PR will refetch `/projects` on page mount. 
   
   This issue is especially prominent with project sharing.

### How was this change implemented?

    React Query `refetchOnMount` property. 

### How was this change tested?

- [x] Manual testing: [describe scenarios]
- [ ] Unit tests: [new/modified tests]
- [ ] Integration tests: [if applicable]
- [ ] Known limitations: [what wasn't tested]

### Is there anything the reviewers should focus on/be aware of?

    No
    
    

https://github.com/user-attachments/assets/bf795bbd-4f49-42f7-b407-a8bc6b690c7f


    
