### PR TITLE
Fix bare except clauses in web search and audio services

### DIFF
--- a/src/solace_agent_mesh/gateway/http_sse/services/audio_service.py
+++ b/src/solace_agent_mesh/gateway/http_sse/services/audio_service.py
@@ -789,12 +789,12 @@ class AudioService:
                 if wav_temp_path:
                     try:
                         os.remove(wav_temp_path)
-                    except:
+                    except Exception:
                         pass
                 if mp3_temp_path:
                     try:
                         os.remove(mp3_temp_path)
-                    except:
+                    except Exception:
                         pass
             
         except HTTPException:

--- a/src/solace_agent_mesh/tools/web_search/google_search.py
+++ b/src/solace_agent_mesh/tools/web_search/google_search.py
@@ -100,7 +100,7 @@ class GoogleSearchTool(WebSearchTool):
                     try:
                         error_data = response.json()
                         error_msg += f" - {error_data.get('error', {}).get('message', '')}"
-                    except:
+                    except Exception:
                         error_msg += f" - {response.text}"
                     
                     logger.error(error_msg)
@@ -208,7 +208,7 @@ class GoogleSearchTool(WebSearchTool):
             if domain.startswith("www."):
                 domain = domain[4:]
             return domain
-        except:
+        except Exception:
             return url
     
     def get_tool_definition(self) -> dict:


### PR DESCRIPTION
## Problem

This PR fixes 4 instances of bare `except:` clauses that could catch system-level exceptions like `KeyboardInterrupt` and `SystemExit`.

## What Changed

Changed `except:` to `except Exception:` in:
- `google_search.py`:103 - JSON error parsing when Google API request fails
- `google_search.py`:211 - Domain extraction from URL
- `audio_service.py`:792 - Temporary WAV file cleanup
- `audio_service.py`:797 - Temporary MP3 file cleanup

## Why This Matters

Bare except clauses catch **all** exceptions including system-level ones:
- `KeyboardInterrupt` (Ctrl+C) - makes the service harder to interrupt
- `SystemExit` - can prevent graceful shutdown
- `GeneratorExit` - can break generator cleanup

This is particularly problematic in:
- **Cleanup code** (audio_service.py) - Could prevent shutdown during file cleanup
- **Error handling** (google_search.py) - Could mask critical errors during API error parsing

## Impact

The fix maintains identical error handling behavior for regular exceptions while allowing system exceptions to propagate correctly. This ensures the agent mesh can be properly interrupted and shut down.

## Testing

No functional changes to error handling - only the exception type filter is more specific.

## References

- [PEP 8: Programming Recommendations](https://peps.python.org/pep-0008/#programming-recommendations)
- [Python Best Practices: Avoid Bare Except](https://docs.quantifiedcode.com/python-anti-patterns/correctness/catching_exceptions_the_wrong_way.html)