### PR TITLE
fix(DATAGO-130431): WebUI: Switching agents mid-session resets entire conversation context

### DIFF
--- a/client/webui/frontend/src/lib/api/sessions/hooks.ts
+++ b/client/webui/frontend/src/lib/api/sessions/hooks.ts
@@ -1,5 +1,5 @@
 import { useEffect } from "react";
-import { useQuery, useQueryClient } from "@tanstack/react-query";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 
 import { sessionKeys } from "./keys";
 import * as sessionService from "./service";
@@ -33,5 +33,11 @@ export function useRecentSessions(maxItems: number = MAX_RECENT_CHATS) {
         queryKey: sessionKeys.recent(maxItems),
         queryFn: () => sessionService.getRecentSessions(maxItems),
         refetchOnMount: "always",
+    });
+}
+
+export function useTransferContext() {
+    return useMutation({
+        mutationFn: ({ sessionId, request }: { sessionId: string; request: sessionService.TransferContextRequest }) => sessionService.transferContext(sessionId, request),
     });
 }

--- a/client/webui/frontend/src/lib/api/sessions/service.ts
+++ b/client/webui/frontend/src/lib/api/sessions/service.ts
@@ -12,3 +12,24 @@ export const getRecentSessions = async (maxItems: number): Promise<Session[]> =>
     const result = await api.webui.get<PaginatedSessionsResponse>(`/api/v1/sessions?pageNumber=1&pageSize=${maxItems}`);
     return result.data || [];
 };
+
+export interface TransferContextRequest {
+    sourceAgentName: string;
+    targetAgentName: string;
+}
+
+export interface TransferContextResponse {
+    contextTransferred: boolean;
+    message: string;
+}
+
+export const transferContext = async (sessionId: string, request: TransferContextRequest): Promise<TransferContextResponse> => {
+    const raw = await api.webui.post<{ context_transferred: boolean; message: string }>(`/api/v1/sessions/${sessionId}/transfer-context`, {
+        source_agent_name: request.sourceAgentName,
+        target_agent_name: request.targetAgentName,
+    });
+    return {
+        contextTransferred: raw.context_transferred,
+        message: raw.message,
+    };
+};

--- a/client/webui/frontend/src/lib/components/chat/ChatMessage.tsx
+++ b/client/webui/frontend/src/lib/components/chat/ChatMessage.tsx
@@ -641,6 +641,19 @@ const getChatBubble = (
         return null;
     }
 
+    // Agent switch indicator: render as a centered divider-style message
+    if (message.isAgentSwitchIndicator) {
+        const textPart = message.parts?.find(p => p.kind === "text") as TextPart | undefined;
+        const text = textPart?.text || "Agent switched";
+        return (
+            <div className="flex items-center justify-center gap-3 py-3">
+                <div className="bg-border h-px flex-1" />
+                <span className="text-muted-foreground text-xs font-medium whitespace-nowrap">{text}</span>
+                <div className="bg-border h-px flex-1" />
+            </div>
+        );
+    }
+
     if (message.authenticationLink) {
         return <AuthenticationMessage message={message} />;
     }

--- a/client/webui/frontend/src/lib/hooks/useAgentSelection.ts
+++ b/client/webui/frontend/src/lib/hooks/useAgentSelection.ts
@@ -5,6 +5,7 @@ import { useTransferContext } from "@/lib/api/sessions/hooks";
 // Generation counter to implement "latest wins" for rapid agent switching.
 // If user switches A->B->C rapidly, only the last transfer's indicator message
 // is shown — earlier transfers are silently discarded.
+// NOTE: Module-level counter assumes a single useAgentSelection instance per app.
 let transferGeneration = 0;
 
 export const useAgentSelection = () => {
@@ -17,6 +18,9 @@ export const useAgentSelection = () => {
 
     const messagesRef = useRef(messages);
     messagesRef.current = messages;
+
+    const selectedAgentNameRef = useRef(selectedAgentName);
+    selectedAgentNameRef.current = selectedAgentName;
 
     const handleAgentSelection = useCallback(
         async (agentName: string, startNewChat = false) => {
@@ -49,7 +53,8 @@ export const useAgentSelection = () => {
             }
 
             // Mid-session agent switch: transfer context if there's an active session
-            const previousAgentName = selectedAgentName;
+            // Use ref for consistency with other refs (avoids stale closure)
+            const previousAgentName = selectedAgentNameRef.current;
 
             // Guard against re-selecting the same agent
             if (agentName === previousAgentName) return;
@@ -58,12 +63,12 @@ export const useAgentSelection = () => {
             // Use ref to get fresh messages.length (avoids stale closure)
             const hasConversation = !!(currentSessionId && previousAgentName && previousAgentName !== agentName && messagesRef.current.length > 1);
 
+            // Increment generation counter BEFORE state update for clearer ordering
+            const thisGeneration = ++transferGeneration;
+
             // Update selection immediately — this prevents race conditions where
             // a message is sent to the old agent while transfer is in progress
             setSelectedAgentName(agentName);
-
-            // Increment generation counter for "latest wins" pattern
-            const thisGeneration = ++transferGeneration;
 
             let contextTransferred = false;
 
@@ -114,7 +119,7 @@ export const useAgentSelection = () => {
                 },
             ]);
         },
-        [agents, selectedAgentName, setMessages, setSelectedAgentName, handleNewSession, transferContext]
+        [agents, setMessages, setSelectedAgentName, handleNewSession, transferContext]
     );
 
     return { handleAgentSelection };

--- a/client/webui/frontend/src/lib/hooks/useAgentSelection.ts
+++ b/client/webui/frontend/src/lib/hooks/useAgentSelection.ts
@@ -2,12 +2,21 @@ import { useCallback, useRef } from "react";
 import { useChatContext } from "./useChatContext";
 import { useTransferContext } from "@/lib/api/sessions/hooks";
 
+// Generation counter to implement "latest wins" for rapid agent switching.
+// If user switches A->B->C rapidly, only the last transfer's indicator message
+// is shown — earlier transfers are silently discarded.
+let transferGeneration = 0;
+
 export const useAgentSelection = () => {
     const { agents, sessionId, messages, selectedAgentName, setMessages, setSelectedAgentName, handleNewSession } = useChatContext();
     const { mutateAsync: transferContext } = useTransferContext();
-    const hasExistingConversation = messages.length > 1;
+
+    // Use refs to avoid stale closures in the async callback
     const sessionIdRef = useRef(sessionId);
     sessionIdRef.current = sessionId;
+
+    const messagesRef = useRef(messages);
+    messagesRef.current = messages;
 
     const handleAgentSelection = useCallback(
         async (agentName: string, startNewChat = false) => {
@@ -29,8 +38,9 @@ export const useAgentSelection = () => {
                         isComplete: true,
                         role: "agent",
                         metadata: {
-                            // sessionIdRef may be stale after handleNewSession resets state
-                            sessionId: sessionIdRef.current || "",
+                            // handleNewSession resets sessionId asynchronously — use empty string
+                            // since the new session ID hasn't been assigned yet
+                            sessionId: "",
                             lastProcessedEventSequence: 0,
                         },
                     },
@@ -45,27 +55,49 @@ export const useAgentSelection = () => {
             if (agentName === previousAgentName) return;
 
             const currentSessionId = sessionIdRef.current;
-            const hasConversation = currentSessionId && previousAgentName && previousAgentName !== agentName && hasExistingConversation;
+            // Use ref to get fresh messages.length (avoids stale closure)
+            const hasConversation = !!(currentSessionId && previousAgentName && previousAgentName !== agentName && messagesRef.current.length > 1);
 
-            // Update selection immediately to prevent race condition
+            // Update selection immediately — this prevents race conditions where
+            // a message is sent to the old agent while transfer is in progress
             setSelectedAgentName(agentName);
+
+            // Increment generation counter for "latest wins" pattern
+            const thisGeneration = ++transferGeneration;
+
+            let contextTransferred = false;
 
             if (hasConversation) {
                 try {
-                    await transferContext({
+                    const result = await transferContext({
                         sessionId: currentSessionId,
                         request: {
                             sourceAgentName: previousAgentName,
                             targetAgentName: agentName,
                         },
                     });
+                    contextTransferred = result.contextTransferred;
                 } catch {
-                    // Context transfer is best-effort; new agent starts fresh on failure
+                    // Context transfer failed — agent starts fresh
+                    contextTransferred = false;
                 }
             }
 
-            // Append an agent switch indicator message (preserving existing messages)
-            const switchText = hasConversation ? `Switched to ${selectedAgent.displayName}.` : `Hi! I'm the ${selectedAgent.displayName}. How can I help?`;
+            // "Latest wins": if another switch happened while we were awaiting,
+            // skip appending the indicator message (the newer switch will handle it)
+            if (thisGeneration !== transferGeneration) {
+                return;
+            }
+
+            // Drive messaging based on transfer result
+            let switchText: string;
+            if (!hasConversation) {
+                switchText = `Hi! I'm the ${selectedAgent.displayName}. How can I help?`;
+            } else if (contextTransferred) {
+                switchText = `Switched to ${selectedAgent.displayName}. I have context from your previous conversation.`;
+            } else {
+                switchText = `Switched to ${selectedAgent.displayName}. Starting fresh.`;
+            }
 
             setMessages(prev => [
                 ...prev,
@@ -74,7 +106,7 @@ export const useAgentSelection = () => {
                     isUser: false,
                     isComplete: true,
                     role: "agent",
-                    isAgentSwitchIndicator: hasConversation ? true : undefined,
+                    isAgentSwitchIndicator: hasConversation || undefined,
                     metadata: {
                         sessionId: currentSessionId || "",
                         lastProcessedEventSequence: 0,
@@ -82,7 +114,7 @@ export const useAgentSelection = () => {
                 },
             ]);
         },
-        [agents, hasExistingConversation, selectedAgentName, setMessages, setSelectedAgentName, handleNewSession, transferContext]
+        [agents, selectedAgentName, setMessages, setSelectedAgentName, handleNewSession, transferContext]
     );
 
     return { handleAgentSelection };

--- a/client/webui/frontend/src/lib/hooks/useAgentSelection.ts
+++ b/client/webui/frontend/src/lib/hooks/useAgentSelection.ts
@@ -1,19 +1,20 @@
-import { useCallback } from "react";
+import { useCallback, useRef } from "react";
 import { useChatContext } from "./useChatContext";
-import { api } from "@/lib/api/client";
+import { useTransferContext } from "@/lib/api/sessions/hooks";
 
 export const useAgentSelection = () => {
-    const { agents, sessionId, messages, selectedAgentName, setMessages, setSelectedAgentName, handleNewSession, agentNameDisplayNameMap } = useChatContext();
+    const { agents, sessionId, messages, selectedAgentName, setMessages, setSelectedAgentName, handleNewSession } = useChatContext();
+    const { mutateAsync: transferContext } = useTransferContext();
+    const hasExistingConversation = messages.length > 1;
+    const sessionIdRef = useRef(sessionId);
+    sessionIdRef.current = sessionId;
 
     const handleAgentSelection = useCallback(
         async (agentName: string, startNewChat = false) => {
             if (!agentName) return;
 
             const selectedAgent = agents.find(agent => agent.name === agentName);
-            if (!selectedAgent) {
-                console.warn(`Selected agent not found: ${agentName}`);
-                return;
-            }
+            if (!selectedAgent) return;
 
             if (startNewChat) {
                 handleNewSession();
@@ -28,7 +29,8 @@ export const useAgentSelection = () => {
                         isComplete: true,
                         role: "agent",
                         metadata: {
-                            sessionId: sessionId || "",
+                            // sessionIdRef may be stale after handleNewSession resets state
+                            sessionId: sessionIdRef.current || "",
                             lastProcessedEventSequence: 0,
                         },
                     },
@@ -38,26 +40,29 @@ export const useAgentSelection = () => {
 
             // Mid-session agent switch: transfer context if there's an active session
             const previousAgentName = selectedAgentName;
-            const hasConversation = sessionId && previousAgentName && previousAgentName !== agentName && messages.length > 1;
+
+            // Guard against re-selecting the same agent
+            if (agentName === previousAgentName) return;
+
+            const currentSessionId = sessionIdRef.current;
+            const hasConversation = currentSessionId && previousAgentName && previousAgentName !== agentName && hasExistingConversation;
+
+            // Update selection immediately to prevent race condition
+            setSelectedAgentName(agentName);
 
             if (hasConversation) {
-                // Get display name of the previous agent for context marker
-                const previousDisplayName = agentNameDisplayNameMap[previousAgentName] || previousAgentName;
-
                 try {
-                    console.log(`[useAgentSelection] Transferring context from ${previousAgentName} to ${agentName} for session ${sessionId}`);
-                    await api.webui.post(`/api/v1/sessions/${sessionId}/transfer-context`, {
-                        source_agent_name: previousAgentName,
-                        target_agent_name: agentName,
-                        source_agent_display_name: previousDisplayName,
+                    await transferContext({
+                        sessionId: currentSessionId,
+                        request: {
+                            sourceAgentName: previousAgentName,
+                            targetAgentName: agentName,
+                        },
                     });
-                    console.log(`[useAgentSelection] Context transfer successful`);
-                } catch (error) {
-                    console.warn("[useAgentSelection] Context transfer failed, new agent starts fresh:", error);
+                } catch {
+                    // Context transfer is best-effort; new agent starts fresh on failure
                 }
             }
-
-            setSelectedAgentName(agentName);
 
             // Append an agent switch indicator message (preserving existing messages)
             const switchText = hasConversation ? `Switched to ${selectedAgent.displayName}.` : `Hi! I'm the ${selectedAgent.displayName}. How can I help?`;
@@ -71,13 +76,13 @@ export const useAgentSelection = () => {
                     role: "agent",
                     isAgentSwitchIndicator: hasConversation ? true : undefined,
                     metadata: {
-                        sessionId: sessionId || "",
+                        sessionId: currentSessionId || "",
                         lastProcessedEventSequence: 0,
                     },
                 },
             ]);
         },
-        [agents, sessionId, messages.length, selectedAgentName, setMessages, setSelectedAgentName, handleNewSession, agentNameDisplayNameMap]
+        [agents, hasExistingConversation, selectedAgentName, setMessages, setSelectedAgentName, handleNewSession, transferContext]
     );
 
     return { handleAgentSelection };

--- a/client/webui/frontend/src/lib/hooks/useAgentSelection.ts
+++ b/client/webui/frontend/src/lib/hooks/useAgentSelection.ts
@@ -1,40 +1,83 @@
 import { useCallback } from "react";
 import { useChatContext } from "./useChatContext";
+import { api } from "@/lib/api/client";
 
 export const useAgentSelection = () => {
-    const { agents, sessionId, setMessages, setSelectedAgentName, handleNewSession } = useChatContext();
+    const { agents, sessionId, messages, selectedAgentName, setMessages, setSelectedAgentName, handleNewSession, agentNameDisplayNameMap } = useChatContext();
 
     const handleAgentSelection = useCallback(
-        (agentName: string, startNewChat = false) => {
-            if (agentName) {
-                const selectedAgent = agents.find(agent => agent.name === agentName);
-                if (selectedAgent) {
-                    if (startNewChat) {
-                        handleNewSession();
-                    }
+        async (agentName: string, startNewChat = false) => {
+            if (!agentName) return;
 
-                    setSelectedAgentName(agentName);
+            const selectedAgent = agents.find(agent => agent.name === agentName);
+            if (!selectedAgent) {
+                console.warn(`Selected agent not found: ${agentName}`);
+                return;
+            }
 
-                    const displayedText = `Hi! I'm the ${selectedAgent.displayName}. How can I help?`;
-                    setMessages(prev => [
-                        ...prev,
-                        {
-                            parts: [{ kind: "text", text: displayedText }],
-                            isUser: false,
-                            isComplete: true,
-                            role: "agent",
-                            metadata: {
-                                sessionId: sessionId || "",
-                                lastProcessedEventSequence: 0,
-                            },
+            if (startNewChat) {
+                handleNewSession();
+                setSelectedAgentName(agentName);
+
+                const displayedText = `Hi! I'm the ${selectedAgent.displayName}. How can I help?`;
+                setMessages(prev => [
+                    ...prev,
+                    {
+                        parts: [{ kind: "text", text: displayedText }],
+                        isUser: false,
+                        isComplete: true,
+                        role: "agent",
+                        metadata: {
+                            sessionId: sessionId || "",
+                            lastProcessedEventSequence: 0,
                         },
-                    ]);
-                } else {
-                    console.warn(`Selected agent not found: ${agentName}`);
+                    },
+                ]);
+                return;
+            }
+
+            // Mid-session agent switch: transfer context if there's an active session
+            const previousAgentName = selectedAgentName;
+            const hasConversation = sessionId && previousAgentName && previousAgentName !== agentName && messages.length > 1;
+
+            if (hasConversation) {
+                // Get display name of the previous agent for context marker
+                const previousDisplayName = agentNameDisplayNameMap[previousAgentName] || previousAgentName;
+
+                try {
+                    console.log(`[useAgentSelection] Transferring context from ${previousAgentName} to ${agentName} for session ${sessionId}`);
+                    await api.webui.post(`/api/v1/sessions/${sessionId}/transfer-context`, {
+                        source_agent_name: previousAgentName,
+                        target_agent_name: agentName,
+                        source_agent_display_name: previousDisplayName,
+                    });
+                    console.log(`[useAgentSelection] Context transfer successful`);
+                } catch (error) {
+                    console.warn("[useAgentSelection] Context transfer failed, new agent starts fresh:", error);
                 }
             }
+
+            setSelectedAgentName(agentName);
+
+            // Append an agent switch indicator message (preserving existing messages)
+            const switchText = hasConversation ? `Switched to ${selectedAgent.displayName}.` : `Hi! I'm the ${selectedAgent.displayName}. How can I help?`;
+
+            setMessages(prev => [
+                ...prev,
+                {
+                    parts: [{ kind: "text", text: switchText }],
+                    isUser: false,
+                    isComplete: true,
+                    role: "agent",
+                    isAgentSwitchIndicator: hasConversation ? true : undefined,
+                    metadata: {
+                        sessionId: sessionId || "",
+                        lastProcessedEventSequence: 0,
+                    },
+                },
+            ]);
         },
-        [agents, sessionId, setMessages, setSelectedAgentName, handleNewSession]
+        [agents, sessionId, messages.length, selectedAgentName, setMessages, setSelectedAgentName, handleNewSession, agentNameDisplayNameMap]
     );
 
     return { handleAgentSelection };

--- a/client/webui/frontend/src/lib/types/fe.ts
+++ b/client/webui/frontend/src/lib/types/fe.ts
@@ -148,6 +148,7 @@ export interface MessageFE {
     };
     senderDisplayName?: string; // Display name of the sender (for collaborative sessions)
     senderEmail?: string; // Email of the sender (for collaborative sessions)
+    isAgentSwitchIndicator?: boolean; // True if this message indicates an agent switch mid-session
     metadata?: {
         // Optional metadata, e.g., for feedback or correlation
         messageId?: string; // Unique ID for the agent's message (if provided by backend)

--- a/src/solace_agent_mesh/agent/adk/services.py
+++ b/src/solace_agent_mesh/agent/adk/services.py
@@ -5,6 +5,7 @@ Initializes ADK Services based on configuration.
 import logging
 import os
 import re
+import uuid as _uuid
 from typing import Any, Callable, Dict, List, Optional
 
 from google.adk.artifacts import (
@@ -1187,7 +1188,6 @@ def _filter_events_for_transfer(
             continue
 
         # Create a new event with fresh invocation ID to avoid correlation confusion
-        import uuid as _uuid
         filtered_event = ADKEvent(
             invocation_id=f"ctx-transfer-{_uuid.uuid4().hex[:12]}",
             author=event.author,
@@ -1314,13 +1314,20 @@ async def transfer_session_context(
     if target_session is None:
         # Use allowlist for state cloning — only copy known-safe keys
         clone_state = None
-        if _SAFE_STATE_KEYS and hasattr(source_session, "state") and source_session.state:
-            clone_state = {
-                k: v for k, v in source_session.state.items()
-                if k in _SAFE_STATE_KEYS
-            }
-            if not clone_state:
-                clone_state = None
+        if hasattr(source_session, "state") and source_session.state:
+            if _SAFE_STATE_KEYS:
+                clone_state = {
+                    k: v for k, v in source_session.state.items()
+                    if k in _SAFE_STATE_KEYS
+                }
+                if not clone_state:
+                    clone_state = None
+            else:
+                log.debug(
+                    "%s _SAFE_STATE_KEYS is empty — skipping state copy (%d keys in source).",
+                    log_identifier,
+                    len(source_session.state),
+                )
         try:
             target_session = await session_service.create_session(
                 app_name=target_agent_name,
@@ -1355,7 +1362,7 @@ async def transfer_session_context(
         f"The following is the conversation history from that agent.]"
     )
     marker_event = ADKEvent(
-        invocation_id=f"context-transfer-marker-{session_id}",
+        invocation_id=f"ctx-transfer-marker-{_uuid.uuid4().hex[:12]}",
         author="model",
         content=adk_types.Content(
             role="model",

--- a/src/solace_agent_mesh/agent/adk/services.py
+++ b/src/solace_agent_mesh/agent/adk/services.py
@@ -1174,10 +1174,11 @@ def _filter_events_for_transfer(
             continue
 
         # Filter parts: keep only text parts, strip function_call/function_response
+        # Deep copy text parts to avoid shared references with source events
         text_parts = []
         for part in event.content.parts:
             if hasattr(part, "text") and part.text:
-                text_parts.append(part)
+                text_parts.append(adk_types.Part(text=part.text))
             # Explicitly skip function_call and function_response parts
 
         # If no text parts remain after filtering, skip the entire event
@@ -1185,9 +1186,10 @@ def _filter_events_for_transfer(
             skipped_count += 1
             continue
 
-        # Create a new event with only text parts (preserving metadata)
+        # Create a new event with fresh invocation ID to avoid correlation confusion
+        import uuid as _uuid
         filtered_event = ADKEvent(
-            invocation_id=event.invocation_id,
+            invocation_id=f"ctx-transfer-{_uuid.uuid4().hex[:12]}",
             author=event.author,
             content=adk_types.Content(
                 role=role,
@@ -1206,6 +1208,30 @@ def _filter_events_for_transfer(
     return filtered
 
 
+# Maximum number of events to transfer to prevent unbounded clone loops
+MAX_TRANSFER_EVENTS = 200
+
+# Allowlist of session state keys safe to copy across agents
+_SAFE_STATE_KEYS = frozenset({
+    # Add known-safe keys here as needed; empty set means no state is copied
+})
+
+
+class TransferResult:
+    """Result of a context transfer operation with detailed counts."""
+
+    __slots__ = ("success", "transferred_count", "total_count", "message")
+
+    def __init__(self, success: bool, transferred_count: int = 0, total_count: int = 0, message: str = ""):
+        self.success = success
+        self.transferred_count = transferred_count
+        self.total_count = total_count
+        self.message = message
+
+    def __bool__(self) -> bool:
+        return self.success
+
+
 async def transfer_session_context(
     session_service: BaseSessionService,
     source_agent_name: str,
@@ -1214,15 +1240,14 @@ async def transfer_session_context(
     session_id: str,
     source_agent_display_name: str = "previous agent",
     log_identifier: str = "",
-) -> bool:
+    max_events: int = MAX_TRANSFER_EVENTS,
+) -> TransferResult:
     """
     Transfer conversation context from one agent's ADK session to another.
 
     Uses a filtered clone approach: copies user/model text events from the source
     session to the target session, stripping tool call/response parts that would
     confuse the new agent. Compaction events (conversation summaries) are preserved.
-
-    If the source session has no events or no text content, returns False.
 
     Args:
         session_service: The ADK session service (should be FilteringSessionService)
@@ -1232,9 +1257,10 @@ async def transfer_session_context(
         session_id: The session ID (same for both agents)
         source_agent_display_name: Human-readable name for context marker
         log_identifier: Logging prefix
+        max_events: Maximum number of events to transfer (oldest truncated first)
 
     Returns:
-        True if context was successfully transferred, False otherwise.
+        TransferResult with success flag, transferred/total counts, and message.
     """
     # 1. Load source session (FilteringSessionService handles compaction filtering)
     source_session = await session_service.get_session(
@@ -1250,7 +1276,7 @@ async def transfer_session_context(
             source_agent_name,
             session_id,
         )
-        return False
+        return TransferResult(False, message="No source session found.")
 
     # 2. Filter events: strip tool calls, keep text + compaction events
     filtered_events = _filter_events_for_transfer(
@@ -1265,7 +1291,18 @@ async def transfer_session_context(
             source_agent_name,
             session_id,
         )
-        return False
+        return TransferResult(False, message="No text content to transfer.")
+
+    # 2b. Truncate from oldest if exceeding max_events limit
+    total_before_truncation = len(filtered_events)
+    if len(filtered_events) > max_events:
+        log.warning(
+            "%s Truncating %d filtered events to max_events=%d (dropping oldest).",
+            log_identifier,
+            len(filtered_events),
+            max_events,
+        )
+        filtered_events = filtered_events[-max_events:]
 
     # 3. Get or create target session
     target_session = await session_service.get_session(
@@ -1275,13 +1312,15 @@ async def transfer_session_context(
     )
 
     if target_session is None:
-        # Copy state from source (strip compaction_time as it references source timestamps)
+        # Use allowlist for state cloning — only copy known-safe keys
         clone_state = None
-        if hasattr(source_session, "state") and source_session.state:
+        if _SAFE_STATE_KEYS and hasattr(source_session, "state") and source_session.state:
             clone_state = {
                 k: v for k, v in source_session.state.items()
-                if k != "compaction_time"
+                if k in _SAFE_STATE_KEYS
             }
+            if not clone_state:
+                clone_state = None
         try:
             target_session = await session_service.create_session(
                 app_name=target_agent_name,
@@ -1308,7 +1347,7 @@ async def transfer_session_context(
             target_agent_name,
             session_id,
         )
-        return False
+        return TransferResult(False, message="Failed to create target session.")
 
     # 4. Append a context marker event first
     marker_text = (
@@ -1339,10 +1378,19 @@ async def transfer_session_context(
             "%s Failed to append context marker event: %s",
             log_identifier, e, exc_info=True,
         )
-        return False
+        return TransferResult(False, message="Failed to append context marker.")
 
     # 5. Clone filtered events into target session
+    # Refresh target_session before the loop to avoid stale-session retries
+    # on every append (append_event_with_retry doesn't return the refreshed session)
+    target_session = await session_service.get_session(
+        app_name=target_agent_name,
+        user_id=user_id,
+        session_id=session_id,
+    ) or target_session
+
     cloned_count = 0
+    failed_count = 0
     for event_to_copy in filtered_events:
         try:
             await append_event_with_retry(
@@ -1355,20 +1403,45 @@ async def transfer_session_context(
                 log_identifier=f"{log_identifier}[ContextTransfer:Clone]",
             )
             cloned_count += 1
+
+            # Periodically refresh session to reduce stale-session retries
+            if cloned_count % 20 == 0:
+                refreshed = await session_service.get_session(
+                    app_name=target_agent_name,
+                    user_id=user_id,
+                    session_id=session_id,
+                )
+                if refreshed:
+                    target_session = refreshed
         except Exception as e:
+            failed_count += 1
             log.warning(
                 "%s Failed to clone event %d to target session: %s",
-                log_identifier, cloned_count, e,
+                log_identifier, cloned_count + failed_count, e,
             )
             # Continue cloning remaining events
 
+    total_events = len(filtered_events)
     log.info(
-        "%s Successfully transferred %d/%d events from '%s' to '%s' for session '%s'.",
+        "%s Context transfer complete: %d/%d events cloned (%d failed, %d truncated) "
+        "from '%s' to '%s' for session '%s'.",
         log_identifier,
         cloned_count,
-        len(filtered_events),
+        total_events,
+        failed_count,
+        max(0, total_before_truncation - max_events),
         source_agent_name,
         target_agent_name,
         session_id,
     )
-    return cloned_count > 0
+
+    if cloned_count == 0:
+        return TransferResult(False, 0, total_events, "All event clones failed.")
+
+    if failed_count > 0:
+        return TransferResult(
+            True, cloned_count, total_events,
+            f"Partial transfer: {cloned_count}/{total_events} events.",
+        )
+
+    return TransferResult(True, cloned_count, total_events, "Transfer complete.")

--- a/src/solace_agent_mesh/agent/adk/services.py
+++ b/src/solace_agent_mesh/agent/adk/services.py
@@ -1001,6 +1001,25 @@ async def append_event_with_retry(
     raise RuntimeError("Unexpected state in append_event_with_retry")
 
 
+def _extract_compaction_summary(event: ADKEvent) -> str | None:
+    """Extract the summary text from a compaction event, handling both dict and object forms."""
+    compacted_content = event.actions.compaction
+    if isinstance(compacted_content, dict):
+        cc = compacted_content.get("compacted_content", {})
+        parts = cc.get("parts", []) if isinstance(cc, dict) else []
+        for part in parts:
+            text = part.get("text", "") if isinstance(part, dict) else getattr(part, "text", "")
+            if text:
+                return text
+    else:
+        cc = getattr(compacted_content, "compacted_content", None)
+        if cc and hasattr(cc, "parts") and cc.parts:
+            for part in cc.parts:
+                if hasattr(part, "text") and part.text:
+                    return part.text
+    return None
+
+
 def extract_session_text_for_transfer(
     session: ADKSession,
     source_agent_display_name: str = "previous agent",
@@ -1009,9 +1028,9 @@ def extract_session_text_for_transfer(
     """
     Extract a clean text transcript from an ADK session for cross-agent context transfer.
 
-    Filters out tool call/response events and internal state events, keeping only
-    user/model text content. Handles compacted sessions by extracting the compaction
-    summary and prepending it to the transcript.
+    Delegates event filtering to _filter_events_for_transfer, then builds a formatted
+    text transcript from the filtered events. Handles compacted sessions by extracting
+    the compaction summary and prepending it to the transcript.
 
     The session MUST be loaded through FilteringSessionService (which automatically
     filters ghost events from compacted sessions) before calling this function.
@@ -1029,55 +1048,31 @@ def extract_session_text_for_transfer(
         log.info("%s No events in session to extract text from.", log_identifier)
         return None
 
-    # Step 1: Separate compaction events from regular events
+    # Step 1: Use shared filtering logic
+    filtered_events = _filter_events_for_transfer(
+        events=session.events,
+        log_identifier=log_identifier,
+    )
+
+    # Step 2: Separate compaction summaries from regular text events
     compaction_summary = None
-    regular_events = []
-
-    for event in session.events:
-        if event.actions and event.actions.compaction:
-            # Extract summary text from the compaction event
-            compacted_content = event.actions.compaction
-            # Handle both dict and object forms
-            if isinstance(compacted_content, dict):
-                cc = compacted_content.get("compacted_content", {})
-                parts = cc.get("parts", []) if isinstance(cc, dict) else []
-                for part in parts:
-                    text = part.get("text", "") if isinstance(part, dict) else getattr(part, "text", "")
-                    if text:
-                        compaction_summary = text
-                        break
-            else:
-                cc = getattr(compacted_content, "compacted_content", None)
-                if cc and hasattr(cc, "parts") and cc.parts:
-                    for part in cc.parts:
-                        if hasattr(part, "text") and part.text:
-                            compaction_summary = part.text
-                            break
-        else:
-            regular_events.append(event)
-
-    # Step 2: Extract text-only content from regular events
     transcript_lines = []
 
-    for event in regular_events:
+    for event in filtered_events:
+        if event.actions and event.actions.compaction:
+            summary = _extract_compaction_summary(event)
+            if summary:
+                compaction_summary = summary
+            continue
+
         if not event.content or not event.content.parts:
             continue
 
         role = event.content.role
-        if role not in ("user", "model"):
-            continue
-
-        # Skip events that contain ONLY function_call or function_response parts
-        has_text = False
         text_parts = []
         for part in event.content.parts:
             if hasattr(part, "text") and part.text:
-                has_text = True
                 text_parts.append(part.text)
-            # Skip function_call and function_response parts entirely
-
-        if not has_text:
-            continue
 
         combined_text = "\n".join(text_parts).strip()
         if not combined_text:
@@ -1111,10 +1106,10 @@ def extract_session_text_for_transfer(
     )
 
     log.info(
-        "%s Extracted %d chars of text for context transfer (%d regular events, compaction=%s).",
+        "%s Extracted %d chars of text for context transfer (%d filtered events, compaction=%s).",
         log_identifier,
         len(result),
-        len(regular_events),
+        len(filtered_events),
         "yes" if compaction_summary else "no",
     )
 
@@ -1163,10 +1158,14 @@ def _filter_events_for_transfer(
             skipped_count += 1
             continue
 
-        # Skip system/context-setting events (state_delta only)
-        if event.actions and event.actions.state_delta and not event.content.parts:
-            skipped_count += 1
-            continue
+        # Skip system/context-setting events (state_delta only, no text)
+        if event.actions and event.actions.state_delta:
+            has_text = any(
+                hasattr(p, "text") and p.text for p in event.content.parts
+            )
+            if not has_text:
+                skipped_count += 1
+                continue
 
         role = event.content.role
         # Only keep user and model events
@@ -1290,8 +1289,12 @@ async def transfer_session_context(
                 session_id=session_id,
                 state=clone_state,
             )
-        except Exception:
+        except Exception as exc:
             # Race condition: another request may have created it
+            log.warning(
+                "%s create_session failed, retrying with get_session: %s",
+                log_identifier, exc,
+            )
             target_session = await session_service.get_session(
                 app_name=target_agent_name,
                 user_id=user_id,

--- a/src/solace_agent_mesh/agent/adk/services.py
+++ b/src/solace_agent_mesh/agent/adk/services.py
@@ -999,3 +999,373 @@ async def append_event_with_retry(
     if last_error:
         raise last_error
     raise RuntimeError("Unexpected state in append_event_with_retry")
+
+
+def extract_session_text_for_transfer(
+    session: ADKSession,
+    source_agent_display_name: str = "previous agent",
+    log_identifier: str = "",
+) -> str | None:
+    """
+    Extract a clean text transcript from an ADK session for cross-agent context transfer.
+
+    Filters out tool call/response events and internal state events, keeping only
+    user/model text content. Handles compacted sessions by extracting the compaction
+    summary and prepending it to the transcript.
+
+    The session MUST be loaded through FilteringSessionService (which automatically
+    filters ghost events from compacted sessions) before calling this function.
+
+    Args:
+        session: The ADK session loaded via FilteringSessionService.get_session()
+        source_agent_display_name: Display name of the source agent for context marker
+        log_identifier: Logging prefix
+
+    Returns:
+        A formatted text transcript suitable for injection into a new agent's session,
+        or None if the session has no meaningful text content.
+    """
+    if not session or not session.events:
+        log.info("%s No events in session to extract text from.", log_identifier)
+        return None
+
+    # Step 1: Separate compaction events from regular events
+    compaction_summary = None
+    regular_events = []
+
+    for event in session.events:
+        if event.actions and event.actions.compaction:
+            # Extract summary text from the compaction event
+            compacted_content = event.actions.compaction
+            # Handle both dict and object forms
+            if isinstance(compacted_content, dict):
+                cc = compacted_content.get("compacted_content", {})
+                parts = cc.get("parts", []) if isinstance(cc, dict) else []
+                for part in parts:
+                    text = part.get("text", "") if isinstance(part, dict) else getattr(part, "text", "")
+                    if text:
+                        compaction_summary = text
+                        break
+            else:
+                cc = getattr(compacted_content, "compacted_content", None)
+                if cc and hasattr(cc, "parts") and cc.parts:
+                    for part in cc.parts:
+                        if hasattr(part, "text") and part.text:
+                            compaction_summary = part.text
+                            break
+        else:
+            regular_events.append(event)
+
+    # Step 2: Extract text-only content from regular events
+    transcript_lines = []
+
+    for event in regular_events:
+        if not event.content or not event.content.parts:
+            continue
+
+        role = event.content.role
+        if role not in ("user", "model"):
+            continue
+
+        # Skip events that contain ONLY function_call or function_response parts
+        has_text = False
+        text_parts = []
+        for part in event.content.parts:
+            if hasattr(part, "text") and part.text:
+                has_text = True
+                text_parts.append(part.text)
+            # Skip function_call and function_response parts entirely
+
+        if not has_text:
+            continue
+
+        combined_text = "\n".join(text_parts).strip()
+        if not combined_text:
+            continue
+
+        role_label = "User" if role == "user" else "Assistant"
+        transcript_lines.append(f"{role_label}: {combined_text}")
+
+    # Step 3: Build the final transcript
+    if not compaction_summary and not transcript_lines:
+        log.info("%s No text content found in session events.", log_identifier)
+        return None
+
+    parts = []
+
+    if compaction_summary:
+        parts.append(f"[Summary of earlier conversation]\n{compaction_summary}")
+
+    if transcript_lines:
+        if compaction_summary:
+            parts.append("\n[Recent conversation]")
+        parts.append("\n".join(transcript_lines))
+
+    transcript = "\n\n".join(parts)
+
+    # Step 4: Wrap with context markers
+    result = (
+        f"[Context from previous conversation with {source_agent_display_name}]\n"
+        f"{transcript}\n"
+        f"[End of previous context]"
+    )
+
+    log.info(
+        "%s Extracted %d chars of text for context transfer (%d regular events, compaction=%s).",
+        log_identifier,
+        len(result),
+        len(regular_events),
+        "yes" if compaction_summary else "no",
+    )
+
+    return result
+
+
+def _filter_events_for_transfer(
+    events: list[ADKEvent],
+    log_identifier: str = "",
+) -> list[ADKEvent]:
+    """
+    Filter ADK session events for cross-agent transfer by stripping tool-only events.
+
+    Keeps:
+    - User text events (user messages)
+    - Model text events (assistant responses with text content)
+    - Compaction events (contain conversation summaries)
+
+    Strips from kept events:
+    - function_call parts (tool invocations the new agent doesn't have)
+    - function_response parts (tool results)
+
+    Removes entirely:
+    - Events with ONLY function_call/function_response parts (no text)
+    - System/context-setting events (state_delta events)
+    - Events with no content
+
+    Args:
+        events: List of ADK events from the source session
+        log_identifier: Logging prefix
+
+    Returns:
+        List of filtered ADKEvent objects safe for the target agent
+    """
+    filtered = []
+    skipped_count = 0
+
+    for event in events:
+        # Keep compaction events as-is (they contain conversation summaries)
+        if event.actions and event.actions.compaction:
+            filtered.append(event)
+            continue
+
+        # Skip events with no content
+        if not event.content or not event.content.parts:
+            skipped_count += 1
+            continue
+
+        # Skip system/context-setting events (state_delta only)
+        if event.actions and event.actions.state_delta and not event.content.parts:
+            skipped_count += 1
+            continue
+
+        role = event.content.role
+        # Only keep user and model events
+        if role not in ("user", "model"):
+            skipped_count += 1
+            continue
+
+        # Filter parts: keep only text parts, strip function_call/function_response
+        text_parts = []
+        for part in event.content.parts:
+            if hasattr(part, "text") and part.text:
+                text_parts.append(part)
+            # Explicitly skip function_call and function_response parts
+
+        # If no text parts remain after filtering, skip the entire event
+        if not text_parts:
+            skipped_count += 1
+            continue
+
+        # Create a new event with only text parts (preserving metadata)
+        filtered_event = ADKEvent(
+            invocation_id=event.invocation_id,
+            author=event.author,
+            content=adk_types.Content(
+                role=role,
+                parts=text_parts,
+            ),
+            timestamp=event.timestamp,
+        )
+        filtered.append(filtered_event)
+
+    log.info(
+        "%s Filtered events for transfer: %d kept, %d skipped (tool-only/system).",
+        log_identifier,
+        len(filtered),
+        skipped_count,
+    )
+    return filtered
+
+
+async def transfer_session_context(
+    session_service: BaseSessionService,
+    source_agent_name: str,
+    target_agent_name: str,
+    user_id: str,
+    session_id: str,
+    source_agent_display_name: str = "previous agent",
+    log_identifier: str = "",
+) -> bool:
+    """
+    Transfer conversation context from one agent's ADK session to another.
+
+    Uses a filtered clone approach: copies user/model text events from the source
+    session to the target session, stripping tool call/response parts that would
+    confuse the new agent. Compaction events (conversation summaries) are preserved.
+
+    If the source session has no events or no text content, returns False.
+
+    Args:
+        session_service: The ADK session service (should be FilteringSessionService)
+        source_agent_name: The source agent's name (used as app_name)
+        target_agent_name: The target agent's name (used as app_name)
+        user_id: The user ID
+        session_id: The session ID (same for both agents)
+        source_agent_display_name: Human-readable name for context marker
+        log_identifier: Logging prefix
+
+    Returns:
+        True if context was successfully transferred, False otherwise.
+    """
+    # 1. Load source session (FilteringSessionService handles compaction filtering)
+    source_session = await session_service.get_session(
+        app_name=source_agent_name,
+        user_id=user_id,
+        session_id=session_id,
+    )
+
+    if not source_session or not source_session.events:
+        log.info(
+            "%s No source session found for agent '%s', session '%s'. Nothing to transfer.",
+            log_identifier,
+            source_agent_name,
+            session_id,
+        )
+        return False
+
+    # 2. Filter events: strip tool calls, keep text + compaction events
+    filtered_events = _filter_events_for_transfer(
+        events=source_session.events,
+        log_identifier=log_identifier,
+    )
+
+    if not filtered_events:
+        log.info(
+            "%s No transferable events from agent '%s' session '%s'.",
+            log_identifier,
+            source_agent_name,
+            session_id,
+        )
+        return False
+
+    # 3. Get or create target session
+    target_session = await session_service.get_session(
+        app_name=target_agent_name,
+        user_id=user_id,
+        session_id=session_id,
+    )
+
+    if target_session is None:
+        # Copy state from source (strip compaction_time as it references source timestamps)
+        clone_state = None
+        if hasattr(source_session, "state") and source_session.state:
+            clone_state = {
+                k: v for k, v in source_session.state.items()
+                if k != "compaction_time"
+            }
+        try:
+            target_session = await session_service.create_session(
+                app_name=target_agent_name,
+                user_id=user_id,
+                session_id=session_id,
+                state=clone_state,
+            )
+        except Exception:
+            # Race condition: another request may have created it
+            target_session = await session_service.get_session(
+                app_name=target_agent_name,
+                user_id=user_id,
+                session_id=session_id,
+            )
+
+    if target_session is None:
+        log.error(
+            "%s Failed to create/get target session for agent '%s', session '%s'.",
+            log_identifier,
+            target_agent_name,
+            session_id,
+        )
+        return False
+
+    # 4. Append a context marker event first
+    marker_text = (
+        f"[The user has switched from {source_agent_display_name}. "
+        f"The following is the conversation history from that agent.]"
+    )
+    marker_event = ADKEvent(
+        invocation_id=f"context-transfer-marker-{session_id}",
+        author="model",
+        content=adk_types.Content(
+            role="model",
+            parts=[adk_types.Part(text=marker_text)],
+        ),
+    )
+
+    try:
+        await append_event_with_retry(
+            session_service=session_service,
+            session=target_session,
+            event=marker_event,
+            app_name=target_agent_name,
+            user_id=user_id,
+            session_id=session_id,
+            log_identifier=f"{log_identifier}[ContextTransfer:Marker]",
+        )
+    except Exception as e:
+        log.error(
+            "%s Failed to append context marker event: %s",
+            log_identifier, e, exc_info=True,
+        )
+        return False
+
+    # 5. Clone filtered events into target session
+    cloned_count = 0
+    for event_to_copy in filtered_events:
+        try:
+            await append_event_with_retry(
+                session_service=session_service,
+                session=target_session,
+                event=event_to_copy,
+                app_name=target_agent_name,
+                user_id=user_id,
+                session_id=session_id,
+                log_identifier=f"{log_identifier}[ContextTransfer:Clone]",
+            )
+            cloned_count += 1
+        except Exception as e:
+            log.warning(
+                "%s Failed to clone event %d to target session: %s",
+                log_identifier, cloned_count, e,
+            )
+            # Continue cloning remaining events
+
+    log.info(
+        "%s Successfully transferred %d/%d events from '%s' to '%s' for session '%s'.",
+        log_identifier,
+        cloned_count,
+        len(filtered_events),
+        source_agent_name,
+        target_agent_name,
+        session_id,
+    )
+    return cloned_count > 0

--- a/src/solace_agent_mesh/gateway/http_sse/component.py
+++ b/src/solace_agent_mesh/gateway/http_sse/component.py
@@ -271,6 +271,7 @@ class WebUIBackendComponent(BaseGatewayComponent):
 
         # Lazy-initialized ADK session service for cross-agent context transfer
         self._adk_session_service = None
+        self._adk_session_service_lock = threading.Lock()
 
         # Initialize SAM Events service for system events
         from ...common.sam_events import SamEventService
@@ -2161,57 +2162,64 @@ class WebUIBackendComponent(BaseGatewayComponent):
     def get_shared_artifact_service(self) -> BaseArtifactService | None:
         return self.shared_artifact_service
 
-    def get_adk_session_service(self):
+    def get_adk_session_service(self) -> Any:
         """
         Get an ADK session service for cross-agent context transfer.
 
-        Finds the first agent component's session_service by traversing the
-        connector's app list. All agents in the same deployment share the same
-        session service instance (whether InMemory or SQL-backed), so we only
-        need to find one agent's session_service to access all agent sessions.
+        Thread-safe lazy initialization: finds the first agent component's
+        session_service by traversing the connector's app list. All agents in
+        the same deployment share the same session service instance (whether
+        InMemory or SQL-backed), so we only need to find one.
 
         Returns None if no agent components are found or none have a session_service.
         """
+        # Fast path: already cached (no lock needed for reads of immutable reference)
         if self._adk_session_service is not None:
             return self._adk_session_service
 
-        try:
-            main_app = self.get_app()
-            if not main_app or not main_app.connector:
+        # Slow path: thread-safe initialization
+        with self._adk_session_service_lock:
+            # Double-check after acquiring lock
+            if self._adk_session_service is not None:
+                return self._adk_session_service
+
+            try:
+                main_app = self.get_app()
+                if not main_app or not main_app.connector:
+                    log.warning(
+                        "%s Cannot get ADK session service: no connector available.",
+                        self.log_identifier,
+                    )
+                    return None
+
+                # Import SamAgentComponent to identify agent apps
+                from ...agent.sac.component import SamAgentComponent
+
+                # Iterate through all apps in the connector to find an agent component
+                for app in main_app.connector.apps:
+                    if hasattr(app, 'get_component'):
+                        component = app.get_component()
+                        if isinstance(component, SamAgentComponent) and component.session_service:
+                            self._adk_session_service = component.session_service
+                            log.info(
+                                "%s Found ADK session service from agent '%s' for context transfer.",
+                                self.log_identifier,
+                                getattr(component, 'agent_name', 'unknown'),
+                            )
+                            return self._adk_session_service
+
                 log.warning(
-                    "%s Cannot get ADK session service: no connector available.",
+                    "%s No agent components with session_service found in connector apps. "
+                    "Context transfer requires at least one running agent.",
                     self.log_identifier,
                 )
                 return None
-
-            # Import SamAgentComponent to identify agent apps
-            from ...agent.sac.component import SamAgentComponent
-
-            # Iterate through all apps in the connector to find an agent component
-            for app in main_app.connector.apps:
-                if hasattr(app, 'get_component'):
-                    component = app.get_component()
-                    if isinstance(component, SamAgentComponent) and component.session_service:
-                        self._adk_session_service = component.session_service
-                        log.info(
-                            "%s Found ADK session service from agent '%s' for context transfer.",
-                            self.log_identifier,
-                            getattr(component, 'agent_name', 'unknown'),
-                        )
-                        return self._adk_session_service
-
-            log.warning(
-                "%s No agent components with session_service found in connector apps. "
-                "Context transfer requires at least one running agent.",
-                self.log_identifier,
-            )
-            return None
-        except Exception as e:
-            log.error(
-                "%s Failed to get ADK session service for context transfer: %s",
-                self.log_identifier, e, exc_info=True,
-            )
-            return None
+            except Exception as e:
+                log.error(
+                    "%s Failed to get ADK session service for context transfer: %s",
+                    self.log_identifier, e, exc_info=True,
+                )
+                return None
 
     def get_embed_config(self) -> dict[str, Any]:
         """Returns embed-related configuration needed by dependencies."""

--- a/src/solace_agent_mesh/gateway/http_sse/component.py
+++ b/src/solace_agent_mesh/gateway/http_sse/component.py
@@ -269,6 +269,9 @@ class WebUIBackendComponent(BaseGatewayComponent):
         self.background_task_monitor = None
         self._background_task_monitor_timer_id = None
 
+        # Lazy-initialized ADK session service for cross-agent context transfer
+        self._adk_session_service = None
+
         # Initialize SAM Events service for system events
         from ...common.sam_events import SamEventService
 
@@ -2157,6 +2160,58 @@ class WebUIBackendComponent(BaseGatewayComponent):
 
     def get_shared_artifact_service(self) -> BaseArtifactService | None:
         return self.shared_artifact_service
+
+    def get_adk_session_service(self):
+        """
+        Get an ADK session service for cross-agent context transfer.
+
+        Finds the first agent component's session_service by traversing the
+        connector's app list. All agents in the same deployment share the same
+        session service instance (whether InMemory or SQL-backed), so we only
+        need to find one agent's session_service to access all agent sessions.
+
+        Returns None if no agent components are found or none have a session_service.
+        """
+        if self._adk_session_service is not None:
+            return self._adk_session_service
+
+        try:
+            main_app = self.get_app()
+            if not main_app or not main_app.connector:
+                log.warning(
+                    "%s Cannot get ADK session service: no connector available.",
+                    self.log_identifier,
+                )
+                return None
+
+            # Import SamAgentComponent to identify agent apps
+            from ...agent.sac.component import SamAgentComponent
+
+            # Iterate through all apps in the connector to find an agent component
+            for app in main_app.connector.apps:
+                if hasattr(app, 'get_component'):
+                    component = app.get_component()
+                    if isinstance(component, SamAgentComponent) and component.session_service:
+                        self._adk_session_service = component.session_service
+                        log.info(
+                            "%s Found ADK session service from agent '%s' for context transfer.",
+                            self.log_identifier,
+                            getattr(component, 'agent_name', 'unknown'),
+                        )
+                        return self._adk_session_service
+
+            log.warning(
+                "%s No agent components with session_service found in connector apps. "
+                "Context transfer requires at least one running agent.",
+                self.log_identifier,
+            )
+            return None
+        except Exception as e:
+            log.error(
+                "%s Failed to get ADK session service for context transfer: %s",
+                self.log_identifier, e, exc_info=True,
+            )
+            return None
 
     def get_embed_config(self) -> dict[str, Any]:
         """Returns embed-related configuration needed by dependencies."""

--- a/src/solace_agent_mesh/gateway/http_sse/dependencies.py
+++ b/src/solace_agent_mesh/gateway/http_sse/dependencies.py
@@ -571,6 +571,14 @@ def get_shared_artifact_service(
     return component.get_shared_artifact_service()
 
 
+def get_adk_session_service(
+    component: "WebUIBackendComponent" = Depends(get_sac_component),
+):
+    """FastAPI dependency to get the ADK session service for cross-agent context transfer."""
+    log.debug("get_adk_session_service called")
+    return component.get_adk_session_service()
+
+
 def get_embed_config(
     component: "WebUIBackendComponent" = Depends(get_sac_component),
 ) -> dict[str, Any]:

--- a/src/solace_agent_mesh/gateway/http_sse/routers/sessions.py
+++ b/src/solace_agent_mesh/gateway/http_sse/routers/sessions.py
@@ -1077,7 +1077,11 @@ def _resolve_agent_display_name(agent_registry, agent_name: str) -> str:
 
     return agent_name
 
-_transfer_context_semaphore = asyncio.BoundedSemaphore(10)
+# Simple concurrency limiter for context transfer requests.
+# asyncio is single-threaded, so a plain counter is safe (no race between
+# the check and increment within a single synchronous code path).
+_MAX_CONCURRENT_TRANSFERS = 10
+_active_transfer_count = 0
 
 
 class TransferContextRequest(BaseModel):
@@ -1179,14 +1183,16 @@ async def transfer_context(
             message="Context transfer unavailable: no agent session service found.",
         )
 
-    # Rate limit using public asyncio API (wait_for with timeout=0)
-    try:
-        await asyncio.wait_for(_transfer_context_semaphore.acquire(), timeout=0)
-    except asyncio.TimeoutError:
+    # Rate limit using a simple counter (safe in asyncio's single-threaded event loop —
+    # no await between the check and increment, so no interleaving is possible)
+    global _active_transfer_count
+    if _active_transfer_count >= _MAX_CONCURRENT_TRANSFERS:
         raise HTTPException(
             status_code=status.HTTP_429_TOO_MANY_REQUESTS,
             detail="Too many context transfer requests. Please try again shortly.",
         )
+
+    _active_transfer_count += 1
     try:
         from ....agent.adk.services import transfer_session_context
 
@@ -1238,4 +1244,4 @@ async def transfer_context(
             detail="Failed to transfer conversation context.",
         ) from e
     finally:
-        _transfer_context_semaphore.release()
+        _active_transfer_count -= 1

--- a/src/solace_agent_mesh/gateway/http_sse/routers/sessions.py
+++ b/src/solace_agent_mesh/gateway/http_sse/routers/sessions.py
@@ -14,7 +14,7 @@ from ....common.utils.embeds import (
 )
 from ....common.utils.embeds.types import ResolutionMode
 from ....common.utils.templates import resolve_template_blocks_in_string
-from ..dependencies import get_session_business_service, get_db, get_title_generation_service, get_shared_artifact_service, get_sac_component
+from ..dependencies import get_session_business_service, get_db, get_title_generation_service, get_shared_artifact_service, get_sac_component, get_adk_session_service, get_agent_registry
 from ..services.session_service import SessionService
 from solace_agent_mesh.shared.api.auth_utils import get_current_user
 from solace_agent_mesh.shared.api.pagination import DataResponse, PaginatedResponse, PaginationParams
@@ -1052,14 +1052,38 @@ async def trigger_title_generation(
 
 # --- Context Transfer ---
 
+DISPLAY_NAME_EXTENSION_URI = "https://solace.com/a2a/extensions/display-name"
+
+
+def _resolve_agent_display_name(agent_registry, agent_name: str) -> str:
+    """Resolve display name from agent registry, falling back to agent_name."""
+    card = agent_registry.get_agent(agent_name)
+    if not card:
+        return agent_name
+
+    capabilities = getattr(card, "capabilities", None)
+    if not capabilities:
+        return agent_name
+
+    extensions = getattr(capabilities, "extensions", None)
+    if not extensions:
+        return agent_name
+
+    for ext in extensions:
+        if ext.uri == DISPLAY_NAME_EXTENSION_URI:
+            display_name = (ext.params or {}).get("display_name")
+            if display_name:
+                return str(display_name)
+
+    return agent_name
+
+_transfer_context_semaphore = asyncio.BoundedSemaphore(10)
+
+
 class TransferContextRequest(BaseModel):
     """Request body for transferring conversation context between agents."""
     source_agent_name: str = Field(..., description="Name of the source agent to transfer context from")
     target_agent_name: str = Field(..., description="Name of the target agent to transfer context to")
-    source_agent_display_name: str = Field(
-        default="previous agent",
-        description="Human-readable display name of the source agent",
-    )
 
 
 class TransferContextResponse(BaseModel):
@@ -1076,6 +1100,10 @@ async def transfer_context(
     session_id: str,
     request_body: TransferContextRequest,
     user: dict = Depends(get_current_user),
+    db: Session = Depends(get_db),
+    session_service: SessionService = Depends(get_session_business_service),
+    adk_session_service=Depends(get_adk_session_service),
+    agent_registry=Depends(get_agent_registry),
 ):
     """
     Transfer conversation context from one agent's ADK session to another.
@@ -1103,16 +1131,33 @@ async def transfer_context(
             detail="Invalid session_id.",
         )
 
+    # Verify the authenticated user owns this session
+    session_domain = session_service.get_session_details(
+        db=db, session_id=session_id, user_id=user_id
+    )
+    if not session_domain:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=SESSION_NOT_FOUND_MSG,
+        )
+
     if request_body.source_agent_name == request_body.target_agent_name:
         return TransferContextResponse(
             context_transferred=False,
             message="Source and target agents are the same. No transfer needed.",
         )
 
-    # Get the ADK session service from the gateway component
-    from ..dependencies import get_sac_component
-    component = get_sac_component()
-    adk_session_service = component.get_adk_session_service()
+    # Validate agent names against the registry
+    if request_body.source_agent_name not in agent_registry or request_body.target_agent_name not in agent_registry:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail="One or both specified agents are not registered.",
+        )
+
+    # Resolve display name server-side from the agent registry
+    source_agent_display_name = _resolve_agent_display_name(
+        agent_registry, request_body.source_agent_name
+    )
 
     if adk_session_service is None:
         log.warning(
@@ -1125,6 +1170,14 @@ async def transfer_context(
         )
 
     try:
+        _transfer_context_semaphore.acquire_nowait()
+    except ValueError:
+        raise HTTPException(
+            status_code=status.HTTP_429_TOO_MANY_REQUESTS,
+            detail="Too many context transfer requests. Please try again shortly.",
+        )
+
+    try:
         from ....agent.adk.services import transfer_session_context
 
         success = await transfer_session_context(
@@ -1133,7 +1186,7 @@ async def transfer_context(
             target_agent_name=request_body.target_agent_name,
             user_id=user_id,
             session_id=session_id,
-            source_agent_display_name=request_body.source_agent_display_name,
+            source_agent_display_name=source_agent_display_name,
             log_identifier=f"[ContextTransfer:{session_id}]",
         )
 
@@ -1146,7 +1199,7 @@ async def transfer_context(
             )
             return TransferContextResponse(
                 context_transferred=True,
-                message=f"Context transferred from {request_body.source_agent_display_name}.",
+                message=f"Context transferred from {source_agent_display_name}.",
             )
         else:
             log.info(
@@ -1171,3 +1224,5 @@ async def transfer_context(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
             detail="Failed to transfer conversation context.",
         ) from e
+    finally:
+        _transfer_context_semaphore.release()

--- a/src/solace_agent_mesh/gateway/http_sse/routers/sessions.py
+++ b/src/solace_agent_mesh/gateway/http_sse/routers/sessions.py
@@ -4,7 +4,7 @@ import logging
 import re
 from typing import Optional, TYPE_CHECKING
 from fastapi import APIRouter, Body, Depends, HTTPException, Query, status
-from pydantic import ValidationError
+from pydantic import BaseModel, Field, ValidationError
 from sqlalchemy.orm import Session
 
 from ....common.utils.embeds import (
@@ -1050,4 +1050,124 @@ async def trigger_title_generation(
         ) from e
 
 
+# --- Context Transfer ---
 
+class TransferContextRequest(BaseModel):
+    """Request body for transferring conversation context between agents."""
+    source_agent_name: str = Field(..., description="Name of the source agent to transfer context from")
+    target_agent_name: str = Field(..., description="Name of the target agent to transfer context to")
+    source_agent_display_name: str = Field(
+        default="previous agent",
+        description="Human-readable display name of the source agent",
+    )
+
+
+class TransferContextResponse(BaseModel):
+    """Response body for context transfer."""
+    context_transferred: bool = Field(..., description="Whether context was successfully transferred")
+    message: str = Field(..., description="Human-readable status message")
+
+
+@router.post(
+    "/sessions/{session_id}/transfer-context",
+    response_model=TransferContextResponse,
+)
+async def transfer_context(
+    session_id: str,
+    request_body: TransferContextRequest,
+    user: dict = Depends(get_current_user),
+):
+    """
+    Transfer conversation context from one agent's ADK session to another.
+
+    When a user switches agents mid-session via the agent selector, this endpoint
+    copies the filtered conversation history (text-only, no tool calls) from the
+    source agent's ADK session to the target agent's ADK session.
+
+    This preserves conversation context across agent switches so the new agent
+    understands what was previously discussed.
+    """
+    user_id = user.get("id")
+    log.info(
+        "User %s requesting context transfer for session %s: %s -> %s",
+        user_id,
+        session_id,
+        request_body.source_agent_name,
+        request_body.target_agent_name,
+    )
+
+    # Validate inputs
+    if not session_id or session_id.strip() == "" or session_id in ["null", "undefined"]:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Invalid session_id.",
+        )
+
+    if request_body.source_agent_name == request_body.target_agent_name:
+        return TransferContextResponse(
+            context_transferred=False,
+            message="Source and target agents are the same. No transfer needed.",
+        )
+
+    # Get the ADK session service from the gateway component
+    from ..dependencies import get_sac_component
+    component = get_sac_component()
+    adk_session_service = component.get_adk_session_service()
+
+    if adk_session_service is None:
+        log.warning(
+            "Context transfer unavailable: ADK session service not initialized "
+            "(requires SQL session storage)."
+        )
+        return TransferContextResponse(
+            context_transferred=False,
+            message="Context transfer unavailable: requires SQL session storage.",
+        )
+
+    try:
+        from ....agent.adk.services import transfer_session_context
+
+        success = await transfer_session_context(
+            session_service=adk_session_service,
+            source_agent_name=request_body.source_agent_name,
+            target_agent_name=request_body.target_agent_name,
+            user_id=user_id,
+            session_id=session_id,
+            source_agent_display_name=request_body.source_agent_display_name,
+            log_identifier=f"[ContextTransfer:{session_id}]",
+        )
+
+        if success:
+            log.info(
+                "Context transfer successful for session %s: %s -> %s",
+                session_id,
+                request_body.source_agent_name,
+                request_body.target_agent_name,
+            )
+            return TransferContextResponse(
+                context_transferred=True,
+                message=f"Context transferred from {request_body.source_agent_display_name}.",
+            )
+        else:
+            log.info(
+                "No context to transfer for session %s: %s -> %s",
+                session_id,
+                request_body.source_agent_name,
+                request_body.target_agent_name,
+            )
+            return TransferContextResponse(
+                context_transferred=False,
+                message="No conversation context found to transfer.",
+            )
+
+    except Exception as e:
+        log.error(
+            "Error during context transfer for session %s: %s",
+            session_id,
+            e,
+            exc_info=True,
+        )
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="Failed to transfer conversation context.",
+        ) from e

--- a/src/solace_agent_mesh/gateway/http_sse/routers/sessions.py
+++ b/src/solace_agent_mesh/gateway/http_sse/routers/sessions.py
@@ -1082,8 +1082,18 @@ _transfer_context_semaphore = asyncio.BoundedSemaphore(10)
 
 class TransferContextRequest(BaseModel):
     """Request body for transferring conversation context between agents."""
-    source_agent_name: str = Field(..., description="Name of the source agent to transfer context from")
-    target_agent_name: str = Field(..., description="Name of the target agent to transfer context to")
+    source_agent_name: str = Field(
+        ...,
+        max_length=256,
+        pattern=r'^[a-zA-Z0-9_\-\.]+$',
+        description="Name of the source agent to transfer context from",
+    )
+    target_agent_name: str = Field(
+        ...,
+        max_length=256,
+        pattern=r'^[a-zA-Z0-9_\-\.]+$',
+        description="Name of the target agent to transfer context to",
+    )
 
 
 class TransferContextResponse(BaseModel):
@@ -1159,28 +1169,28 @@ async def transfer_context(
         agent_registry, request_body.source_agent_name
     )
 
+    # Fail-fast: check ADK session service before acquiring semaphore
     if adk_session_service is None:
         log.warning(
-            "Context transfer unavailable: ADK session service not initialized "
-            "(requires SQL session storage)."
+            "Context transfer unavailable: ADK session service not initialized."
         )
         return TransferContextResponse(
             context_transferred=False,
-            message="Context transfer unavailable: requires SQL session storage.",
+            message="Context transfer unavailable: no agent session service found.",
         )
 
-    try:
-        _transfer_context_semaphore.acquire_nowait()
-    except ValueError:
+    # Rate limit: acquire_nowait returns False (not raises) when exhausted
+    if not _transfer_context_semaphore._value > 0:
         raise HTTPException(
             status_code=status.HTTP_429_TOO_MANY_REQUESTS,
             detail="Too many context transfer requests. Please try again shortly.",
         )
 
+    await _transfer_context_semaphore.acquire()
     try:
         from ....agent.adk.services import transfer_session_context
 
-        success = await transfer_session_context(
+        result = await transfer_session_context(
             session_service=adk_session_service,
             source_agent_name=request_body.source_agent_name,
             target_agent_name=request_body.target_agent_name,
@@ -1190,27 +1200,30 @@ async def transfer_context(
             log_identifier=f"[ContextTransfer:{session_id}]",
         )
 
-        if success:
+        if result.success:
             log.info(
-                "Context transfer successful for session %s: %s -> %s",
+                "Context transfer successful for session %s: %s -> %s (%d/%d events)",
                 session_id,
                 request_body.source_agent_name,
                 request_body.target_agent_name,
+                result.transferred_count,
+                result.total_count,
             )
             return TransferContextResponse(
                 context_transferred=True,
-                message=f"Context transferred from {source_agent_display_name}.",
+                message=result.message or f"Context transferred from {source_agent_display_name}.",
             )
         else:
             log.info(
-                "No context to transfer for session %s: %s -> %s",
+                "No context to transfer for session %s: %s -> %s (%s)",
                 session_id,
                 request_body.source_agent_name,
                 request_body.target_agent_name,
+                result.message,
             )
             return TransferContextResponse(
                 context_transferred=False,
-                message="No conversation context found to transfer.",
+                message=result.message or "No conversation context found to transfer.",
             )
 
     except Exception as e:

--- a/src/solace_agent_mesh/gateway/http_sse/routers/sessions.py
+++ b/src/solace_agent_mesh/gateway/http_sse/routers/sessions.py
@@ -1179,14 +1179,14 @@ async def transfer_context(
             message="Context transfer unavailable: no agent session service found.",
         )
 
-    # Rate limit: acquire_nowait returns False (not raises) when exhausted
-    if not _transfer_context_semaphore._value > 0:
+    # Rate limit using public asyncio API (wait_for with timeout=0)
+    try:
+        await asyncio.wait_for(_transfer_context_semaphore.acquire(), timeout=0)
+    except asyncio.TimeoutError:
         raise HTTPException(
             status_code=status.HTTP_429_TOO_MANY_REQUESTS,
             detail="Too many context transfer requests. Please try again shortly.",
         )
-
-    await _transfer_context_semaphore.acquire()
     try:
         from ....agent.adk.services import transfer_session_context
 

--- a/tests/unit/agent/adk/test_transfer_services.py
+++ b/tests/unit/agent/adk/test_transfer_services.py
@@ -1,0 +1,449 @@
+"""Tests for cross-agent context transfer service functions."""
+
+import pytest
+from unittest.mock import AsyncMock, MagicMock
+
+from google.adk.events import Event as ADKEvent
+from google.genai import types as adk_types
+
+from solace_agent_mesh.agent.adk.services import (
+    _extract_compaction_summary,
+    _filter_events_for_transfer,
+    extract_session_text_for_transfer,
+    transfer_session_context,
+)
+
+
+# --- Helpers ---
+
+
+def _make_text_event(role: str, text: str, author: str = "user") -> ADKEvent:
+    return ADKEvent(
+        invocation_id="inv-1",
+        author=author,
+        content=adk_types.Content(
+            role=role,
+            parts=[adk_types.Part(text=text)],
+        ),
+    )
+
+
+def _make_function_call_event() -> ADKEvent:
+    """Event with only a function_call part (no text)."""
+    part = MagicMock()
+    part.text = None
+    part.function_call = MagicMock()
+    del part.text  # hasattr(part, "text") will return False
+    return ADKEvent(
+        invocation_id="inv-fc",
+        author="model",
+        content=adk_types.Content(
+            role="model",
+            parts=[part],
+        ),
+    )
+
+
+def _make_mixed_event(text: str) -> ADKEvent:
+    """Event with both a text part and a function_call part."""
+    text_part = adk_types.Part(text=text)
+    fc_part = MagicMock()
+    fc_part.text = None
+    del fc_part.text
+    return ADKEvent(
+        invocation_id="inv-mixed",
+        author="model",
+        content=adk_types.Content(
+            role="model",
+            parts=[text_part, fc_part],
+        ),
+    )
+
+
+def _make_compaction_event(summary_text: str) -> ADKEvent:
+    event = MagicMock(spec=ADKEvent)
+    event.actions = MagicMock()
+    event.actions.compaction = {
+        "compacted_content": {
+            "parts": [{"text": summary_text}],
+        },
+    }
+    event.content = None
+    return event
+
+
+def _make_no_content_event() -> ADKEvent:
+    return ADKEvent(
+        invocation_id="inv-empty",
+        author="system",
+        content=None,
+    )
+
+
+# --- _filter_events_for_transfer ---
+
+
+class TestFilterEventsForTransfer:
+    def test_keeps_user_text_events(self):
+        events = [_make_text_event("user", "Hello")]
+        result = _filter_events_for_transfer(events)
+        assert len(result) == 1
+        assert result[0].content.parts[0].text == "Hello"
+
+    def test_keeps_model_text_events(self):
+        events = [_make_text_event("model", "Hi there", author="model")]
+        result = _filter_events_for_transfer(events)
+        assert len(result) == 1
+
+    def test_removes_function_call_only_events(self):
+        events = [_make_function_call_event()]
+        result = _filter_events_for_transfer(events)
+        assert len(result) == 0
+
+    def test_strips_function_call_parts_keeps_text(self):
+        events = [_make_mixed_event("Some text")]
+        result = _filter_events_for_transfer(events)
+        assert len(result) == 1
+        # Only text part should remain
+        assert len(result[0].content.parts) == 1
+        assert result[0].content.parts[0].text == "Some text"
+
+    def test_removes_no_content_events(self):
+        events = [_make_no_content_event()]
+        result = _filter_events_for_transfer(events)
+        assert len(result) == 0
+
+    def test_removes_non_user_model_roles(self):
+        event = ADKEvent(
+            invocation_id="inv-sys",
+            author="system",
+            content=adk_types.Content(
+                role="system",
+                parts=[adk_types.Part(text="System prompt")],
+            ),
+        )
+        result = _filter_events_for_transfer([event])
+        assert len(result) == 0
+
+    def test_keeps_compaction_events(self):
+        events = [_make_compaction_event("Summary")]
+        result = _filter_events_for_transfer(events)
+        assert len(result) == 1
+
+    def test_keeps_state_delta_event_with_text(self):
+        """Issue #1: state_delta events with text content should be kept."""
+        event = ADKEvent(
+            invocation_id="inv-sd",
+            author="model",
+            content=adk_types.Content(
+                role="model",
+                parts=[adk_types.Part(text="Some text alongside state delta")],
+            ),
+        )
+        event.actions = MagicMock()
+        event.actions.state_delta = {"key": "value"}
+        event.actions.compaction = None
+        result = _filter_events_for_transfer([event])
+        assert len(result) == 1
+        assert result[0].content.parts[0].text == "Some text alongside state delta"
+
+    def test_empty_events_list(self):
+        result = _filter_events_for_transfer([])
+        assert result == []
+
+    def test_mixed_events_ordering_preserved(self):
+        events = [
+            _make_text_event("user", "First"),
+            _make_function_call_event(),
+            _make_text_event("model", "Second", author="model"),
+            _make_no_content_event(),
+            _make_text_event("user", "Third"),
+        ]
+        result = _filter_events_for_transfer(events)
+        assert len(result) == 3
+        assert result[0].content.parts[0].text == "First"
+        assert result[1].content.parts[0].text == "Second"
+        assert result[2].content.parts[0].text == "Third"
+
+
+# --- extract_session_text_for_transfer ---
+
+
+class TestExtractSessionTextForTransfer:
+    def test_returns_none_for_no_session(self):
+        assert extract_session_text_for_transfer(None) is None
+
+    def test_returns_none_for_empty_events(self):
+        session = MagicMock()
+        session.events = []
+        assert extract_session_text_for_transfer(session) is None
+
+    def test_basic_transcript(self):
+        session = MagicMock()
+        session.events = [
+            _make_text_event("user", "What is 2+2?"),
+            _make_text_event("model", "4", author="model"),
+        ]
+        result = extract_session_text_for_transfer(session, source_agent_display_name="Math Agent")
+        assert result is not None
+        assert "User: What is 2+2?" in result
+        assert "Assistant: 4" in result
+        assert "[Context from previous conversation with Math Agent]" in result
+        assert "[End of previous context]" in result
+
+    def test_filters_out_tool_only_events(self):
+        session = MagicMock()
+        session.events = [
+            _make_text_event("user", "Hello"),
+            _make_function_call_event(),
+            _make_text_event("model", "Hi", author="model"),
+        ]
+        result = extract_session_text_for_transfer(session)
+        assert result is not None
+        assert "User: Hello" in result
+        assert "Assistant: Hi" in result
+        # No function call content should appear
+        assert "function" not in result.lower()
+
+    def test_includes_compaction_summary(self):
+        session = MagicMock()
+        session.events = [
+            _make_compaction_event("Earlier they discussed weather"),
+            _make_text_event("user", "Follow up question"),
+        ]
+        result = extract_session_text_for_transfer(session)
+        assert result is not None
+        assert "[Summary of earlier conversation]" in result
+        assert "Earlier they discussed weather" in result
+        assert "[Recent conversation]" in result
+        assert "User: Follow up question" in result
+
+    def test_returns_none_when_only_tool_events(self):
+        session = MagicMock()
+        session.events = [_make_function_call_event(), _make_no_content_event()]
+        assert extract_session_text_for_transfer(session) is None
+
+
+# --- transfer_session_context ---
+
+
+class TestTransferSessionContext:
+    @pytest.fixture
+    def mock_session_service(self):
+        service = MagicMock()
+        service.get_session = AsyncMock()
+        service.create_session = AsyncMock()
+        service.append_event = AsyncMock()
+        return service
+
+    @pytest.mark.asyncio
+    async def test_returns_false_when_no_source_session(self, mock_session_service):
+        mock_session_service.get_session.return_value = None
+        result = await transfer_session_context(
+            session_service=mock_session_service,
+            source_agent_name="agent-a",
+            target_agent_name="agent-b",
+            user_id="user1",
+            session_id="sess1",
+        )
+        assert result is False
+
+    @pytest.mark.asyncio
+    async def test_returns_false_when_source_has_no_events(self, mock_session_service):
+        source = MagicMock()
+        source.events = []
+        mock_session_service.get_session.return_value = source
+        result = await transfer_session_context(
+            session_service=mock_session_service,
+            source_agent_name="agent-a",
+            target_agent_name="agent-b",
+            user_id="user1",
+            session_id="sess1",
+        )
+        assert result is False
+
+    @pytest.mark.asyncio
+    async def test_returns_false_when_only_tool_events(self, mock_session_service):
+        source = MagicMock()
+        source.events = [_make_function_call_event()]
+        mock_session_service.get_session.return_value = source
+        result = await transfer_session_context(
+            session_service=mock_session_service,
+            source_agent_name="agent-a",
+            target_agent_name="agent-b",
+            user_id="user1",
+            session_id="sess1",
+        )
+        assert result is False
+
+    @pytest.mark.asyncio
+    async def test_successful_transfer(self, mock_session_service):
+        source = MagicMock()
+        source.events = [_make_text_event("user", "Hello")]
+        source.state = {}
+
+        target = MagicMock()
+        target.id = "sess1"
+        target.user_id = "user1"
+
+        # First call returns source, second returns target
+        mock_session_service.get_session.side_effect = [source, target]
+
+        mock_append = AsyncMock()
+        with pytest.MonkeyPatch.context() as mp:
+            mp.setattr(
+                "solace_agent_mesh.agent.adk.services.append_event_with_retry",
+                mock_append,
+            )
+            result = await transfer_session_context(
+                session_service=mock_session_service,
+                source_agent_name="agent-a",
+                target_agent_name="agent-b",
+                user_id="user1",
+                session_id="sess1",
+                source_agent_display_name="Agent A",
+            )
+        assert result is True
+
+        # First call is the context marker event
+        marker_call = mock_append.call_args_list[0]
+        marker_event = marker_call.kwargs.get("event") or marker_call[1].get("event")
+        assert "Agent A" in marker_event.content.parts[0].text
+
+        # Subsequent calls are the cloned source events
+        cloned_call = mock_append.call_args_list[1]
+        cloned_event = cloned_call.kwargs.get("event") or cloned_call[1].get("event")
+        assert cloned_event.content.parts[0].text == "Hello"
+
+    @pytest.mark.asyncio
+    async def test_creates_target_session_if_not_exists(self, mock_session_service):
+        source = MagicMock()
+        source.events = [_make_text_event("user", "Hello")]
+        source.state = {"key": "val", "compaction_time": 123}
+
+        new_target = MagicMock()
+        new_target.id = "sess1"
+        new_target.user_id = "user1"
+
+        # get_session: source found, target not found
+        mock_session_service.get_session.side_effect = [source, None]
+        mock_session_service.create_session.return_value = new_target
+
+        with pytest.MonkeyPatch.context() as mp:
+            mp.setattr(
+                "solace_agent_mesh.agent.adk.services.append_event_with_retry",
+                AsyncMock(),
+            )
+            result = await transfer_session_context(
+                session_service=mock_session_service,
+                source_agent_name="agent-a",
+                target_agent_name="agent-b",
+                user_id="user1",
+                session_id="sess1",
+            )
+
+        assert result is True
+        mock_session_service.create_session.assert_called_once()
+        create_kwargs = mock_session_service.create_session.call_args
+        passed_state = create_kwargs.kwargs.get("state") or create_kwargs[1].get("state")
+        assert passed_state == {"key": "val"}
+        assert "compaction_time" not in passed_state
+
+    @pytest.mark.asyncio
+    async def test_race_condition_create_falls_back_to_get(self, mock_session_service):
+        """Issue #9a: create_session raises, falls back to get_session."""
+        source = MagicMock()
+        source.events = [_make_text_event("user", "Hello")]
+        source.state = {}
+
+        target = MagicMock()
+        target.id = "sess1"
+        target.user_id = "user1"
+
+        # get_session: source found, target not found, then found on retry
+        mock_session_service.get_session.side_effect = [source, None, target]
+        mock_session_service.create_session.side_effect = RuntimeError("duplicate key")
+
+        with pytest.MonkeyPatch.context() as mp:
+            mp.setattr(
+                "solace_agent_mesh.agent.adk.services.append_event_with_retry",
+                AsyncMock(),
+            )
+            result = await transfer_session_context(
+                session_service=mock_session_service,
+                source_agent_name="agent-a",
+                target_agent_name="agent-b",
+                user_id="user1",
+                session_id="sess1",
+            )
+
+        assert result is True
+
+    @pytest.mark.asyncio
+    async def test_marker_event_failure_returns_false(self, mock_session_service):
+        """Issue #9b: append_event_with_retry raises on marker event."""
+        source = MagicMock()
+        source.events = [_make_text_event("user", "Hello")]
+        source.state = {}
+
+        target = MagicMock()
+        target.id = "sess1"
+        target.user_id = "user1"
+
+        mock_session_service.get_session.side_effect = [source, target]
+
+        mock_append = AsyncMock(side_effect=RuntimeError("DB error"))
+        with pytest.MonkeyPatch.context() as mp:
+            mp.setattr(
+                "solace_agent_mesh.agent.adk.services.append_event_with_retry",
+                mock_append,
+            )
+            result = await transfer_session_context(
+                session_service=mock_session_service,
+                source_agent_name="agent-a",
+                target_agent_name="agent-b",
+                user_id="user1",
+                session_id="sess1",
+            )
+
+        assert result is False
+
+
+# --- _extract_compaction_summary ---
+
+
+class TestExtractCompactionSummary:
+    def test_object_form_extraction(self):
+        """Issue #8: test object/attribute branch of _extract_compaction_summary."""
+        part = MagicMock()
+        part.text = "Summary from object form"
+
+        cc = MagicMock()
+        cc.parts = [part]
+
+        compaction = MagicMock()
+        compaction.compacted_content = cc
+
+        event = MagicMock()
+        event.actions = MagicMock()
+        event.actions.compaction = compaction
+
+        result = _extract_compaction_summary(event)
+        assert result == "Summary from object form"
+
+    def test_object_form_no_text(self):
+        part = MagicMock()
+        part.text = ""
+
+        cc = MagicMock()
+        cc.parts = [part]
+
+        compaction = MagicMock()
+        compaction.compacted_content = cc
+
+        event = MagicMock()
+        event.actions = MagicMock()
+        event.actions.compaction = compaction
+
+        result = _extract_compaction_summary(event)
+        assert result is None

--- a/tests/unit/gateway/http_sse/routers/test_sessions_transfer_context.py
+++ b/tests/unit/gateway/http_sse/routers/test_sessions_transfer_context.py
@@ -1,0 +1,404 @@
+"""Unit tests for POST /sessions/{session_id}/transfer-context endpoint and helpers."""
+
+import pytest
+from unittest.mock import AsyncMock, MagicMock, patch
+
+
+class TestResolveAgentDisplayName:
+    """Tests for _resolve_agent_display_name helper."""
+
+    def _make_registry(self, agent_card=None):
+        registry = MagicMock()
+        registry.get_agent.return_value = agent_card
+        return registry
+
+    def _make_card_with_display_name(self, display_name):
+        ext = MagicMock()
+        ext.uri = "https://solace.com/a2a/extensions/display-name"
+        ext.params = {"display_name": display_name}
+        card = MagicMock()
+        card.capabilities.extensions = [ext]
+        return card
+
+    def test_returns_display_name_from_extension(self):
+        with patch(
+            "solace_agent_mesh.gateway.http_sse.dependencies.get_sac_component",
+            return_value=MagicMock(),
+        ):
+            from solace_agent_mesh.gateway.http_sse.routers.sessions import (
+                _resolve_agent_display_name,
+            )
+
+        card = self._make_card_with_display_name("My Agent")
+        registry = self._make_registry(card)
+        assert _resolve_agent_display_name(registry, "my-agent") == "My Agent"
+
+    def test_falls_back_to_agent_name_when_no_extension(self):
+        with patch(
+            "solace_agent_mesh.gateway.http_sse.dependencies.get_sac_component",
+            return_value=MagicMock(),
+        ):
+            from solace_agent_mesh.gateway.http_sse.routers.sessions import (
+                _resolve_agent_display_name,
+            )
+
+        card = MagicMock()
+        card.capabilities.extensions = []
+        registry = self._make_registry(card)
+        assert _resolve_agent_display_name(registry, "my-agent") == "my-agent"
+
+    def test_falls_back_when_agent_not_found(self):
+        with patch(
+            "solace_agent_mesh.gateway.http_sse.dependencies.get_sac_component",
+            return_value=MagicMock(),
+        ):
+            from solace_agent_mesh.gateway.http_sse.routers.sessions import (
+                _resolve_agent_display_name,
+            )
+
+        registry = self._make_registry(None)
+        assert _resolve_agent_display_name(registry, "missing-agent") == "missing-agent"
+
+    def test_handles_no_capabilities(self):
+        with patch(
+            "solace_agent_mesh.gateway.http_sse.dependencies.get_sac_component",
+            return_value=MagicMock(),
+        ):
+            from solace_agent_mesh.gateway.http_sse.routers.sessions import (
+                _resolve_agent_display_name,
+            )
+
+        card = MagicMock()
+        card.capabilities = None
+        registry = self._make_registry(card)
+        assert _resolve_agent_display_name(registry, "my-agent") == "my-agent"
+
+
+def _mock_session_service_with_ownership(owns_session=True):
+    """Create a mock session service that simulates ownership check."""
+    service = MagicMock()
+    service.get_session_details.return_value = MagicMock() if owns_session else None
+    return service
+
+
+class TestTransferContextEndpoint:
+    """Tests for POST /sessions/{session_id}/transfer-context."""
+
+    @pytest.fixture
+    def mock_agent_registry(self):
+        registry = MagicMock()
+        registry.__contains__ = MagicMock(return_value=True)
+        registry.get_agent.return_value = MagicMock(capabilities=None)
+        return registry
+
+    @pytest.fixture
+    def mock_db(self):
+        return MagicMock()
+
+    @pytest.fixture
+    def mock_session_service(self):
+        return _mock_session_service_with_ownership(owns_session=True)
+
+    @pytest.mark.asyncio
+    async def test_same_source_and_target_returns_early(self, mock_agent_registry, mock_db, mock_session_service):
+        from fastapi import HTTPException
+
+        with patch(
+            "solace_agent_mesh.gateway.http_sse.dependencies.get_sac_component",
+            return_value=MagicMock(),
+        ):
+            from solace_agent_mesh.gateway.http_sse.routers.sessions import (
+                transfer_context,
+                TransferContextRequest,
+            )
+
+        request_body = TransferContextRequest(
+            source_agent_name="agent-a",
+            target_agent_name="agent-a",
+        )
+
+        result = await transfer_context(
+            session_id="sess-1",
+            request_body=request_body,
+            user={"id": "user1"},
+            db=mock_db,
+            session_service=mock_session_service,
+            adk_session_service=MagicMock(),
+            agent_registry=mock_agent_registry,
+        )
+
+        assert result.context_transferred is False
+        assert "same" in result.message.lower()
+
+    @pytest.mark.asyncio
+    async def test_unregistered_source_agent_returns_422(self, mock_agent_registry, mock_db, mock_session_service):
+        from fastapi import HTTPException
+
+        with patch(
+            "solace_agent_mesh.gateway.http_sse.dependencies.get_sac_component",
+            return_value=MagicMock(),
+        ):
+            from solace_agent_mesh.gateway.http_sse.routers.sessions import (
+                transfer_context,
+                TransferContextRequest,
+            )
+
+        # Source not in registry, target is
+        mock_agent_registry.__contains__ = MagicMock(
+            side_effect=lambda name: name != "bad-agent"
+        )
+
+        request_body = TransferContextRequest(
+            source_agent_name="bad-agent",
+            target_agent_name="agent-b",
+        )
+
+        with pytest.raises(HTTPException) as exc_info:
+            await transfer_context(
+                session_id="sess-1",
+                request_body=request_body,
+                user={"id": "user1"},
+                db=mock_db,
+                session_service=mock_session_service,
+                adk_session_service=MagicMock(),
+                agent_registry=mock_agent_registry,
+            )
+
+        assert exc_info.value.status_code == 422
+        assert "not registered" in exc_info.value.detail.lower()
+
+    @pytest.mark.asyncio
+    async def test_unregistered_target_agent_returns_422(self, mock_agent_registry, mock_db, mock_session_service):
+        from fastapi import HTTPException
+
+        with patch(
+            "solace_agent_mesh.gateway.http_sse.dependencies.get_sac_component",
+            return_value=MagicMock(),
+        ):
+            from solace_agent_mesh.gateway.http_sse.routers.sessions import (
+                transfer_context,
+                TransferContextRequest,
+            )
+
+        # Source is in registry, target is not
+        mock_agent_registry.__contains__ = MagicMock(
+            side_effect=lambda name: name != "bad-target"
+        )
+
+        request_body = TransferContextRequest(
+            source_agent_name="agent-a",
+            target_agent_name="bad-target",
+        )
+
+        with pytest.raises(HTTPException) as exc_info:
+            await transfer_context(
+                session_id="sess-1",
+                request_body=request_body,
+                user={"id": "user1"},
+                db=mock_db,
+                session_service=mock_session_service,
+                adk_session_service=MagicMock(),
+                agent_registry=mock_agent_registry,
+            )
+
+        assert exc_info.value.status_code == 422
+        assert "not registered" in exc_info.value.detail.lower()
+
+    @pytest.mark.asyncio
+    async def test_missing_adk_service_returns_unavailable(self, mock_agent_registry, mock_db, mock_session_service):
+        with patch(
+            "solace_agent_mesh.gateway.http_sse.dependencies.get_sac_component",
+            return_value=MagicMock(),
+        ):
+            from solace_agent_mesh.gateway.http_sse.routers.sessions import (
+                transfer_context,
+                TransferContextRequest,
+            )
+
+        request_body = TransferContextRequest(
+            source_agent_name="agent-a",
+            target_agent_name="agent-b",
+        )
+
+        result = await transfer_context(
+            session_id="sess-1",
+            request_body=request_body,
+            user={"id": "user1"},
+            db=mock_db,
+            session_service=mock_session_service,
+            adk_session_service=None,
+            agent_registry=mock_agent_registry,
+        )
+
+        assert result.context_transferred is False
+        assert "unavailable" in result.message.lower()
+
+    @pytest.mark.asyncio
+    async def test_invalid_session_id_returns_400(self, mock_agent_registry, mock_db, mock_session_service):
+        from fastapi import HTTPException
+
+        with patch(
+            "solace_agent_mesh.gateway.http_sse.dependencies.get_sac_component",
+            return_value=MagicMock(),
+        ):
+            from solace_agent_mesh.gateway.http_sse.routers.sessions import (
+                transfer_context,
+                TransferContextRequest,
+            )
+
+        request_body = TransferContextRequest(
+            source_agent_name="agent-a",
+            target_agent_name="agent-b",
+        )
+
+        for bad_id in ["", "null", "undefined", "   "]:
+            with pytest.raises(HTTPException) as exc_info:
+                await transfer_context(
+                    session_id=bad_id,
+                    request_body=request_body,
+                    user={"id": "user1"},
+                    db=mock_db,
+                    session_service=mock_session_service,
+                    adk_session_service=MagicMock(),
+                    agent_registry=mock_agent_registry,
+                )
+
+            assert exc_info.value.status_code == 400
+
+    @pytest.mark.asyncio
+    async def test_transfer_success_returns_true(self, mock_agent_registry, mock_db, mock_session_service):
+        with patch(
+            "solace_agent_mesh.gateway.http_sse.dependencies.get_sac_component",
+            return_value=MagicMock(),
+        ):
+            from solace_agent_mesh.gateway.http_sse.routers.sessions import (
+                transfer_context,
+                TransferContextRequest,
+            )
+
+        request_body = TransferContextRequest(
+            source_agent_name="agent-a",
+            target_agent_name="agent-b",
+        )
+
+        with patch(
+            "solace_agent_mesh.agent.adk.services.transfer_session_context",
+            new_callable=AsyncMock,
+            return_value=True,
+        ):
+            result = await transfer_context(
+                session_id="sess-1",
+                request_body=request_body,
+                user={"id": "user1"},
+                db=mock_db,
+                session_service=mock_session_service,
+                adk_session_service=MagicMock(),
+                agent_registry=mock_agent_registry,
+            )
+
+        assert result.context_transferred is True
+
+    @pytest.mark.asyncio
+    async def test_transfer_failure_returns_false(self, mock_agent_registry, mock_db, mock_session_service):
+        with patch(
+            "solace_agent_mesh.gateway.http_sse.dependencies.get_sac_component",
+            return_value=MagicMock(),
+        ):
+            from solace_agent_mesh.gateway.http_sse.routers.sessions import (
+                transfer_context,
+                TransferContextRequest,
+            )
+
+        request_body = TransferContextRequest(
+            source_agent_name="agent-a",
+            target_agent_name="agent-b",
+        )
+
+        with patch(
+            "solace_agent_mesh.agent.adk.services.transfer_session_context",
+            new_callable=AsyncMock,
+            return_value=False,
+        ):
+            result = await transfer_context(
+                session_id="sess-1",
+                request_body=request_body,
+                user={"id": "user1"},
+                db=mock_db,
+                session_service=mock_session_service,
+                adk_session_service=MagicMock(),
+                agent_registry=mock_agent_registry,
+            )
+
+        assert result.context_transferred is False
+        assert "no conversation context" in result.message.lower()
+
+    @pytest.mark.asyncio
+    async def test_session_not_owned_returns_404(self, mock_agent_registry, mock_db):
+        """Issue #10: session ownership check returns 404."""
+        from fastapi import HTTPException
+
+        with patch(
+            "solace_agent_mesh.gateway.http_sse.dependencies.get_sac_component",
+            return_value=MagicMock(),
+        ):
+            from solace_agent_mesh.gateway.http_sse.routers.sessions import (
+                transfer_context,
+                TransferContextRequest,
+            )
+
+        not_owned_service = _mock_session_service_with_ownership(owns_session=False)
+
+        request_body = TransferContextRequest(
+            source_agent_name="agent-a",
+            target_agent_name="agent-b",
+        )
+
+        with pytest.raises(HTTPException) as exc_info:
+            await transfer_context(
+                session_id="sess-1",
+                request_body=request_body,
+                user={"id": "user1"},
+                db=mock_db,
+                session_service=not_owned_service,
+                adk_session_service=MagicMock(),
+                agent_registry=mock_agent_registry,
+            )
+
+        assert exc_info.value.status_code == 404
+
+    @pytest.mark.asyncio
+    async def test_unexpected_error_returns_500(self, mock_agent_registry, mock_db, mock_session_service):
+        """Issue #10: RuntimeError from transfer_session_context returns 500."""
+        from fastapi import HTTPException
+
+        with patch(
+            "solace_agent_mesh.gateway.http_sse.dependencies.get_sac_component",
+            return_value=MagicMock(),
+        ):
+            from solace_agent_mesh.gateway.http_sse.routers.sessions import (
+                transfer_context,
+                TransferContextRequest,
+            )
+
+        request_body = TransferContextRequest(
+            source_agent_name="agent-a",
+            target_agent_name="agent-b",
+        )
+
+        with patch(
+            "solace_agent_mesh.agent.adk.services.transfer_session_context",
+            new_callable=AsyncMock,
+            side_effect=RuntimeError("unexpected failure"),
+        ):
+            with pytest.raises(HTTPException) as exc_info:
+                await transfer_context(
+                    session_id="sess-1",
+                    request_body=request_body,
+                    user={"id": "user1"},
+                    db=mock_db,
+                    session_service=mock_session_service,
+                    adk_session_service=MagicMock(),
+                    agent_registry=mock_agent_registry,
+                )
+
+        assert exc_info.value.status_code == 500


### PR DESCRIPTION
This pull request introduces cross-agent context transfer when switching agents mid-session in the chat UI, along with UI enhancements to indicate agent switches. The backend implements robust logic for extracting and transferring relevant conversation history between agents, while the frontend updates ensure a smooth user experience and visual feedback during agent changes.

**Cross-agent context transfer functionality:**

- Added `transfer_session_context` and supporting functions in `services.py` to extract, filter, and transfer conversation history between agents, preserving only user/model text and summaries while stripping tool-specific events. This enables seamless context handoff when a user switches agents in the same session.
- Implemented logic in the gateway component to lazily locate and provide access to the shared ADK session service, ensuring that context transfer works across all agents in the deployment. [[1]](diffhunk://#diff-c0dc5dfe164069e3fe9586ec25f99aed7c56b80e33f6ff2e417fdd8e86444b80R272-R274) [[2]](diffhunk://#diff-c0dc5dfe164069e3fe9586ec25f99aed7c56b80e33f6ff2e417fdd8e86444b80R2164-R2215)

**Frontend API and hooks updates:**

- Added `transferContext` API endpoint, request/response types, and the `useTransferContext` React hook to facilitate context transfer requests from the frontend. [[1]](diffhunk://#diff-4e249a3611190564de8b036cefa6f1f3ddad1adc7b2d685155c0e978c28a7943R15-R35) [[2]](diffhunk://#diff-e8f0e163ef3c81ae44aaf3bfb5b3437515d37ae7c7ab3c3a1581ecfadaf01d8aL2-R2) [[3]](diffhunk://#diff-e8f0e163ef3c81ae44aaf3bfb5b3437515d37ae7c7ab3c3a1581ecfadaf01d8aR38-R43)

**Agent selection and UI improvements:**

- Enhanced `useAgentSelection` to detect mid-session agent switches, trigger context transfer, and append a special agent switch indicator message to the chat. Prevents duplicate switches and ensures state consistency. [[1]](diffhunk://#diff-5afa99cdb99c1f52f4119485d62c5be3bf9e63c2c0c0795c19ff9f05f319826aL1-L15) [[2]](diffhunk://#diff-5afa99cdb99c1f52f4119485d62c5be3bf9e63c2c0c0795c19ff9f05f319826aL27-R85)
- Updated chat message rendering to display a divider-style message when an agent switch occurs, improving user awareness of the context change.
- Extended the `MessageFE` type to support an `isAgentSwitchIndicator` flag for special rendering of agent switch messages.