### PR TITLE
chore(DATAGO-125742): Reduce ProjectService initialization logging verbosity

### DIFF
--- a/src/solace_agent_mesh/gateway/http_sse/services/project_service.py
+++ b/src/solace_agent_mesh/gateway/http_sse/services/project_service.py
@@ -94,7 +94,7 @@ class ProjectService:
         )
         self.max_project_size_bytes = int(max_project_size_config) if isinstance(max_project_size_config, (int, float)) else DEFAULT_MAX_PROJECT_SIZE_BYTES
 
-        self.logger.info(
+        self.logger.debug(
             "[ProjectService] Initialized with "
             "max_per_file_upload_size_bytes=%d (%.2f MB), "
             "max_batch_upload_size_bytes=%d (%.2f MB), "


### PR DESCRIPTION
### What is the purpose of this change?

Change ProjectService initialization logging from INFO to DEBUG level to reduce log spam during normal operation (service is instantiated per-request as part of FastAPI dependency injection pattern).

### How was this change implemented?

simple log level change

### Key Design Decisions _(optional - delete if not applicable)_

    Why did you choose this approach over alternatives?

### How was this change tested?

- [ ] Manual testing: [describe scenarios]
- [ ] Unit tests: [new/modified tests]
- [ ] Integration tests: [if applicable]
- [ ] Known limitations: [what wasn't tested]

### Is there anything the reviewers should focus on/be aware of?

    Special attention areas, potential risks, or open questions
