### PR TITLE
fix(security): strip wildcard CORS origin when credentials are enabled

### DIFF
--- a/examples/gateways/webhook_gateway_example.yaml
+++ b/examples/gateways/webhook_gateway_example.yaml
@@ -59,7 +59,7 @@ apps:
       # --- WebhookGatewayApp Specific Config ---
       webhook_server_host: "0.0.0.0" 
       webhook_server_port: 8088      
-      cors_allowed_origins: ["*"]    # Or specify origins like ["http://localhost:3000", "https://myfrontend.com"]
+      cors_allowed_origins: ["http://localhost:3000"]    # Specify allowed origins explicitly (avoid '*' with credentials)
 
       webhook_endpoints:
         # --- Endpoint 1: Simple JSON payload, no auth ---

--- a/src/solace_agent_mesh/gateway/http_sse/app.py
+++ b/src/solace_agent_mesh/gateway/http_sse/app.py
@@ -58,8 +58,8 @@ class WebUIBackendApp(BaseGatewayApp):
             "name": "cors_allowed_origins",
             "required": False,
             "type": "list",
-            "default": ["*"],
-            "description": "List of allowed origins for CORS requests.",
+            "default": [],
+            "description": "List of allowed origins for CORS requests. If empty, origins are auto-constructed from the server host/port. Avoid using '*' with credentials.",
         },
         {
             "name": "cors_allowed_origin_regex",

--- a/src/solace_agent_mesh/gateway/http_sse/component.py
+++ b/src/solace_agent_mesh/gateway/http_sse/component.py
@@ -121,7 +121,7 @@ class WebUIBackendComponent(BaseGatewayComponent):
             self.fastapi_port = self.get_config("fastapi_port", 8000)
             self.fastapi_https_port = self.get_config("fastapi_https_port", 8443)
             self.session_secret_key = self.get_config("session_secret_key")
-            self.cors_allowed_origins = self.get_config("cors_allowed_origins", ["*"])
+            self.cors_allowed_origins = self.get_config("cors_allowed_origins", [])
             self.cors_allowed_origin_regex = self.get_config("cors_allowed_origin_regex", "")
             self.ssl_keyfile = self.get_config("ssl_keyfile", "")
             self.ssl_certfile = self.get_config("ssl_certfile", "")

--- a/src/solace_agent_mesh/gateway/http_sse/main.py
+++ b/src/solace_agent_mesh/gateway/http_sse/main.py
@@ -282,8 +282,37 @@ def setup_dependencies(component: "WebUIBackendComponent"):
 
 
 def _setup_middleware(component: "WebUIBackendComponent") -> None:
-    allowed_origins = component.get_cors_origins()
+    allowed_origins = component.get_cors_origins().copy()
     cors_origin_regex = component.get_cors_origin_regex()
+
+    # Security: wildcard CORS with allow_credentials=True lets any website
+    # make authenticated cross-origin requests. Strip the wildcard and
+    # fall through to the auto-construction below.
+    if "*" in allowed_origins:
+        log.warning(
+            "CORS wildcard origin '*' detected with allow_credentials=True. "
+            "This is insecure — removing '*'. Set explicit origins in "
+            "cors_allowed_origins to suppress this warning."
+        )
+        allowed_origins = [o for o in allowed_origins if o != "*"]
+
+    # Auto-construct localhost origins when none are configured
+    if not allowed_origins and not cors_origin_regex:
+        host = getattr(component, "fastapi_host", "127.0.0.1")
+        port = getattr(component, "fastapi_port", 8000)
+        display_host = "localhost" if host == "127.0.0.1" else host
+        ssl_key = getattr(component, "ssl_keyfile", "")
+        ssl_cert = getattr(component, "ssl_certfile", "")
+        if ssl_key and ssl_cert:
+            https_port = getattr(component, "fastapi_https_port", 8443)
+            allowed_origins = [f"https://{display_host}:{https_port}"]
+        else:
+            allowed_origins = [f"http://{display_host}:{port}"]
+        log.info(
+            "No CORS origins configured — auto-constructed from server settings: %s",
+            allowed_origins,
+        )
+
     app.add_middleware(
         CORSMiddleware,
         allow_origins=allowed_origins,

--- a/src/solace_agent_mesh/services/platform/api/main.py
+++ b/src/solace_agent_mesh/services/platform/api/main.py
@@ -250,6 +250,17 @@ def _setup_middleware(component: "PlatformServiceComponent"):
     # Combine and deduplicate
     allowed_origins = list(set(auto_trusted_origins + configured_origins))
 
+    # Security: wildcard CORS with allow_credentials=True lets any website
+    # make authenticated cross-origin requests. Strip the wildcard; the
+    # auto-constructed origins above already provide safe defaults.
+    if "*" in allowed_origins:
+        log.warning(
+            "CORS wildcard origin '*' detected with allow_credentials=True. "
+            "This is insecure — removing '*'. Set explicit origins in "
+            "cors_allowed_origins to suppress this warning."
+        )
+        allowed_origins = [o for o in allowed_origins if o != "*"]
+
     # Get optional regex pattern for CORS origins (useful for local dev with dynamic ports)
     cors_origin_regex = component.get_cors_origin_regex()
 

--- a/src/solace_agent_mesh/services/platform/app.py
+++ b/src/solace_agent_mesh/services/platform/app.py
@@ -100,8 +100,8 @@ class PlatformServiceApp(SamAppBase):
             "name": "cors_allowed_origins",
             "required": False,
             "type": "list",
-            "default": ["*"],
-            "description": "List of allowed origins for CORS requests.",
+            "default": [],
+            "description": "List of allowed origins for CORS requests. If empty, origins are auto-constructed from the server host/port. Avoid using '*' with credentials.",
         },
         {
             "name": "cors_allowed_origin_regex",

--- a/src/solace_agent_mesh/services/platform/component.py
+++ b/src/solace_agent_mesh/services/platform/component.py
@@ -125,7 +125,7 @@ class PlatformServiceComponent(SamComponentBase):
             self.ssl_keyfile = self.get_config("ssl_keyfile", "")
             self.ssl_certfile = self.get_config("ssl_certfile", "")
             self.ssl_keyfile_password = self.get_config("ssl_keyfile_password", "")
-            self.cors_allowed_origins = self.get_config("cors_allowed_origins", ["*"])
+            self.cors_allowed_origins = self.get_config("cors_allowed_origins", [])
             self.cors_allowed_origin_regex = self.get_config("cors_allowed_origin_regex", "")
 
             # OAuth2 configuration (enterprise feature - defaults to community mode)

--- a/tests/integration/apis/platform/test_health_endpoint.py
+++ b/tests/integration/apis/platform/test_health_endpoint.py
@@ -35,7 +35,7 @@ class TestPlatformHealthEndpoint:
         mock_component = platform_api_client_factory.mock_component
         assert mock_component.namespace == "test_namespace"
         assert mock_component.get_config("frontend_use_authorization", False) is False
-        assert mock_component.get_cors_origins() == ["*"]
+        assert mock_component.get_cors_origins() == ["http://localhost:3000"]
 
     def test_factory_heartbeat_tracker_available(self, platform_api_client_factory):
         """Test that heartbeat tracker is available in mock component."""

--- a/tests/sam-test-infrastructure/src/sam_test_infrastructure/fastapi_service/platform_service_factory.py
+++ b/tests/sam-test-infrastructure/src/sam_test_infrastructure/fastapi_service/platform_service_factory.py
@@ -54,7 +54,7 @@ class PlatformServiceFactory:
             return config_values.get(key, default)
 
         mock_component.get_config.side_effect = mock_get_config
-        mock_component.get_cors_origins.return_value = ["*"]
+        mock_component.get_cors_origins.return_value = ["http://localhost:3000"]
         mock_component.service_id = service_id
         mock_component.log_identifier = f"[{service_id}]"
         mock_component.namespace = "test_namespace"

--- a/tests/sam-test-infrastructure/src/sam_test_infrastructure/fastapi_service/webui_backend_factory.py
+++ b/tests/sam-test-infrastructure/src/sam_test_infrastructure/fastapi_service/webui_backend_factory.py
@@ -69,7 +69,7 @@ class WebUIBackendFactory:
                 "frontend_redirect_url": "http://localhost:3000",
             }
         )
-        mock_component.get_cors_origins.return_value = ["*"]
+        mock_component.get_cors_origins.return_value = ["http://localhost:3000"]
         mock_component.get_cors_origin_regex.return_value = ""
         mock_session_manager = Mock(secret_key="test-secret-key")
         mock_session_manager.create_new_session_id.side_effect = (

--- a/tests/unit/gateway/http_sse/test_http_sse_component.py
+++ b/tests/unit/gateway/http_sse/test_http_sse_component.py
@@ -78,7 +78,7 @@ def mock_sql_component_config():
                 "fastapi_host": "127.0.0.1",
                 "fastapi_port": 8000,
                 "session_secret_key": "test_secret_key_12345",
-                "cors_allowed_origins": ["*"],
+                "cors_allowed_origins": ["http://localhost:3000"],
                 "session_service": {
                     "type": "sql",
                     "database_url": "sqlite:///test.db"

--- a/tests/unit/gateway/http_sse/test_http_sse_main.py
+++ b/tests/unit/gateway/http_sse/test_http_sse_main.py
@@ -456,3 +456,112 @@ class TestHealthCheck:
         response = await main.read_root()
         
         assert response["status"] == "A2A Web UI Backend is running"
+
+
+# ============================================================================
+# CORS Wildcard Security Tests
+# ============================================================================
+
+class TestCORSWildcardHandling:
+    """Test that wildcard CORS origins are handled securely."""
+
+    @pytest.fixture(autouse=True)
+    def mock_fastapi_app(self):
+        with patch("solace_agent_mesh.gateway.http_sse.main.app") as mock_app:
+            yield mock_app
+
+    @pytest.fixture(autouse=True)
+    def mock_oauth_middleware(self):
+        with patch(
+            "solace_agent_mesh.gateway.http_sse.main.create_oauth_middleware"
+        ):
+            yield
+
+    @pytest.fixture(autouse=True)
+    def mock_dependencies(self):
+        with patch(
+            "solace_agent_mesh.gateway.http_sse.main.dependencies"
+        ) as mock_deps:
+            mock_deps.get_api_config.return_value = {
+                "frontend_use_authorization": False
+            }
+            yield mock_deps
+
+    @pytest.fixture(autouse=True)
+    def mock_observability(self):
+        with patch(
+            "solace_agent_mesh.gateway.http_sse.main.GatewayObservabilityMiddleware",
+            create=True,
+        ):
+            # The import is inside the function, so patch the module attribute
+            with patch(
+                "solace_agent_mesh.gateway.http_sse.middleware.observability.GatewayObservabilityMiddleware",
+                create=True,
+            ):
+                yield
+
+    def _make_component(self, origins, host="127.0.0.1", port=8000):
+        comp = MagicMock()
+        comp.get_cors_origins.return_value = origins
+        comp.get_cors_origin_regex.return_value = ""
+        comp.fastapi_host = host
+        comp.fastapi_port = port
+        comp.fastapi_https_port = 8443
+        comp.ssl_keyfile = ""
+        comp.ssl_certfile = ""
+        comp.get_session_manager.return_value = MagicMock(
+            secret_key="test_secret"
+        )
+        comp.get_config.return_value = False
+        comp.identity_service = None
+        comp.log_identifier = "[test]"
+        return comp
+
+    def _get_cors_origins(self, mock_fastapi_app):
+        cors_call = mock_fastapi_app.add_middleware.call_args_list[0]
+        return cors_call[1]["allow_origins"]
+
+    def test_wildcard_origin_is_stripped(self, mock_fastapi_app):
+        """Wildcard '*' must not reach CORSMiddleware when credentials are enabled."""
+        component = self._make_component(["*"])
+        main._setup_middleware(component)
+        origins = self._get_cors_origins(mock_fastapi_app)
+        assert "*" not in origins
+
+    def test_wildcard_replaced_with_auto_constructed_origin(self, mock_fastapi_app):
+        """When '*' is stripped and no other origins remain, auto-construct from host/port."""
+        component = self._make_component(["*"])
+        main._setup_middleware(component)
+        origins = self._get_cors_origins(mock_fastapi_app)
+        assert "http://localhost:8000" in origins
+
+    def test_wildcard_stripped_but_explicit_origins_kept(self, mock_fastapi_app):
+        """Explicit origins survive when '*' is removed."""
+        component = self._make_component(["http://myapp.com", "*"])
+        main._setup_middleware(component)
+        origins = self._get_cors_origins(mock_fastapi_app)
+        assert "*" not in origins
+        assert "http://myapp.com" in origins
+
+    def test_empty_origins_auto_constructs(self, mock_fastapi_app):
+        """Empty origin list triggers auto-construction from server config."""
+        component = self._make_component([])
+        main._setup_middleware(component)
+        origins = self._get_cors_origins(mock_fastapi_app)
+        assert "http://localhost:8000" in origins
+
+    def test_auto_construct_uses_https_when_ssl_configured(self, mock_fastapi_app):
+        """Auto-construction picks HTTPS when SSL certs are present."""
+        component = self._make_component([])
+        component.ssl_keyfile = "/path/to/key.pem"
+        component.ssl_certfile = "/path/to/cert.pem"
+        main._setup_middleware(component)
+        origins = self._get_cors_origins(mock_fastapi_app)
+        assert "https://localhost:8443" in origins
+
+    def test_explicit_origins_not_modified(self, mock_fastapi_app):
+        """Explicit origins (no wildcard) pass through unchanged."""
+        component = self._make_component(["http://localhost:3000"])
+        main._setup_middleware(component)
+        origins = self._get_cors_origins(mock_fastapi_app)
+        assert origins == ["http://localhost:3000"]

--- a/tests/unit/services/platform/test_cors_auto_construction.py
+++ b/tests/unit/services/platform/test_cors_auto_construction.py
@@ -266,3 +266,31 @@ class TestPlatformServiceCorsAutoConstruction:
         cors_regex = _get_cors_origin_regex(mock_fastapi_app)
 
         assert cors_regex is None
+
+    def test_wildcard_origin_is_stripped(
+        self, mock_fastapi_app, mock_component, clean_env
+    ):
+        """Wildcard '*' must not reach CORSMiddleware when credentials are enabled."""
+        mock_component.get_cors_origins.return_value = ["*"]
+        clean_env.setenv("FASTAPI_HOST", "127.0.0.1")
+        clean_env.setenv("FASTAPI_PORT", "8000")
+
+        _setup_middleware(mock_component)
+
+        allowed_origins = _get_cors_allowed_origins(mock_fastapi_app)
+
+        assert "*" not in allowed_origins
+
+    def test_wildcard_stripped_with_auto_constructed_origins_present(
+        self, mock_fastapi_app, mock_component, clean_env
+    ):
+        """Auto-constructed origins remain after wildcard is stripped."""
+        mock_component.get_cors_origins.return_value = ["*"]
+        clean_env.setenv("FASTAPI_HOST", "127.0.0.1")
+        clean_env.setenv("FASTAPI_PORT", "8000")
+
+        _setup_middleware(mock_component)
+
+        allowed_origins = _get_cors_allowed_origins(mock_fastapi_app)
+
+        assert "http://localhost:8000" in allowed_origins


### PR DESCRIPTION
## Summary

CORS is configured with `allow_credentials=True` across the WebUI Gateway and Platform Service. When `allow_origins` contains `"*"`, Starlette's `CORSMiddleware` reflects the request's `Origin` header in the response — effectively allowing **any website** to make authenticated cross-origin requests (session cookies, tokens). This is [CWE-942](https://cwe.mitre.org/data/definitions/942.html).

This PR:
- **Detects and strips `"*"`** from `allow_origins` at middleware setup time in both the WebUI Gateway and Platform Service, with a clear warning log explaining the issue and how to suppress it
- **Auto-constructs safe localhost origins** from the component's configured `host`/`port` when no origins remain (matching the existing Platform Service auto-construction pattern)
- **Changes the code default** for `cors_allowed_origins` from `["*"]` to `[]` — YAML templates already set explicit origins (`http://localhost:3000`, etc.), so this only affects unconfigured deployments
- **Updates the webhook gateway example** to use explicit origins instead of `"*"`
- **Adds 8 new unit tests** covering wildcard stripping, auto-construction (HTTP + HTTPS), and pass-through of explicit origins
- **Updates test factories** to use explicit origins instead of wildcard

### Files changed

| File | Change |
|------|--------|
| `src/.../gateway/http_sse/main.py` | Wildcard detection + auto-construction in `_setup_middleware` |
| `src/.../services/platform/api/main.py` | Wildcard detection in `_setup_middleware` |
| `src/.../gateway/http_sse/component.py` | Default `["*"]` → `[]` |
| `src/.../services/platform/component.py` | Default `["*"]` → `[]` |
| `src/.../gateway/http_sse/app.py` | Schema default + description |
| `src/.../services/platform/app.py` | Schema default + description |
| `examples/gateways/webhook_gateway_example.yaml` | Explicit origin in example |
| `tests/unit/.../test_http_sse_main.py` | 6 new tests for WebUI CORS handling |
| `tests/unit/.../test_cors_auto_construction.py` | 2 new tests for Platform CORS handling |
| 3 test infrastructure files | Updated mock origins |

### Backward compatibility

- Deployments using `sam init` (YAML templates) are **unaffected** — templates already set explicit origins
- Deployments with explicit `cors_allowed_origins` config are **unaffected**
- Deployments relying on the `["*"]` code default will now get auto-constructed localhost origins instead, with a warning log. This is a security improvement, not a regression

## Test plan

- [x] 6 new WebUI CORS tests pass (`TestCORSWildcardHandling`)
- [x] 2 new Platform CORS tests pass
- [x] All 13 existing Platform CORS auto-construction tests still pass
- [x] All existing WebUI main tests still pass
- [ ] Manual: run `sam init && sam run` and verify the Web UI at `http://localhost:8000` works (CORS headers should show the auto-constructed origin, not `*`)
- [ ] Manual: set `cors_allowed_origins: ["*"]` in webui.yaml and verify the warning log appears at startup