### PR TITLE
fix(DATAGO-124697): Ensure explicit separation of agent and gateway discovery paths

### DIFF
--- a/src/solace_agent_mesh/agent/sac/app.py
+++ b/src/solace_agent_mesh/agent/sac/app.py
@@ -2,6 +2,8 @@ import logging
 import sys
 import os
 
+from ...common.a2a.protocol import get_agent_discovery_topic
+
 sys.path.insert(
     0, os.path.join(os.path.dirname(os.path.dirname(os.path.dirname(__file__))))
 )
@@ -522,7 +524,7 @@ class SamAgentApp(SamAppBase):
 
         required_topics = [
             get_agent_request_topic(namespace, agent_name),
-            get_discovery_subscription_topic(namespace),
+            get_agent_discovery_topic(namespace),
             get_agent_response_subscription_topic(namespace, agent_name),
             get_agent_status_subscription_topic(namespace, agent_name),
             get_sam_events_subscription_topic(namespace, "session"),


### PR DESCRIPTION
### What is the purpose of this change?

Reverts the filtering hotfix and fixes the issue at the core. The issue being agents were subscribing to `discovery>` which was causing them to also get gateway cards. This issue fixes it by narrowing the subscription for agents and reverts the previous hotfix which fixed it by filtering the cards


### How was this change tested?

- [x] Manual testing: [describe scenarios]
- [ ] Unit tests: [new/modified tests]
- [ ] Integration tests: [if applicable]
- [ ] Known limitations: [what wasn't tested]

### Is there anything the reviewers should focus on/be aware of?

    Special attention areas, potential risks, or open questions
