### PR TITLE
feat(DATAGO-128300[2]): Add DB observability to sharing and project repositories

### DIFF
--- a/src/solace_agent_mesh/gateway/http_sse/repository/document_conversion_cache_repository.py
+++ b/src/solace_agent_mesh/gateway/http_sse/repository/document_conversion_cache_repository.py
@@ -11,6 +11,7 @@ from typing import Optional
 from sqlalchemy import func
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session as DBSession
+from solace_ai_connector.common.observability import DBMonitor, MonitorLatency
 
 from .models.document_conversion_cache_model import DocumentConversionCacheModel
 from solace_agent_mesh.shared.utils.timestamp_utils import now_epoch_ms
@@ -45,24 +46,26 @@ class DocumentConversionCacheRepository:
         Returns:
             Cached PDF bytes, or None if not cached
         """
-        entry = db.query(DocumentConversionCacheModel).filter(
-            DocumentConversionCacheModel.content_hash == content_hash,
-            DocumentConversionCacheModel.file_extension == file_extension,
-        ).first()
-        
+        with MonitorLatency(DBMonitor.query("document_conversion_cache")):
+            entry = db.query(DocumentConversionCacheModel).filter(
+                DocumentConversionCacheModel.content_hash == content_hash,
+                DocumentConversionCacheModel.file_extension == file_extension,
+            ).first()
+
         if entry:
             # Get the PDF data before updating stats
             pdf_data = entry.pdf_data
             pdf_size = entry.pdf_size_bytes
-            
+
             # Update access stats atomically using SQL increment
             # This prevents race conditions where concurrent reads could lose count updates
-            db.query(DocumentConversionCacheModel).filter(
-                DocumentConversionCacheModel.id == entry.id
-            ).update({
-                "last_accessed_at": now_epoch_ms(),
-                "access_count": DocumentConversionCacheModel.access_count + 1,
-            })
+            with MonitorLatency(DBMonitor.update("document_conversion_cache")):
+                db.query(DocumentConversionCacheModel).filter(
+                    DocumentConversionCacheModel.id == entry.id
+                ).update({
+                    "last_accessed_at": now_epoch_ms(),
+                    "access_count": DocumentConversionCacheModel.access_count + 1,
+                })
             
             log.debug(
                 "%s Cache HIT for %s.%s (size: %d bytes)",
@@ -120,9 +123,10 @@ class DocumentConversionCacheRepository:
         )
         
         try:
-            db.add(entry)
-            db.flush()  # Trigger constraint check
-            
+            with MonitorLatency(DBMonitor.insert("document_conversion_cache")):
+                db.add(entry)
+                db.flush()  # Trigger constraint check
+
             log.info(
                 "%s Cached PDF for %s.%s (original: %d bytes, pdf: %d bytes)",
                 self.log_identifier,
@@ -132,7 +136,6 @@ class DocumentConversionCacheRepository:
                 len(pdf_data),
             )
             return True
-            
         except IntegrityError:
             # Another request already cached this document (race condition)
             # This is expected and not an error
@@ -145,6 +148,7 @@ class DocumentConversionCacheRepository:
             )
             return False
 
+    @MonitorLatency(DBMonitor.delete("document_conversion_cache"))
     def delete_cached_pdf(
         self,
         db: DBSession,
@@ -153,12 +157,12 @@ class DocumentConversionCacheRepository:
     ) -> bool:
         """
         Delete a cached PDF entry.
-        
+
         Args:
             db: Database session
             content_hash: SHA-256 hex digest of the original document content
             file_extension: File extension (docx, pptx, etc.)
-            
+
         Returns:
             True if deleted, False if not found
         """
@@ -166,7 +170,7 @@ class DocumentConversionCacheRepository:
             DocumentConversionCacheModel.content_hash == content_hash,
             DocumentConversionCacheModel.file_extension == file_extension,
         ).delete()
-        
+
         if deleted > 0:
             log.debug(
                 "%s Deleted cache entry for %s.%s",
@@ -177,6 +181,7 @@ class DocumentConversionCacheRepository:
         
         return deleted > 0
 
+    @MonitorLatency(DBMonitor.delete("document_conversion_cache"))
     def cleanup_old_entries(
         self,
         db: DBSession,
@@ -184,20 +189,16 @@ class DocumentConversionCacheRepository:
     ) -> int:
         """
         Delete cache entries not accessed since the specified time.
-        
         This implements LRU-like cleanup based on last_accessed_at timestamp.
-        
         Args:
             db: Database session
             older_than_ms: Delete entries with last_accessed_at before this epoch time (ms)
-            
         Returns:
             Number of entries deleted
         """
         deleted = db.query(DocumentConversionCacheModel).filter(
             DocumentConversionCacheModel.last_accessed_at < older_than_ms
         ).delete()
-        
         if deleted > 0:
             log.info(
                 "%s Cleaned up %d old cache entries (older than %d ms)",
@@ -208,6 +209,7 @@ class DocumentConversionCacheRepository:
         
         return deleted
 
+    @MonitorLatency(DBMonitor.query("document_conversion_cache"))
     def get_stats(self, db: DBSession) -> dict:
         """
         Get cache statistics.
@@ -230,7 +232,7 @@ class DocumentConversionCacheRepository:
             func.min(DocumentConversionCacheModel.last_accessed_at),
             func.max(DocumentConversionCacheModel.last_accessed_at),
         ).first()
-        
+
         return {
             "cached_conversions": stats[0] or 0,
             "total_cached_bytes": stats[1] or 0,
@@ -239,13 +241,12 @@ class DocumentConversionCacheRepository:
             "newest_entry_ms": stats[4],
         }
 
+    @MonitorLatency(DBMonitor.query("document_conversion_cache"))
     def get_entry_count(self, db: DBSession) -> int:
         """
         Get the number of cached entries.
-        
         Args:
             db: Database session
-            
         Returns:
             Number of cached entries
         """

--- a/src/solace_agent_mesh/gateway/http_sse/repository/project_repository.py
+++ b/src/solace_agent_mesh/gateway/http_sse/repository/project_repository.py
@@ -7,6 +7,7 @@ import uuid
 from sqlalchemy.orm import Session as DBSession
 from sqlalchemy import or_
 from sqlalchemy.exc import IntegrityError
+from solace_ai_connector.common.observability import DBMonitor, MonitorLatency
 
 from .interfaces import IProjectRepository
 from .models import ProjectModel
@@ -28,11 +29,13 @@ class ProjectRepository(IProjectRepository):
 
     def get_pinned_project_ids_for_user(self, user_id: str) -> set[str]:
         """Return the set of project IDs that *user_id* has pinned."""
-        rows = (
-            self.db.query(ProjectUserPinModel.project_id)
-            .filter(ProjectUserPinModel.user_id == user_id)
-            .all()
-        )
+        with MonitorLatency(DBMonitor.query("project_user_pins")):
+            rows = (
+                self.db.query(ProjectUserPinModel.project_id)
+                .filter(ProjectUserPinModel.user_id == user_id)
+                .all()
+            )
+
         return {row[0] for row in rows}
 
     def toggle_user_pin(self, project_id: str, user_id: str) -> bool:
@@ -41,17 +44,20 @@ class ProjectRepository(IProjectRepository):
 
         Returns the **new** pinned state (True = now pinned, False = now unpinned).
         """
-        existing = (
-            self.db.query(ProjectUserPinModel)
-            .filter(
-                ProjectUserPinModel.project_id == project_id,
-                ProjectUserPinModel.user_id == user_id,
+        with MonitorLatency(DBMonitor.query("project_user_pins")):
+            existing = (
+                self.db.query(ProjectUserPinModel)
+                .filter(
+                    ProjectUserPinModel.project_id == project_id,
+                    ProjectUserPinModel.user_id == user_id,
+                )
+                .first()
             )
-            .first()
-        )
+
         if existing:
-            self.db.delete(existing)
-            self.db.flush()
+            with MonitorLatency(DBMonitor.delete("project_user_pins")):
+                self.db.delete(existing)
+                self.db.flush()
             return False
 
         pin = ProjectUserPinModel(
@@ -62,8 +68,9 @@ class ProjectRepository(IProjectRepository):
         )
         savepoint = self.db.begin_nested()
         try:
-            self.db.add(pin)
-            self.db.flush()
+            with MonitorLatency(DBMonitor.insert("project_user_pins")):
+                self.db.add(pin)
+                self.db.flush()
         except IntegrityError:
             # Concurrent insert won the race — rollback only to savepoint
             savepoint.rollback()
@@ -73,19 +80,23 @@ class ProjectRepository(IProjectRepository):
 
     def is_pinned_by_user(self, project_id: str, user_id: str) -> bool:
         """Return True if *user_id* has pinned *project_id*."""
-        return (
-            self.db.query(ProjectUserPinModel)
-            .filter(
-                ProjectUserPinModel.project_id == project_id,
-                ProjectUserPinModel.user_id == user_id,
+        with MonitorLatency(DBMonitor.query("project_user_pins")):
+            result = (
+                self.db.query(ProjectUserPinModel)
+                .filter(
+                    ProjectUserPinModel.project_id == project_id,
+                    ProjectUserPinModel.user_id == user_id,
+                )
+                .first()
             )
-            .first()
-        ) is not None
+
+        return result is not None
 
     # ------------------------------------------------------------------
     # Core project CRUD
     # ------------------------------------------------------------------
 
+    @MonitorLatency(DBMonitor.insert("projects"))
     def create_project(self, name: str, user_id: str, description: Optional[str] = None,
                        system_prompt: Optional[str] = None, default_agent_id: Optional[str] = None) -> Project:
         """Create a new user project."""
@@ -101,6 +112,7 @@ class ProjectRepository(IProjectRepository):
         self.db.add(model)
         self.db.flush()
         self.db.refresh(model)
+
         return self._model_to_entity(model)
 
     def get_accessible_projects(
@@ -128,37 +140,39 @@ class ProjectRepository(IProjectRepository):
         # SQLite parameter limit: 999, UUID ~40 chars, keep query under 100KB
         MAX_IN_CLAUSE = 500
 
-        if not shared_project_ids:
-            models = query.filter(ProjectModel.user_id == user_email).all()
-        elif len(shared_project_ids) <= MAX_IN_CLAUSE:
-            # Single query for normal case
-            models = query.filter(
-                or_(
-                    ProjectModel.user_id == user_email,
-                    ProjectModel.id.in_(shared_project_ids)
-                )
-            ).all()
-        else:
-            # Batch for large share lists
-            all_models = []
+        with MonitorLatency(DBMonitor.query("projects")):
+            if not shared_project_ids:
+                models = query.filter(ProjectModel.user_id == user_email).all()
+            elif len(shared_project_ids) <= MAX_IN_CLAUSE:
+                # Single query for normal case
+                models = query.filter(
+                    or_(
+                        ProjectModel.user_id == user_email,
+                        ProjectModel.id.in_(shared_project_ids)
+                    )
+                ).all()
+            else:
+                # Batch for large share lists
+                all_models = []
 
-            owned_models = query.filter(ProjectModel.user_id == user_email).all()
-            all_models.extend(owned_models)
+                owned_models = query.filter(ProjectModel.user_id == user_email).all()
+                all_models.extend(owned_models)
 
-            for i in range(0, len(shared_project_ids), MAX_IN_CLAUSE):
-                batch = shared_project_ids[i:i + MAX_IN_CLAUSE]
-                shared_models = query.filter(ProjectModel.id.in_(batch)).all()
-                all_models.extend(shared_models)
+                for i in range(0, len(shared_project_ids), MAX_IN_CLAUSE):
+                    batch = shared_project_ids[i:i + MAX_IN_CLAUSE]
+                    shared_models = query.filter(ProjectModel.id.in_(batch)).all()
+                    all_models.extend(shared_models)
 
-            seen = set()
-            models = []
-            for model in all_models:
-                if model.id not in seen:
-                    seen.add(model.id)
-                    models.append(model)
+                seen = set()
+                models = []
+                for model in all_models:
+                    if model.id not in seen:
+                        seen.add(model.id)
+                        models.append(model)
 
         return [self._model_to_entity(model, pinned_project_ids) for model in models]
 
+    @MonitorLatency(DBMonitor.query("projects"))
     def get_all_projects(self, pinned_project_ids: Optional[set[str]] = None) -> List[Project]:
         """
         Get all projects.
@@ -185,9 +199,12 @@ class ProjectRepository(IProjectRepository):
         if project_filter.user_id is not None:
             query = query.filter(ProjectModel.user_id == project_filter.user_id)
 
-        models = query.all()
+        with MonitorLatency(DBMonitor.query("projects")):
+            models = query.all()
+
         return [self._model_to_entity(model, pinned_project_ids) for model in models]
 
+    @MonitorLatency(DBMonitor.query("projects"))
     def get_by_id(self, project_id: str) -> Optional[Project]:
         """
         Get a project by its ID.
@@ -196,22 +213,26 @@ class ProjectRepository(IProjectRepository):
             ProjectModel.id == project_id,
             ProjectModel.deleted_at.is_(None)  # Exclude soft-deleted projects
         ).first()
+
         return self._model_to_entity(model) if model else None
 
     def get_by_id_for_user(self, project_id: str, user_id: str) -> Optional[Project]:
         """
         Get a project by its ID and resolve the per-user pin state.
         """
-        model = self.db.query(ProjectModel).filter(
-            ProjectModel.id == project_id,
-            ProjectModel.deleted_at.is_(None),
-        ).first()
+        with MonitorLatency(DBMonitor.query("projects")):
+            model = self.db.query(ProjectModel).filter(
+                ProjectModel.id == project_id,
+                ProjectModel.deleted_at.is_(None),
+            ).first()
+
         if not model:
             return None
         is_pinned = self.is_pinned_by_user(project_id, user_id)
         pinned_ids = {project_id} if is_pinned else set()
         return self._model_to_entity(model, pinned_ids)
 
+    @MonitorLatency(DBMonitor.update("projects"))
     def update(self, project_id: str, update_data: dict) -> Optional[Project]:
         """Update a project with the given data."""
         # First, find the project
@@ -232,6 +253,7 @@ class ProjectRepository(IProjectRepository):
         self.db.refresh(model)
         return self._model_to_entity(model)
 
+    @MonitorLatency(DBMonitor.delete("projects"))
     def delete(self, project_id: str) -> bool:
         """Delete a project by its ID (hard delete). Also removes all per-user pin records."""
         # Clean up pin records first to avoid orphaned rows
@@ -243,27 +265,33 @@ class ProjectRepository(IProjectRepository):
             ProjectModel.id == project_id
         ).delete()
         self.db.flush()
+
         return result > 0
 
     def soft_delete(self, project_id: str, deleted_by_user_id: str) -> bool:
         """Soft delete a project by its ID. Also removes all per-user pin records."""
-        model = self.db.query(ProjectModel).filter(
-            ProjectModel.id == project_id,
-            ProjectModel.deleted_at.is_(None)  # Only delete if not already deleted
-        ).first()
+        with MonitorLatency(DBMonitor.query("projects")):
+            model = self.db.query(ProjectModel).filter(
+                ProjectModel.id == project_id,
+                ProjectModel.deleted_at.is_(None)  # Only delete if not already deleted
+            ).first()
 
-        if not model:
-            return False
+            if not model:
+                return False
 
-        # Clean up pin records — deleted projects should not appear pinned for anyone
-        self.db.query(ProjectUserPinModel).filter(
-            ProjectUserPinModel.project_id == project_id
-        ).delete(synchronize_session=False)
+        with MonitorLatency(DBMonitor.delete("projects")):
+            # Clean up pin records — deleted projects should not appear pinned for anyone
+            self.db.query(ProjectUserPinModel).filter(
+                ProjectUserPinModel.project_id == project_id
+            ).delete(synchronize_session=False)
 
         model.deleted_at = now_epoch_ms()
         model.deleted_by = deleted_by_user_id
         model.updated_at = now_epoch_ms()
-        self.db.flush()
+
+        with MonitorLatency(DBMonitor.update("projects")):
+            self.db.flush()
+
         return True
 
     def _model_to_entity(

--- a/src/solace_agent_mesh/gateway/http_sse/repository/project_user_repository.py
+++ b/src/solace_agent_mesh/gateway/http_sse/repository/project_user_repository.py
@@ -5,6 +5,7 @@ from typing import List, Optional
 import uuid
 
 from sqlalchemy.orm import Session as DBSession
+from solace_ai_connector.common.observability import DBMonitor, MonitorLatency
 
 from .models import ProjectUserModel
 from .entities.project_user import ProjectUser
@@ -36,47 +37,53 @@ class ProjectUserRepository:
         Returns:
             ProjectUser: The created project user access record
         """
-        model = ProjectUserModel(
-            id=str(uuid.uuid4()),
-            project_id=project_id,
-            user_id=user_id,
-            role=role,
-            added_at=now_epoch_ms(),
-            added_by_user_id=added_by_user_id,
-        )
-        self.db.add(model)
-        self.db.commit()
-        self.db.refresh(model)
+        with MonitorLatency(DBMonitor.insert("project_users")):
+            model = ProjectUserModel(
+                id=str(uuid.uuid4()),
+                project_id=project_id,
+                user_id=user_id,
+                role=role,
+                added_at=now_epoch_ms(),
+                added_by_user_id=added_by_user_id,
+            )
+            self.db.add(model)
+            self.db.commit()
+            self.db.refresh(model)
+
         return self._model_to_entity(model)
 
+    @MonitorLatency(DBMonitor.query("project_users"))
     def get_project_users(self, project_id: str) -> List[ProjectUser]:
         """
         Get all users who have access to a project.
-        
+
         Args:
             project_id: The project ID
-            
+
         Returns:
             List[ProjectUser]: List of users with access to the project
         """
         models = self.db.query(ProjectUserModel).filter(
             ProjectUserModel.project_id == project_id
         ).all()
+
         return [self._model_to_entity(model) for model in models]
 
+    @MonitorLatency(DBMonitor.query("project_users"))
     def get_user_projects_access(self, user_id: str) -> List[ProjectUser]:
         """
         Get all projects a user has access to.
-        
+
         Args:
             user_id: The user ID
-            
+
         Returns:
             List[ProjectUser]: List of project access records for the user
         """
         models = self.db.query(ProjectUserModel).filter(
             ProjectUserModel.user_id == user_id
         ).all()
+
         return [self._model_to_entity(model) for model in models]
 
     def get_user_project_access(
@@ -94,11 +101,12 @@ class ProjectUserRepository:
         Returns:
             Optional[ProjectUser]: The access record if found, None otherwise
         """
-        model = self.db.query(ProjectUserModel).filter(
-            ProjectUserModel.project_id == project_id,
-            ProjectUserModel.user_id == user_id
-        ).first()
-        
+        with MonitorLatency(DBMonitor.query("project_users")):
+            model = self.db.query(ProjectUserModel).filter(
+                ProjectUserModel.project_id == project_id,
+                ProjectUserModel.user_id == user_id
+            ).first()
+
         return self._model_to_entity(model) if model else None
 
     def update_user_role(
@@ -118,17 +126,19 @@ class ProjectUserRepository:
         Returns:
             Optional[ProjectUser]: The updated access record if found, None otherwise
         """
-        model = self.db.query(ProjectUserModel).filter(
-            ProjectUserModel.project_id == project_id,
-            ProjectUserModel.user_id == user_id
-        ).first()
-        
-        if not model:
-            return None
-        
-        model.role = new_role
-        self.db.commit()
-        self.db.refresh(model)
+        with MonitorLatency(DBMonitor.update("project_users")):
+            model = self.db.query(ProjectUserModel).filter(
+                ProjectUserModel.project_id == project_id,
+                ProjectUserModel.user_id == user_id
+            ).first()
+
+            if not model:
+                return None
+
+            model.role = new_role
+            self.db.commit()
+            self.db.refresh(model)
+
         return self._model_to_entity(model)
 
     def remove_user_from_project(
@@ -146,13 +156,16 @@ class ProjectUserRepository:
         Returns:
             bool: True if removed successfully, False otherwise
         """
-        result = self.db.query(ProjectUserModel).filter(
-            ProjectUserModel.project_id == project_id,
-            ProjectUserModel.user_id == user_id
-        ).delete()
-        self.db.commit()
+        with MonitorLatency(DBMonitor.delete("project_users")):
+            result = self.db.query(ProjectUserModel).filter(
+                ProjectUserModel.project_id == project_id,
+                ProjectUserModel.user_id == user_id
+            ).delete()
+            self.db.commit()
+
         return result > 0
 
+    @MonitorLatency(DBMonitor.query("project_users"))
     def user_has_access(
         self,
         project_id: str,
@@ -160,11 +173,11 @@ class ProjectUserRepository:
     ) -> bool:
         """
         Check if a user has access to a project.
-        
+
         Args:
             project_id: The project ID
             user_id: The user ID
-            
+
         Returns:
             bool: True if user has access, False otherwise
         """
@@ -172,6 +185,7 @@ class ProjectUserRepository:
             ProjectUserModel.project_id == project_id,
             ProjectUserModel.user_id == user_id
         ).count()
+
         return count > 0
 
     def _model_to_entity(self, model: ProjectUserModel) -> ProjectUser:

--- a/src/solace_agent_mesh/gateway/http_sse/repository/session_repository.py
+++ b/src/solace_agent_mesh/gateway/http_sse/repository/session_repository.py
@@ -174,13 +174,13 @@ class SessionRepository(PaginatedRepository[SessionModel, Session], ISessionRepo
                 .first()
             )
 
-            if not session_model:
-                return False
+        if not session_model:
+            return False
 
-            # Perform soft delete
-            session_model.deleted_at = now_epoch_ms()
-            session_model.deleted_by = user_id
-            session_model.updated_time = now_epoch_ms()
+        # Perform soft delete
+        session_model.deleted_at = now_epoch_ms()
+        session_model.deleted_by = user_id
+        session_model.updated_time = now_epoch_ms()
         with MonitorLatency(DBMonitor.update(self.table_name)):
             db_session.flush()
 
@@ -190,19 +190,16 @@ class SessionRepository(PaginatedRepository[SessionModel, Session], ISessionRepo
         """
         Soft delete all sessions belonging to a specific project.
         Used when cascading project deletion.
-        
         Args:
             db_session: Database session
             project_id: The project ID
             user_id: The user ID (for deleted_by tracking)
-            
         Returns:
             int: Number of sessions soft deleted
         """
-        with MonitorLatency(DBMonitor.update(self.table_name)):
-            now = now_epoch_ms()
-
-            # Find all non-deleted sessions for this project
+        now = now_epoch_ms()
+        # Find all non-deleted sessions for this project
+        with MonitorLatency(DBMonitor.query(self.table_name)):
             sessions_to_delete = (
                 db_session.query(SessionModel)
                 .filter(
@@ -213,12 +210,13 @@ class SessionRepository(PaginatedRepository[SessionModel, Session], ISessionRepo
                 .all()
             )
 
-            # Soft delete each session
-            for session_model in sessions_to_delete:
-                session_model.deleted_at = now
-                session_model.deleted_by = user_id
-                session_model.updated_time = now
+        # Soft delete each session
+        for session_model in sessions_to_delete:
+            session_model.deleted_at = now
+            session_model.deleted_by = user_id
+            session_model.updated_time = now
 
+        with MonitorLatency(DBMonitor.update(self.table_name)):
             db_session.flush()
 
         return len(sessions_to_delete)

--- a/src/solace_agent_mesh/gateway/http_sse/repository/share_repository.py
+++ b/src/solace_agent_mesh/gateway/http_sse/repository/share_repository.py
@@ -8,6 +8,7 @@ import uuid
 from typing import Optional, List
 from sqlalchemy.orm import Session as DBSession
 from sqlalchemy import and_, or_, func
+from solace_ai_connector.common.observability import DBMonitor, MonitorLatency
 
 from .models.share_model import SharedLinkModel, SharedArtifactModel, SharedLinkUserModel
 from .entities.share import ShareLink, SharedArtifact, SharedLinkUser
@@ -20,14 +21,15 @@ log = logging.getLogger(__name__)
 class ShareRepository:
     """Repository for share link operations."""
 
+    @MonitorLatency(DBMonitor.query("shared_links"))
     def find_by_share_id(self, db: DBSession, share_id: str) -> Optional[ShareLink]:
         """
         Find a share link by its share ID.
-        
+
         Args:
             db: Database session
             share_id: Share ID to find
-        
+
         Returns:
             ShareLink entity or None if not found
         """
@@ -37,21 +39,22 @@ class ShareRepository:
                 SharedLinkModel.deleted_at.is_(None)
             )
         ).first()
-        
+
         if not model:
             return None
-        
+
         return ShareLink.model_validate(model)
 
+    @MonitorLatency(DBMonitor.query("shared_links"))
     def find_by_session_id(self, db: DBSession, session_id: str, user_id: str) -> Optional[ShareLink]:
         """
         Find a share link for a specific session and user.
-        
+
         Args:
             db: Database session
             session_id: Session ID
             user_id: User ID (owner)
-        
+
         Returns:
             ShareLink entity or None if not found
         """
@@ -62,10 +65,10 @@ class ShareRepository:
                 SharedLinkModel.deleted_at.is_(None)
             )
         ).first()
-        
+
         if not model:
             return None
-        
+
         return ShareLink.model_validate(model)
 
     def find_by_user(
@@ -105,19 +108,21 @@ class ShareRepository:
         query = query.order_by(SharedLinkModel.created_time.desc())
         query = query.offset(pagination.offset)
         query = query.limit(pagination.page_size)
-        
-        models = query.all()
+
+        with MonitorLatency(DBMonitor.query("shared_links")):
+            models = query.all()
+
         return [ShareLink.model_validate(m) for m in models]
 
+    @MonitorLatency(DBMonitor.query("shared_links"))
     def count_by_user(self, db: DBSession, user_id: str, search: Optional[str] = None) -> int:
         """
         Count total share links for a user.
-        
+
         Args:
             db: Database session
             user_id: User ID
             search: Optional search query for title
-        
         Returns:
             Total count
         """
@@ -127,7 +132,6 @@ class ShareRepository:
                 SharedLinkModel.deleted_at.is_(None)
             )
         )
-        
         if search:
             escaped = re.sub(r'([%_])', r'\\\1', search)
             query = query.filter(
@@ -148,34 +152,38 @@ class ShareRepository:
             Saved ShareLink entity
         """
         # Check if exists
-        existing = db.query(SharedLinkModel).filter(
-            SharedLinkModel.share_id == share_link.share_id
-        ).first()
-        
+        with MonitorLatency(DBMonitor.query("shared_links")):
+            existing = db.query(SharedLinkModel).filter(
+                SharedLinkModel.share_id == share_link.share_id
+            ).first()
+
         if existing:
             # Update existing
-            for key, value in share_link.model_dump().items():
-                setattr(existing, key, value)
-            db.flush()
-            db.refresh(existing)
+            with MonitorLatency(DBMonitor.update("shared_links")):
+                for key, value in share_link.model_dump().items():
+                    setattr(existing, key, value)
+                db.flush()
+                db.refresh(existing)
             return ShareLink.model_validate(existing)
         else:
             # Create new
-            model = SharedLinkModel(**share_link.model_dump())
-            db.add(model)
-            db.flush()
-            db.refresh(model)
+            with MonitorLatency(DBMonitor.insert("shared_links")):
+                model = SharedLinkModel(**share_link.model_dump())
+                db.add(model)
+                db.flush()
+                db.refresh(model)
             return ShareLink.model_validate(model)
 
+    @MonitorLatency(DBMonitor.delete("shared_links"))
     def delete(self, db: DBSession, share_id: str, user_id: str) -> bool:
         """
         Hard delete a share link.
-        
+
         Args:
             db: Database session
             share_id: Share ID to delete
             user_id: User ID (must be owner)
-        
+
         Returns:
             True if deleted, False if not found or not authorized
         """
@@ -185,18 +193,19 @@ class ShareRepository:
                 SharedLinkModel.user_id == user_id
             )
         ).delete()
-        
+
         return result > 0
 
+    @MonitorLatency(DBMonitor.update("shared_links"))
     def soft_delete(self, db: DBSession, share_id: str, user_id: str) -> bool:
         """
         Soft delete a share link.
-        
+
         Args:
             db: Database session
             share_id: Share ID to delete
             user_id: User ID (must be owner)
-        
+
         Returns:
             True if deleted, False if not found or not authorized
         """
@@ -211,19 +220,20 @@ class ShareRepository:
             'deleted_at': now,
             'updated_time': now
         })
-        
+
         return result > 0
 
     # Shared Artifacts methods
 
+    @MonitorLatency(DBMonitor.insert("shared_artifacts"))
     def save_artifact(self, db: DBSession, artifact: SharedArtifact) -> SharedArtifact:
         """
         Save a shared artifact reference.
-        
+
         Args:
             db: Database session
             artifact: SharedArtifact entity
-        
+
         Returns:
             Saved SharedArtifact entity
         """
@@ -231,44 +241,44 @@ class ShareRepository:
         db.add(model)
         db.flush()
         db.refresh(model)
+
         return SharedArtifact.model_validate(model)
 
+    @MonitorLatency(DBMonitor.query("shared_artifacts"))
     def find_artifacts_by_share_id(self, db: DBSession, share_id: str) -> List[SharedArtifact]:
         """
         Find all artifacts for a share link.
-        
+
         Args:
             db: Database session
             share_id: Share ID
-        
+
         Returns:
             List of SharedArtifact entities
         """
         models = db.query(SharedArtifactModel).filter(
             SharedArtifactModel.share_id == share_id
         ).all()
-        
+
         return [SharedArtifact.model_validate(m) for m in models]
 
+    @MonitorLatency(DBMonitor.delete("shared_artifacts"))
     def delete_artifacts_by_share_id(self, db: DBSession, share_id: str) -> int:
         """
         Delete all artifacts for a share link.
-        
         Args:
             db: Database session
             share_id: Share ID
-        
         Returns:
             Number of artifacts deleted
         """
         result = db.query(SharedArtifactModel).filter(
             SharedArtifactModel.share_id == share_id
         ).delete()
-        
         return result
 
     # Shared Link Users methods
-
+    @MonitorLatency(DBMonitor.insert("shared_link_users"))
     def add_share_user(
         self,
         db: DBSession,
@@ -326,73 +336,79 @@ class ShareRepository:
         Returns:
             Updated SharedLinkUser entity, or None if not found
         """
-        model = db.query(SharedLinkUserModel).filter(
-            and_(
-                SharedLinkUserModel.share_id == share_id,
-                func.lower(SharedLinkUserModel.user_email) == user_email.lower().strip()
-            )
-        ).first()
+        with MonitorLatency(DBMonitor.query("shared_link_users")):
+            model = db.query(SharedLinkUserModel).filter(
+                and_(
+                    SharedLinkUserModel.share_id == share_id,
+                    func.lower(SharedLinkUserModel.user_email) == user_email.lower().strip()
+                )
+            ).first()
 
-        if not model:
-            return None
+            if not model:
+                return None
 
-        # Preserve the very first access level and timestamp (only if not already set)
-        if model.original_access_level is None:
-            model.original_access_level = model.access_level
-        if model.original_added_at is None:
-            model.original_added_at = model.added_at
+            # Preserve the very first access level and timestamp (only if not already set)
+            if model.original_access_level is None:
+                model.original_access_level = model.access_level
+            if model.original_added_at is None:
+                model.original_added_at = model.added_at
 
-        # Update to the new values
-        model.access_level = new_access_level
-        model.added_at = now_epoch_ms()
+            # Update to the new values
+            model.access_level = new_access_level
+            model.added_at = now_epoch_ms()
 
-        db.flush()
-        db.refresh(model)
+        with MonitorLatency(DBMonitor.update("shared_link_users")):
+            db.flush()
+            db.refresh(model)
+
         return SharedLinkUser.model_validate(model)
 
+    @MonitorLatency(DBMonitor.query("shared_link_users"))
     def find_share_users(self, db: DBSession, share_id: str) -> List[SharedLinkUser]:
         """
         Find all users with access to a share link.
-        
+
         Args:
             db: Database session
             share_id: Share ID
-        
+
         Returns:
             List of SharedLinkUser entities
         """
         models = db.query(SharedLinkUserModel).filter(
             SharedLinkUserModel.share_id == share_id
         ).all()
-        
+
         return [SharedLinkUser.model_validate(m) for m in models]
 
+    @MonitorLatency(DBMonitor.query("shared_link_users"))
     def find_share_user_emails(self, db: DBSession, share_id: str) -> List[str]:
         """
         Get list of user emails with access to a share link.
-        
+
         Args:
             db: Database session
             share_id: Share ID
-        
+
         Returns:
             List of user emails
         """
         results = db.query(SharedLinkUserModel.user_email).filter(
             SharedLinkUserModel.share_id == share_id
         ).all()
-        
+
         return [r[0] for r in results]
 
+    @MonitorLatency(DBMonitor.query("shared_link_users"))
     def check_user_has_access(self, db: DBSession, share_id: str, user_email: str) -> bool:
         """
         Check if a user has access to a share link.
-        
+
         Args:
             db: Database session
             share_id: Share ID
             user_email: User email to check
-        
+
         Returns:
             True if user has access, False otherwise
         """
@@ -402,18 +418,19 @@ class ShareRepository:
                 func.lower(SharedLinkUserModel.user_email) == user_email.lower().strip()
             )
         ).scalar()
-        
+
         return count > 0
 
+    @MonitorLatency(DBMonitor.delete("shared_link_users"))
     def delete_share_user(self, db: DBSession, share_id: str, user_email: str) -> bool:
         """
         Remove a user's access to a share link.
-        
+
         Args:
             db: Database session
             share_id: Share ID
             user_email: User email to remove
-        
+
         Returns:
             True if deleted, False if not found
         """
@@ -426,15 +443,16 @@ class ShareRepository:
 
         return result > 0
 
+    @MonitorLatency(DBMonitor.delete("shared_link_users"))
     def delete_share_users_batch(self, db: DBSession, share_id: str, user_emails: List[str]) -> int:
         """
         Remove multiple users' access to a share link.
-        
+
         Args:
             db: Database session
             share_id: Share ID
             user_emails: List of user emails to remove
-        
+
         Returns:
             Number of users removed
         """
@@ -445,53 +463,56 @@ class ShareRepository:
                 func.lower(SharedLinkUserModel.user_email).in_(normalized_emails)
             )
         ).delete(synchronize_session='fetch')
-        
+
         return result
 
+    @MonitorLatency(DBMonitor.delete("shared_link_users"))
     def delete_all_share_users(self, db: DBSession, share_id: str) -> int:
         """
         Remove all users' access to a share link.
-        
+
         Args:
             db: Database session
             share_id: Share ID
-        
+
         Returns:
             Number of users removed
         """
         result = db.query(SharedLinkUserModel).filter(
             SharedLinkUserModel.share_id == share_id
         ).delete()
-        
+
         return result
 
+    @MonitorLatency(DBMonitor.query("shared_link_users"))
     def has_shared_users(self, db: DBSession, share_id: str) -> bool:
         """
         Check if a share link has any user-specific shares.
-        
+
         Args:
             db: Database session
             share_id: Share ID
-        
+
         Returns:
             True if there are shared users, False otherwise
         """
         count = db.query(func.count(SharedLinkUserModel.id)).filter(
             SharedLinkUserModel.share_id == share_id
         ).scalar()
-        
+
         return count > 0
 
+    @MonitorLatency(DBMonitor.update("shared_link_users"))
     def update_user_snapshot_time(self, db: DBSession, share_id: str, user_email: str, new_time: int) -> bool:
         """
         Update the added_at (snapshot time) for a shared user.
-        
+
         Args:
             db: Database session
             share_id: Share ID
             user_email: Email of the user to update
             new_time: New snapshot time in epoch milliseconds
-        
+
         Returns:
             True if updated, False if user not found
         """
@@ -501,6 +522,7 @@ class ShareRepository:
                 func.lower(SharedLinkUserModel.user_email) == user_email.lower().strip()
             )
         ).update({"added_at": new_time})
+
         return result > 0
 
     def find_share_user_by_email(self, db: DBSession, share_id: str, user_email: str) -> Optional[SharedLinkUser]:
@@ -515,27 +537,29 @@ class ShareRepository:
         Returns:
             SharedLinkUser entity or None if not found
         """
-        model = db.query(SharedLinkUserModel).filter(
-            and_(
-                SharedLinkUserModel.share_id == share_id,
-                func.lower(SharedLinkUserModel.user_email) == user_email.lower().strip()
-            )
-        ).first()
-        
+        with MonitorLatency(DBMonitor.query("shared_link_users")):
+            model = db.query(SharedLinkUserModel).filter(
+                and_(
+                    SharedLinkUserModel.share_id == share_id,
+                    func.lower(SharedLinkUserModel.user_email) == user_email.lower().strip()
+                )
+            ).first()
+
         if not model:
             return None
-        
+
         return SharedLinkUser.model_validate(model)
 
+    @MonitorLatency(DBMonitor.query("shared_link_users"))
     def check_user_editor_access_to_session(self, db: DBSession, session_id: str, user_email: str) -> bool:
         """
         Check if a user has RESOURCE_EDITOR access to a session via sharing.
-        
+
         Args:
             db: Database session
             session_id: Session ID to check access for
             user_email: Email of the user to check
-        
+
         Returns:
             True if user has editor access, False otherwise
         """
@@ -563,18 +587,21 @@ class ShareRepository:
         Returns:
             Owner's user_id if editor access exists, None otherwise
         """
-        result = db.query(SharedLinkModel.user_id).join(
-            SharedLinkUserModel, SharedLinkModel.share_id == SharedLinkUserModel.share_id
-        ).filter(
-            and_(
-                SharedLinkModel.session_id == session_id,
-                SharedLinkModel.deleted_at.is_(None),
-                func.lower(SharedLinkUserModel.user_email) == user_email.lower().strip(),
-                SharedLinkUserModel.access_level == 'RESOURCE_EDITOR'
-            )
-        ).first()
+        with MonitorLatency(DBMonitor.query("shared_links")):
+            result = db.query(SharedLinkModel.user_id).join(
+                SharedLinkUserModel, SharedLinkModel.share_id == SharedLinkUserModel.share_id
+            ).filter(
+                and_(
+                    SharedLinkModel.session_id == session_id,
+                    SharedLinkModel.deleted_at.is_(None),
+                    func.lower(SharedLinkUserModel.user_email) == user_email.lower().strip(),
+                    SharedLinkUserModel.access_level == 'RESOURCE_EDITOR'
+                )
+            ).first()
+
         return result[0] if result else None
 
+    @MonitorLatency(DBMonitor.query("shared_links"))
     def find_shares_for_user_email(self, db: DBSession, user_email: str) -> List[dict]:
         """
         Find all share links that have been shared with a specific user email.
@@ -588,7 +615,6 @@ class ShareRepository:
             List of dicts with share link details and access info
         """
         from .models.session_model import SessionModel
-        
         results = db.query(
             SharedLinkModel.share_id,
             SharedLinkModel.session_id,
@@ -615,7 +641,6 @@ class ShareRepository:
         ).order_by(
             SharedLinkUserModel.added_at.desc()
         ).all()
-        
         return [
             {
                 "share_id": r.share_id,

--- a/src/solace_agent_mesh/gateway/http_sse/repository/sse_event_buffer_repository.py
+++ b/src/solace_agent_mesh/gateway/http_sse/repository/sse_event_buffer_repository.py
@@ -11,6 +11,7 @@ from typing import List, Optional
 from sqlalchemy import func
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session as DBSession
+from solace_ai_connector.common.observability import DBMonitor, MonitorLatency
 
 from .models.sse_event_buffer_model import SSEEventBufferModel
 from .models.task_model import TaskModel
@@ -72,11 +73,12 @@ class SSEEventBufferRepository:
         
         for attempt in range(MAX_SEQUENCE_RETRIES):
             try:
-                # Get next sequence number for this task
-                max_seq = db.query(func.max(SSEEventBufferModel.event_sequence))\
-                    .filter(SSEEventBufferModel.task_id == task_id)\
-                    .scalar() or 0
-                
+                with MonitorLatency(DBMonitor.query("sse_event_buffer")):
+                    # Get next sequence number for this task
+                    max_seq = db.query(func.max(SSEEventBufferModel.event_sequence))\
+                        .filter(SSEEventBufferModel.task_id == task_id)\
+                        .scalar() or 0
+
                 # Create buffer entry
                 buffer_entry = SSEEventBufferModel(
                     task_id=task_id,
@@ -89,14 +91,16 @@ class SSEEventBufferRepository:
                     consumed=False,
                 )
                 db.add(buffer_entry)
-                
-                # Mark task as having buffered events
-                task = db.query(TaskModel).filter(TaskModel.id == task_id).first()
-                if task and not task.events_buffered:
-                    task.events_buffered = True
-                
-                db.flush()  # Flush to get the ID and trigger constraint check
-                
+
+                with MonitorLatency(DBMonitor.query("tasks")):
+                    # Mark task as having buffered events
+                    task = db.query(TaskModel).filter(TaskModel.id == task_id).first()
+                    if task and not task.events_buffered:
+                        task.events_buffered = True
+
+                with MonitorLatency(DBMonitor.insert("sse_event_buffer")):
+                    db.flush()  # Flush to get the ID and trigger constraint check
+
                 log.debug(
                     "%s Buffered event for task %s: sequence=%d, type=%s",
                     self.log_identifier,
@@ -104,7 +108,6 @@ class SSEEventBufferRepository:
                     buffer_entry.event_sequence,
                     event_type,
                 )
-                
                 return buffer_entry
                 
             except IntegrityError as e:
@@ -170,17 +173,19 @@ class SSEEventBufferRepository:
         
         for attempt in range(MAX_SEQUENCE_RETRIES):
             try:
-                # Get task with optional row lock for databases that support it
-                task_query = db.query(TaskModel).filter(TaskModel.id == task_id)
-                if supports_row_locking:
-                    task_query = task_query.with_for_update()
-                task = task_query.first()
-                
-                # Get max sequence (safe due to row lock on PostgreSQL, or DB-level lock on SQLite)
-                max_seq = db.query(func.max(SSEEventBufferModel.event_sequence))\
-                    .filter(SSEEventBufferModel.task_id == task_id)\
-                    .scalar() or 0
-                
+                with MonitorLatency(DBMonitor.query("tasks")):
+                    # Get task with optional row lock for databases that support it
+                    task_query = db.query(TaskModel).filter(TaskModel.id == task_id)
+                    if supports_row_locking:
+                        task_query = task_query.with_for_update()
+                    task = task_query.first()
+
+                with MonitorLatency(DBMonitor.query("sse_event_buffer")):
+                    # Get max sequence (safe due to row lock on PostgreSQL, or DB-level lock on SQLite)
+                    max_seq = db.query(func.max(SSEEventBufferModel.event_sequence))\
+                        .filter(SSEEventBufferModel.task_id == task_id)\
+                        .scalar() or 0
+
                 # Build list of model instances with sequential sequence numbers
                 buffer_entries = []
                 for i, (event_type, event_data, timestamp, session_id, user_id) in enumerate(events):
@@ -194,16 +199,17 @@ class SSEEventBufferRepository:
                         created_at=timestamp,
                         consumed=False,
                     ))
-                
-                # Bulk insert all events
-                db.bulk_save_objects(buffer_entries)
-                
-                # Mark task as having buffered events (task already fetched above)
-                if task and not task.events_buffered:
-                    task.events_buffered = True
-                
-                db.flush()
-                
+
+                with MonitorLatency(DBMonitor.insert("sse_event_buffer")):
+                    # Bulk insert all events
+                    db.bulk_save_objects(buffer_entries)
+
+                    # Mark task as having buffered events (task already fetched above)
+                    if task and not task.events_buffered:
+                        task.events_buffered = True
+
+                    db.flush()
+
                 log.debug(
                     "%s Batch buffered %d events for task %s (sequences %d-%d)",
                     self.log_identifier,
@@ -212,7 +218,6 @@ class SSEEventBufferRepository:
                     max_seq + 1,
                     max_seq + len(events),
                 )
-                
                 return len(events)
                 
             except IntegrityError as e:
@@ -262,15 +267,16 @@ class SSEEventBufferRepository:
         Returns:
             List of event dictionaries with type, data, and sequence
         """
-        query = db.query(SSEEventBufferModel)\
-            .filter(SSEEventBufferModel.task_id == task_id)
-        
-        if mark_consumed:
-            query = query.filter(SSEEventBufferModel.consumed.is_(False))
-            query = query.with_for_update()
-        
-        events = query.order_by(SSEEventBufferModel.event_sequence).all()
-        
+        with MonitorLatency(DBMonitor.query("sse_event_buffer")):
+            query = db.query(SSEEventBufferModel)\
+                .filter(SSEEventBufferModel.task_id == task_id)
+
+            if mark_consumed:
+                query = query.filter(SSEEventBufferModel.consumed.is_(False))
+                query = query.with_for_update()
+
+            events = query.order_by(SSEEventBufferModel.event_sequence).all()
+
         event_data = [
             {
                 "type": event.event_type,
@@ -279,29 +285,30 @@ class SSEEventBufferRepository:
             }
             for event in events
         ]
-        
+
         if mark_consumed and events:
-            # Mark events as consumed
-            consumed_at = now_epoch_ms()
-            db.query(SSEEventBufferModel)\
-                .filter(SSEEventBufferModel.task_id == task_id)\
-                .update({
-                    "consumed": True,
-                    "consumed_at": consumed_at,
-                })
-            
+            with MonitorLatency(DBMonitor.update("sse_event_buffer")):
+                # Mark events as consumed
+                consumed_at = now_epoch_ms()
+                db.query(SSEEventBufferModel)\
+                    .filter(SSEEventBufferModel.task_id == task_id)\
+                    .update({
+                        "consumed": True,
+                        "consumed_at": consumed_at,
+                    })
+
             # Mark task as consumed
-            task = db.query(TaskModel).filter(TaskModel.id == task_id).first()
-            if task:
-                task.events_consumed = True
-            
+            with MonitorLatency(DBMonitor.query("tasks")):
+                task = db.query(TaskModel).filter(TaskModel.id == task_id).first()
+                if task:
+                    task.events_consumed = True
+
             log.info(
                 "%s Marked %d events as consumed for task %s",
                 self.log_identifier,
                 len(events),
                 task_id,
             )
-        
         return event_data
 
     def get_unconsumed_events_for_session(
@@ -323,22 +330,24 @@ class SSEEventBufferRepository:
         Returns:
             List of SSEEventBufferModel instances
         """
-        query = db.query(SSEEventBufferModel)\
-            .filter(SSEEventBufferModel.session_id == session_id)\
-            .filter(SSEEventBufferModel.consumed.is_(False))
-        
-        if task_id:
-            query = query.filter(SSEEventBufferModel.task_id == task_id)
-        
-        events = query.order_by(SSEEventBufferModel.event_sequence).all()
-        
+        with MonitorLatency(DBMonitor.query("sse_event_buffer")):
+            query = db.query(SSEEventBufferModel)\
+                .filter(SSEEventBufferModel.session_id == session_id)\
+                .filter(SSEEventBufferModel.consumed.is_(False))
+
+            if task_id:
+                query = query.filter(SSEEventBufferModel.task_id == task_id)
+
+            events = query.order_by(SSEEventBufferModel.event_sequence).all()
+
         if mark_consumed and events:
-            # Mark events as consumed
-            consumed_at = now_epoch_ms()
-            for event in events:
-                event.consumed = True
-                event.consumed_at = consumed_at
-            
+            with MonitorLatency(DBMonitor.update("sse_event_buffer")):
+                # Mark events as consumed
+                consumed_at = now_epoch_ms()
+                for event in events:
+                    event.consumed = True
+                    event.consumed_at = consumed_at
+
             log.info(
                 "%s Marked %d events as consumed for session %s (task=%s)",
                 self.log_identifier,
@@ -346,7 +355,7 @@ class SSEEventBufferRepository:
                 session_id,
                 task_id,
             )
-        
+
         return events
 
     def has_unconsumed_events(
@@ -364,13 +373,15 @@ class SSEEventBufferRepository:
         Returns:
             True if there are unconsumed events, False otherwise
         """
-        count = db.query(func.count(SSEEventBufferModel.id))\
-            .filter(SSEEventBufferModel.task_id == task_id)\
-            .filter(SSEEventBufferModel.consumed.is_(False))\
-            .scalar()
-        
+        with MonitorLatency(DBMonitor.query("sse_event_buffer")):
+            count = db.query(func.count(SSEEventBufferModel.id))\
+                .filter(SSEEventBufferModel.task_id == task_id)\
+                .filter(SSEEventBufferModel.consumed.is_(False))\
+                .scalar()
+
         return count > 0
 
+    @MonitorLatency(DBMonitor.query("sse_event_buffer"))
     def get_event_count(
         self,
         db: DBSession,
@@ -390,6 +401,7 @@ class SSEEventBufferRepository:
             .filter(SSEEventBufferModel.task_id == task_id)\
             .scalar() or 0
 
+    @MonitorLatency(DBMonitor.delete("sse_event_buffer"))
     def cleanup_consumed_events(
         self,
         db: DBSession,
@@ -397,11 +409,11 @@ class SSEEventBufferRepository:
     ) -> int:
         """
         Clean up consumed events older than the specified time.
-        
+
         Args:
             db: Database session
             older_than_ms: Delete events consumed before this epoch time (ms)
-            
+
         Returns:
             Number of events deleted
         """
@@ -409,7 +421,7 @@ class SSEEventBufferRepository:
             .filter(SSEEventBufferModel.consumed.is_(True))\
             .filter(SSEEventBufferModel.consumed_at < older_than_ms)\
             .delete()
-        
+
         if deleted > 0:
             log.info(
                 "%s Cleaned up %d consumed events older than %d",
@@ -420,6 +432,7 @@ class SSEEventBufferRepository:
         
         return deleted
 
+    @MonitorLatency(DBMonitor.delete("sse_event_buffer"))
     def delete_events_for_task(
         self,
         db: DBSession,
@@ -427,18 +440,17 @@ class SSEEventBufferRepository:
     ) -> int:
         """
         Delete all buffered events for a task.
-        
+
         Args:
             db: Database session
             task_id: The task ID
-            
+
         Returns:
             Number of events deleted
         """
         deleted = db.query(SSEEventBufferModel)\
             .filter(SSEEventBufferModel.task_id == task_id)\
             .delete()
-        
         if deleted > 0:
             log.debug(
                 "%s Deleted %d events for task %s",
@@ -473,24 +485,26 @@ class SSEEventBufferRepository:
         total_deleted = 0
         
         while True:
-            # Delete in batches to avoid long-running transactions
             # Get IDs of events to delete
-            events_to_delete = db.query(SSEEventBufferModel.id)\
-                .filter(SSEEventBufferModel.created_at < older_than_ms)\
-                .limit(batch_size)\
-                .all()
-            
+            with MonitorLatency(DBMonitor.query("sse_event_buffer")):
+                events_to_delete = db.query(SSEEventBufferModel.id)\
+                    .filter(SSEEventBufferModel.created_at < older_than_ms)\
+                    .limit(batch_size)\
+                    .all()
+
             if not events_to_delete:
                 break
-            
+
             event_ids = [e.id for e in events_to_delete]
-            deleted = db.query(SSEEventBufferModel)\
-                .filter(SSEEventBufferModel.id.in_(event_ids))\
-                .delete(synchronize_session=False)
-            
-            db.commit()
+
+            with MonitorLatency(DBMonitor.delete("sse_event_buffer")):
+                deleted = db.query(SSEEventBufferModel)\
+                    .filter(SSEEventBufferModel.id.in_(event_ids))\
+                    .delete(synchronize_session=False)
+                db.commit()
+
             total_deleted += deleted
-            
+
             log.debug(
                 "%s Deleted batch of %d old SSE events (total so far: %d)",
                 self.log_identifier,

--- a/src/solace_agent_mesh/services/platform/repositories/model_configuration_repository.py
+++ b/src/solace_agent_mesh/services/platform/repositories/model_configuration_repository.py
@@ -5,6 +5,7 @@ from typing import List, Optional
 
 from sqlalchemy.orm import Session
 from sqlalchemy import or_
+from solace_ai_connector.common.observability import DBMonitor, MonitorLatency
 from solace_agent_mesh.services.platform.models import ModelConfiguration
 from solace_agent_mesh.shared.database.database_exceptions import handle_database_errors
 from solace_agent_mesh.shared.exceptions.exceptions import ValidationError
@@ -30,6 +31,7 @@ class ModelConfigurationRepository:
             )
         return model_id.strip()
 
+    @MonitorLatency(DBMonitor.query("model_configurations"))
     def get_all(self, db: Session) -> List[ModelConfiguration]:
         """
         Retrieve all model configurations from the database.
@@ -42,6 +44,7 @@ class ModelConfigurationRepository:
         """
         return db.query(ModelConfiguration).all()
 
+    @MonitorLatency(DBMonitor.query("model_configurations"))
     def get_by_alias(self, db: Session, alias: str) -> Optional[ModelConfiguration]:
         """
         Retrieve a model configuration by alias (case-sensitive exact match).
@@ -58,6 +61,7 @@ class ModelConfigurationRepository:
         ).first()
 
     @handle_database_errors("ModelConfiguration")
+    @MonitorLatency(DBMonitor.insert("model_configurations"))
     def create(self, db: Session, model: ModelConfiguration) -> ModelConfiguration:
         """
         Create a new model configuration.
@@ -71,9 +75,11 @@ class ModelConfigurationRepository:
         """
         db.add(model)
         db.flush()
+
         return model
 
     @handle_database_errors("ModelConfiguration")
+    @MonitorLatency(DBMonitor.update("model_configurations"))
     def update(self, db: Session, model: ModelConfiguration) -> ModelConfiguration:
         """
         Update an existing model configuration.
@@ -86,8 +92,10 @@ class ModelConfigurationRepository:
             The updated ModelConfiguration
         """
         db.flush()
+
         return model
 
+    @MonitorLatency(DBMonitor.delete("model_configurations"))
     def delete(self, db: Session, model: ModelConfiguration) -> None:
         """
         Delete a model configuration.
@@ -99,6 +107,7 @@ class ModelConfigurationRepository:
         db.delete(model)
         db.flush()
 
+    @MonitorLatency(DBMonitor.query("model_configurations"))
     def get_by_id(self, db: Session, model_id: str) -> Optional[ModelConfiguration]:
         """
         Retrieve a model configuration by ID.
@@ -115,6 +124,7 @@ class ModelConfigurationRepository:
             ModelConfiguration.id == model_id
         ).first()
 
+    @MonitorLatency(DBMonitor.query("model_configurations"))
     def get_by_alias_or_id(self, db: Session, alias: str) -> Optional[ModelConfiguration]:
         """
         Retrieve a model configuration by alias or ID.

--- a/src/solace_agent_mesh/shared/outbox/repository.py
+++ b/src/solace_agent_mesh/shared/outbox/repository.py
@@ -71,7 +71,7 @@ class OutboxEventRepository:
     def has_pending_event(
         self, session: Session, entity_type: str, entity_id: str, event_type: str
     ) -> bool:
-        return (
+        result = (
             session.query(OutboxEventModel)
             .filter(
                 OutboxEventModel.entity_type == entity_type,
@@ -80,8 +80,8 @@ class OutboxEventRepository:
                 OutboxEventModel.status == "pending",
             )
             .first()
-            is not None
         )
+        return result is not None
 
     def update_event(self, session: Session, event_id: str, data: UpdateOutboxEventModel) -> OutboxEventEntity:
         with MonitorLatency(DBMonitor.query("outbox_events")):
@@ -192,7 +192,6 @@ class OutboxEventRepository:
             older.error_message = "Deduplicated by newer event"
         with MonitorLatency(DBMonitor.update("outbox_events")):
             session.flush()
-
         return True
 
     @MonitorLatency(DBMonitor.delete("outbox_events"))


### PR DESCRIPTION
Add DBMonitor instrumentation to remaining repositories:
- sse_event_buffer_repository.py: Monitor event buffering, consumption, cleanup
- share_repository.py: Monitor shared links, artifacts, user access operations
- project_repository.py: Monitor project CRUD, user pins, accessible projects
- project_user_repository.py: Monitor user-project access operations
- document_conversion_cache_repository.py: Monitor cache CRUD, stats queries
- model_configuration_repository.py: Monitor model config CRUD

Completes DB observability coverage for all 20 database tables. All operations use decorator pattern or context managers with correct table names and operation labels.

### What is the purpose of this change?

    Brief summary - what problem does this solve?

### How was this change implemented?

    High-level approach - what files/components changed and why?

### Key Design Decisions _(optional - delete if not applicable)_

    Why did you choose this approach over alternatives?

### How was this change tested?

to enable metrics add in one of agents:
```
management_server:
  enabled: true
  port: 8080
  observability:
    enabled: true
    metric_prefix: sam
    path: /metrics
```


- [x] Manual testing: start SAM engage with components relevant to tables from PR, ensure metrics listed under (localhost:8080/metrics).
- [ ] Unit tests: [new/modified tests]
- [ ] Integration tests: [if applicable]
- [ ] Known limitations: [what wasn't tested]

### Is there anything the reviewers should focus on/be aware of?

    Special attention areas, potential risks, or open questions
