### PR TITLE
chore(DATAGO-125771): Add Docs link to README navigation

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@
   <a href="#-key-features">Key Features</a> •
   <a href="#-quick-start-5-minutes">Quickstart</a> •
   <a href="#️-next-steps">Next Steps</a> •
-  <a href="https://solacelabs.github.io/solace-agent-mesh/docs/documentation/getting-started/introduction">Docs</a>
+  <a href="https://solacelabs.github.io/solace-agent-mesh/">Docs</a>
 </p>
 
 


### PR DESCRIPTION
## Summary
- Adds a "Docs" link to the README top navigation menu, pointing to the documentation site getting-started page
- Makes the full documentation easier to discover directly from the README

Closes #1047

## Test plan
- [ ] Verify the rendered README on GitHub shows four nav links: Key Features • Quickstart • Next Steps • Docs
- [ ] Verify the Docs link navigates to https://solacelabs.github.io/solace-agent-mesh/docs/documentation/getting-started/introduction