### PR TITLE
docs(DATAGO-123059): Add documentation covering the MSSQL and Oracle connectors

### DIFF
--- a/docs/docs/documentation/enterprise/connectors/connectors.md
+++ b/docs/docs/documentation/enterprise/connectors/connectors.md
@@ -25,7 +25,7 @@ OpenAPI connectors allow agents to interact with REST APIs that use OpenAPI spec
 
 ### SQL Connectors
 
-SQL connectors allow agents to query relational databases using natural language. The connectors convert user questions into SQL queries and execute them against MySQL, PostgreSQL, or MariaDB databases. For detailed information about creating and configuring SQL connectors, see [SQL Connectors](sql-connectors.md).
+SQL connectors allow agents to query relational databases using natural language. The connectors convert user questions into SQL queries and execute them against MySQL, PostgreSQL, MariaDB, Microsoft SQL Server, or Oracle databases. For detailed information about creating and configuring SQL connectors, see [SQL Connectors](sql-connectors.md).
 
 ## Creating Connectors
 

--- a/docs/docs/documentation/enterprise/connectors/sql-connectors.md
+++ b/docs/docs/documentation/enterprise/connectors/sql-connectors.md
@@ -3,6 +3,10 @@ title: SQL Connectors
 sidebar_position: 4
 ---
 
+:::info Coming Soon
+Microsoft SQL Server and Oracle connector support will be available in an upcoming release.
+:::
+
 SQL connectors allow agents to query and analyze database information using natural language.
 
 ## Overview
@@ -13,13 +17,17 @@ SQL connectors establish persistent connection pools to your database servers. A
 
 The connector supports common relational database systems and handles the specifics of each database type automatically, including appropriate SQL dialect, connection protocols, and driver configurations.
 
+The SQL connector functionality is powered by the [sam-sql-database-tool](https://github.com/SolaceLabs/solace-agent-mesh-core-plugins/tree/main/sam-sql-database-tool) plugin, which contains additional technical details about the underlying implementation.
+
 ## Supported Databases
 
-Agent Mesh Enterprise supports three database types for SQL connectors:
+Agent Mesh Enterprise supports the following database types for SQL connectors:
 
 - MySQL
 - PostgreSQL
 - MariaDB
+- Microsoft SQL Server (MSSQL)
+- Oracle
 
 Each database type uses the same configuration interface but requires connection parameters appropriate for that database system.
 
@@ -37,7 +45,13 @@ You need a database username and password with appropriate permissions for the o
 
 ### Network Connectivity
 
-Verify that network firewalls and security groups allow traffic from Agent Mesh Enterprise to your database server on the appropriate port. Default ports are 3306 for MySQL and MariaDB, and 5432 for PostgreSQL.
+Verify that network firewalls and security groups allow traffic from Agent Mesh Enterprise to your database server on the appropriate port. Default ports are:
+
+- MySQL: `3306`
+- MariaDB: `3306`
+- PostgreSQL: `5432`
+- MSSQL: `1433`
+- Oracle: `1521`
 
 ### Database Name
 
@@ -59,7 +73,7 @@ The connector name must be unique across all connectors in your deployment, rega
 
 **Database Type**
 
-Select the database system you are connecting to from the dropdown menu. The available options are MySQL, PostgreSQL, and MariaDB. This selection determines the appropriate driver and connection string format that Agent Mesh Enterprise uses.
+Select the database system you are connecting to from the dropdown menu. The available options are MySQL, PostgreSQL, MariaDB, Microsoft SQL Server, and Oracle. This selection determines the appropriate driver and connection string format that Agent Mesh Enterprise uses.
 
 If you select the wrong database type, connection tests will fail with errors about incompatible protocols or unsupported features.
 
@@ -75,6 +89,8 @@ The port number where your database accepts connections. Default ports are:
 - MySQL: `3306`
 - PostgreSQL: `5432`
 - MariaDB: `3306`
+- MSSQL: `1433`
+- Oracle: `1521`
 
 If your database administrator configured a custom port for security reasons or to avoid conflicts, enter that value instead of the default.
 
@@ -95,6 +111,16 @@ You should create a dedicated database user for agent access rather than using a
 The password for the database username. Agent Mesh Enterprise stores this credential securely in its configuration and uses it to establish database connections.
 
 The password is encrypted at rest and transmitted securely to the database server. However, you should still follow password security best practices, such as using strong passwords and rotating them periodically.
+
+**Service Name** *(Oracle only)*
+
+The Oracle service name that identifies the target database on the Oracle listener. The service name is not the same as the Database Name field used by other connector types; Oracle identifies databases by service name rather than a simple database name.
+
+**ODBC Driver** *(MSSQL only)*
+
+The ODBC driver used to connect to SQL Server. Agent Mesh Enterprise includes the FreeTDS driver out of the box, which works for standard SQL operations and requires no additional installation.
+
+If your use case requires a different driver, you must install that driver on the host system first. See [Using an Alternative MSSQL ODBC Driver](#using-an-alternative-mssql-odbc-driver) in the Troubleshooting section for instructions on how to extend the base image. If the driver is installed correctly, it appears in the ODBC Driver dropdown for selection.
 
 ### Connection Pooling
 
@@ -128,6 +154,29 @@ GRANT CONNECT ON DATABASE your_database TO agent_readonly;
 GRANT USAGE ON SCHEMA public TO agent_readonly;
 GRANT SELECT ON ALL TABLES IN SCHEMA public TO agent_readonly;
 ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT SELECT ON TABLES TO agent_readonly;
+```
+
+**Microsoft SQL Server:**
+
+```sql
+CREATE LOGIN agent_readonly WITH PASSWORD = 'secure_password';
+USE your_database;
+CREATE USER agent_readonly FOR LOGIN agent_readonly;
+GRANT SELECT ON SCHEMA::dbo TO agent_readonly;
+```
+
+**Oracle:**
+
+```sql
+CREATE USER agent_readonly IDENTIFIED BY secure_password;
+GRANT CREATE SESSION TO agent_readonly;
+GRANT SELECT ANY TABLE TO agent_readonly;
+```
+
+For tighter access control, grant `SELECT` on individual tables rather than `SELECT ANY TABLE`:
+
+```sql
+GRANT SELECT ON your_schema.your_table TO agent_readonly;
 ```
 
 ## After Creating the Connector
@@ -179,3 +228,51 @@ If agents experience slow query responses:
 1. Ensure frequently queried columns have appropriate indexes
 2. Optimize database views if you use them for access control
 3. Review query patterns in database logs to identify inefficient queries that agents generate
+
+### Using an Alternative MSSQL ODBC Driver
+
+Agent Mesh Enterprise includes the FreeTDS ODBC driver in the base image. FreeTDS handles standard SQL Server connectivity without any additional setup.
+
+If you require a different ODBC driver, extend the base image to install it before deploying. The following example Dockerfile installs Microsoft ODBC Driver 18 for SQL Server on top of the SAM Enterprise base image:
+
+```dockerfile
+# Extend the Solace Agent Mesh Enterprise base image with Microsoft ODBC Driver 18
+# This Dockerfile demonstrates how to add MS SQL Server connectivity to SAM Enterprise
+FROM solace-agent-mesh-enterprise:<tag>
+
+# Switch to root user to install system packages
+# The base image runs as non-root user 'solaceai' by default
+USER root
+
+# Install Microsoft ODBC Driver 18 for SQL Server
+# Steps:
+# 1. Ensure apt directories exist with proper permissions (fixes potential permission issues)
+# 2. Update package lists
+# 3. Install curl and gnupg (without recommended extras) for downloading and verifying Microsoft packages
+# 4. Download and install Microsoft's GPG signing key to verify package authenticity
+# 5. Add Microsoft's Debian 12 (bookworm) package repository
+#    Note: Using Debian 12 repos because the base image uses Debian 13 (trixie),
+#    which is not yet officially supported by Microsoft. Debian 12 packages are
+#    forward-compatible with Debian 13.
+# 6. Refresh package lists to include Microsoft repository
+# 7. Install msodbcsql18 (without recommended extras) with automatic EULA acceptance
+# 8. Purge curl and gnupg along with any dependencies pulled in solely for them
+# 9. Clean up package cache and temp files to minimize image size
+RUN mkdir -p /var/lib/apt/lists/partial \
+    && chmod -R 755 /var/lib/apt/lists \
+    && apt-get update \
+    && apt-get install -y --no-install-recommends curl gnupg \
+    && curl https://packages.microsoft.com/keys/microsoft.asc | gpg --dearmor > /usr/share/keyrings/microsoft-prod.gpg \
+    && curl https://packages.microsoft.com/config/debian/12/prod.list > /etc/apt/sources.list.d/mssql-release.list \
+    && apt-get update \
+    && ACCEPT_EULA=Y apt-get install -y --no-install-recommends msodbcsql18 \
+    && apt-get purge -y --auto-remove curl gnupg \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+
+# Verify the ODBC driver was installed correctly
+# This will fail the build if the driver is not properly registered
+RUN odbcinst -q -d -n "ODBC Driver 18 for SQL Server"
+```
+
+Replace `<tag>` with the version of Agent Mesh Enterprise you are running. After building and deploying this image, `ODBC Driver 18 for SQL Server` appears in the ODBC Driver dropdown when you create an MSSQL connector.


### PR DESCRIPTION
### What is the purpose of this change?

Extends the SQL connectors documentation to cover two new upcoming database types — Microsoft SQL Server (MSSQL) and Oracle — so users can understand what to expect and how to prepare.

### How was this change implemented?

Updated two files in the Enterprise connectors docs:

- **`connectors.md`**: Updated the SQL Connectors blurb to mention MSSQL and Oracle.
- **`sql-connectors.md`**:
  - Added a "Coming Soon" info banner at the top of the page.
  - Extended the Supported Databases list to include MSSQL and Oracle.
  - Added MSSQL (1433) and Oracle (1521) default ports to the Prerequisites and Configuration Fields sections.
  - Updated the Database Type dropdown description to list all five options.
  - Added two new configuration fields: **Service Name** (Oracle only) and **ODBC Driver** (MSSQL only).
  - Added read-only permission grant examples for MSSQL and Oracle.
  - Added a new Troubleshooting section explaining that FreeTDS ships out of the box, with a full Dockerfile example for extending the base image with MS ODBC Driver 18.
  - Added a link to the underlying `sam-sql-database-tool` plugin in the Overview.
