### PR TITLE
fix(DATAGO-123916): fixing no content parse for project file deletion

### DIFF
--- a/client/webui/frontend/src/lib/api/projects/service.ts
+++ b/client/webui/frontend/src/lib/api/projects/service.ts
@@ -46,8 +46,7 @@ export const removeFileFromProject = async (projectId: string, filename: string)
         throw new Error(await getErrorFromResponse(response));
     }
 
-    const result = await response.json();
-    return { ...result, sseLocation: response.headers.get("sse-location") };
+    return { sseLocation: response.headers.get("sse-location") };
 };
 
 export const updateFileMetadata = async (projectId: string, filename: string, description: string) => {


### PR DESCRIPTION
### What is the purpose of this change?

Removing effort to parse a project file deletion response - that was causing refresh of the artifact list to fail.

### How was this change implemented?

This pull request makes a small change to the `removeFileFromProject` function in `service.ts`. The change simplifies the return value by removing unnecessary data from the response and now only returns the `sseLocation` header.

### How was this change tested?

- [x] Manual testing: [describe scenarios]
- [ ] Unit tests: [new/modified tests]
- [ ] Integration tests: [if applicable]
- [ ] Known limitations: [what wasn't tested]

### Is there anything the reviewers should focus on/be aware of?

None
