### PR TITLE
fix(DATAGO-122505): Handle revoked MCP tool credentials by triggering re-auth

### DIFF
--- a/src/solace_agent_mesh/agent/adk/embed_resolving_mcp_toolset.py
+++ b/src/solace_agent_mesh/agent/adk/embed_resolving_mcp_toolset.py
@@ -386,9 +386,10 @@ class EmbedResolvingMCPTool(_BaseMcpToolClass):
 
         try:
             await tool_context.save_credential(auth_config)
-        except ValueError:
+        except Exception:
             log.debug(
-                "No credential service available to clear persisted credential.",
+                "Failed to clear persisted credential (best-effort).",
+                exc_info=True,
             )
 
     async def _execute_tool_with_audit_logs(self, tool_call, tool_context):


### PR DESCRIPTION
## Summary
- Detect 401/403 auth errors in MCP tool responses after execution (the ADK only checks credentials pre-execution, missing revoked tokens)
- Clear stale credentials from both in-memory cache and credential service
- Trigger re-authentication via `request_credential()` so the user is seamlessly redirected to authenticate again without manual retry

## Test plan
- [ ] Configure an MCP tool with OAuth authentication
- [ ] Authenticate and make a successful tool call
- [ ] Revoke the token on the OAuth provider side
- [ ] Make another tool call — should trigger re-auth flow instead of returning a raw 401 error
- [ ] Complete re-auth — tool call should succeed with the fresh token

🤖 Generated with [Claude Code](https://claude.com/claude-code)