### PR TITLE
fix(DATAGO-125359): update workflow paths in launch configurations

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -47,7 +47,7 @@
             "request": "launch",
             "module": "solace_ai_connector.main",
             "console": "integratedTerminal",
-            "args": "--envfile .env examples/agents/orchestrator_example.yaml examples/agents/test_agent_example.yaml examples/agents/jira_bug_triage_workflow.yaml examples/gateways/webui_gateway_example.yaml examples/agents/advanced_workflow_test.yaml",
+            "args": "--envfile .env examples/agents/orchestrator_example.yaml examples/agents/test_agent_example.yaml examples/workflows/jira_bug_triage_workflow.yaml examples/gateways/webui_gateway_example.yaml",
             "justMyCode": false,
             "env": {
                 "LOGGING_CONFIG_PATH": "${workspaceFolder}/preset/logging_config.yaml"
@@ -59,7 +59,7 @@
             "request": "launch",
             "module": "solace_ai_connector.main",
             "console": "integratedTerminal",
-            "args": "--envfile .env examples/agents/orchestrator_example.yaml examples/gateways/webui_gateway_example.yaml examples/agents/all_node_types_workflow.yaml examples/agents/complex_branching_workflow.yaml examples/agents/workflow_to_workflow_example.yaml examples/agents/simple_nested_test.yaml",
+            "args": "--envfile .env examples/agents/orchestrator_example.yaml examples/gateways/webui_gateway_example.yaml examples/workflows/all_node_types_workflow.yaml examples/workflows/complex_branching_workflow.yaml examples/workflows/workflow_to_workflow_example.yaml examples/workflows/simple_nested_test.yaml",
             "justMyCode": false,
             "env": {
                 "LOGGING_CONFIG_PATH": "${workspaceFolder}/preset/logging_config.yaml"
@@ -260,7 +260,7 @@
             "request": "launch",
             "module": "cli.main",
             "console": "integratedTerminal",
-            "args": "run examples/gateways/event_mesh_gateway_example.yaml examples/gateways/test_gateway_workflow.yaml examples/agents/all_node_types_workflow.yaml examples/agents/simple_nested_test.yaml examples/agents/orchestrator_example.yaml examples/gateways/webui_gateway_example.yaml",
+            "args": "run examples/gateways/event_mesh_gateway_example.yaml examples/gateways/test_gateway_workflow.yaml examples/workflows/all_node_types_workflow.yaml examples/workflows/simple_nested_test.yaml examples/agents/orchestrator_example.yaml examples/gateways/webui_gateway_example.yaml",
             "justMyCode": false,
             "env": {
                 "LOGGING_CONFIG_PATH": "${workspaceFolder}/preset/logging_config.yaml"


### PR DESCRIPTION
## Summary
- Updated launch configurations to reference workflow YAML files from the correct `examples/workflows/` directory instead of `examples/agents/`
- Removed reference to non-existent `advanced_workflow_test.yaml` file

## Changes
Fixed three launch configurations:
1. **SAM (workflow)** - Updated `jira_bug_triage_workflow.yaml` path and removed non-existent file
2. **SAM (new node types)** - Updated paths for 4 workflow files: `all_node_types_workflow.yaml`, `complex_branching_workflow.yaml`, `workflow_to_workflow_example.yaml`, `simple_nested_test.yaml`
3. **EM Gateway + Workflow** - Updated paths for `all_node_types_workflow.yaml` and `simple_nested_test.yaml`

## Test plan
- [ ] Verify the SAM (workflow) configuration launches successfully
- [ ] Verify the SAM (new node types) configuration launches successfully
- [ ] Verify the EM Gateway + Workflow configuration launches successfully (requires sam-event-mesh-gateway plugin)

🤖 Generated with [Claude Code](https://claude.com/claude-code)