### PR TITLE
chore(DATAGO-130514): update documentation for network features

### DIFF
--- a/docs/docs/documentation/components/builtin-tools/audio-tools.md
+++ b/docs/docs/documentation/components/builtin-tools/audio-tools.md
@@ -3,6 +3,8 @@ title: Audio Tools
 sidebar_position: 30
 ---
 
+import NetworkAccessRequiredSingleFeature from '@site/docs/partials/network-access-required.mdx';
+
 # Using Text-to-Speech (TTS) Tools
 
 This guide provides technical documentation for the text-to-speech (TTS) tools available in Agent Mesh.
@@ -14,9 +16,7 @@ The `audio` tool group provides two primary TTS tools for generating high-qualit
 1.  **`text_to_speech`**: Converts a string of text to speech using a single voice, featuring intelligent tone selection.
 2.  **`multi_speaker_text_to_speech`**: Converts a conversational script, delineated by speaker, into a multi-speaker audio file.
 
-:::info NETWORK ACCESS REQUIRED
-This feature requires network access. In network restricted environments, ensure the necessary routes and firewall rules are in place before use.
-:::
+<NetworkAccessRequiredSingleFeature />
 
 ## Setup and Configuration
 

--- a/docs/docs/documentation/components/builtin-tools/audio-tools.md
+++ b/docs/docs/documentation/components/builtin-tools/audio-tools.md
@@ -14,6 +14,10 @@ The `audio` tool group provides two primary TTS tools for generating high-qualit
 1.  **`text_to_speech`**: Converts a string of text to speech using a single voice, featuring intelligent tone selection.
 2.  **`multi_speaker_text_to_speech`**: Converts a conversational script, delineated by speaker, into a multi-speaker audio file.
 
+:::info NETWORK ACCESS REQUIRED
+This feature requires network access. In network restricted environments, ensure the necessary routes and firewall rules are in place before use.
+:::
+
 ## Setup and Configuration
 
 ### Prerequisites

--- a/docs/docs/documentation/components/builtin-tools/builtin-tools.md
+++ b/docs/docs/documentation/components/builtin-tools/builtin-tools.md
@@ -3,6 +3,8 @@ title: Configuring Built-in Tools
 sidebar_position: 60
 ---
 
+import NetworkAccessRequiredSomeFeatures from '@site/docs/partials/network-access-required-some-features.mdx';
+
 # Configuring Built-in Tools
 
 This guide provides instructions for enabling and configuring the built-in tools provided by Agent Mesh framework.
@@ -13,9 +15,7 @@ Built-in tools are pre-packaged functionalities that can be granted to agents wi
 
 The Agent Mesh framework manages these tools through a central `tool_registry`, which is responsible for loading the tools, generating instructional prompts for the Large Language Model (LLM), and handling their execution in a consistent manner.
 
-:::info NETWORK ACCESS REQUIRED
-Some of the features on this page require network access. In network restricted environments, ensure the necessary routes and firewall rules are in place before use.
-:::
+<NetworkAccessRequiredSomeFeatures />
 
 ## Configuration Methods
 

--- a/docs/docs/documentation/components/builtin-tools/builtin-tools.md
+++ b/docs/docs/documentation/components/builtin-tools/builtin-tools.md
@@ -15,8 +15,6 @@ Built-in tools are pre-packaged functionalities that can be granted to agents wi
 
 The Agent Mesh framework manages these tools through a central `tool_registry`, which is responsible for loading the tools, generating instructional prompts for the Large Language Model (LLM), and handling their execution in a consistent manner.
 
-<NetworkAccessRequiredSomeFeatures />
-
 ## Configuration Methods
 
 Tool configuration is managed within the `tools` list in an agent's `app_config` block in the corresponding YAML configuration file.
@@ -73,6 +71,8 @@ The Agent Mesh framework automatically handles duplicate tool registrations. If 
 ## Available Tool Groups and Tools
 
 The following sections detail the available tool groups and the individual tools they contain.
+
+<NetworkAccessRequiredSomeFeatures />
 
 ### Artifact Management
 **Group Name**: `artifact_management`

--- a/docs/docs/documentation/components/builtin-tools/builtin-tools.md
+++ b/docs/docs/documentation/components/builtin-tools/builtin-tools.md
@@ -13,6 +13,10 @@ Built-in tools are pre-packaged functionalities that can be granted to agents wi
 
 The Agent Mesh framework manages these tools through a central `tool_registry`, which is responsible for loading the tools, generating instructional prompts for the Large Language Model (LLM), and handling their execution in a consistent manner.
 
+:::info NETWORK ACCESS REQUIRED
+Some of the features on this page require network access. In network restricted environments, ensure the necessary routes and firewall rules are in place before use.
+:::
+
 ## Configuration Methods
 
 Tool configuration is managed within the `tools` list in an agent's `app_config` block in the corresponding YAML configuration file.

--- a/docs/docs/documentation/components/builtin-tools/image-tools.md
+++ b/docs/docs/documentation/components/builtin-tools/image-tools.md
@@ -3,6 +3,8 @@ title: Image Tools
 sidebar_position: 35
 ---
 
+import NetworkAccessRequiredSomeFeatures from '@site/docs/partials/network-access-required-some-features.mdx';
+
 # Image Tools
 
 ## Overview
@@ -15,6 +17,8 @@ The image tools provide agents with capabilities for generating, editing, and an
 - **describe_image**: Analyze and describe image contents
 - **edit_image_with_gemini**: Edit existing images using AI
 - **describe_audio**: Analyze audio content (cross-listed with audio tools)
+
+<NetworkAccessRequiredSomeFeatures />
 
 ## Tool Reference
 

--- a/docs/docs/documentation/components/builtin-tools/research-tools.md
+++ b/docs/docs/documentation/components/builtin-tools/research-tools.md
@@ -13,6 +13,10 @@ The research tools consist of two categories:
 
 The web search tools provide direct access to web search engines, allowing agents to retrieve current information, news, and facts. The deep research tool builds on web search to conduct iterative research with LLM-powered reflection and report generation.
 
+:::info NETWORK ACCESS REQUIRED
+This feature requires network access. In network restricted environments, ensure the necessary routes and firewall rules are in place before use.
+:::
+
 ## Setup and Configuration
 
 ### Prerequisites

--- a/docs/docs/documentation/components/builtin-tools/research-tools.md
+++ b/docs/docs/documentation/components/builtin-tools/research-tools.md
@@ -3,6 +3,8 @@ title: Research Tools
 sidebar_position: 50
 ---
 
+import NetworkAccessRequiredSingleFeature from '@site/docs/partials/network-access-required.mdx';
+
 # Research Tools
 
 Agent Mesh provides research tools that enable agents to search the web and conduct comprehensive research on complex topics. These tools give agents access to current information beyond their training data and the ability to synthesize findings from multiple sources into detailed reports.
@@ -13,9 +15,7 @@ The research tools consist of two categories:
 
 The web search tools provide direct access to web search engines, allowing agents to retrieve current information, news, and facts. The deep research tool builds on web search to conduct iterative research with LLM-powered reflection and report generation.
 
-:::info NETWORK ACCESS REQUIRED
-This feature requires network access. In network restricted environments, ensure the necessary routes and firewall rules are in place before use.
-:::
+<NetworkAccessRequiredSingleFeature />
 
 ## Setup and Configuration
 

--- a/docs/docs/documentation/components/gateways.md
+++ b/docs/docs/documentation/components/gateways.md
@@ -3,6 +3,8 @@ title: Gateways
 sidebar_position: 260
 ---
 
+import NetworkAccessRequiredSomeFeatures from '@site/docs/partials/network-access-required-some-features.mdx';
+
 # Gateways
 
 Gateways are a crucial component of the Agent Mesh framework that expose the agent mesh to external systems through various protocols. Built on a common base gateway architecture, they provide the following functions:
@@ -16,9 +18,7 @@ Gateways are a crucial component of the Agent Mesh framework that expose the age
 Gateways are the external interfaces that connect various systems to the A2A agent mesh through standardized protocols.
 :::
 
-:::info NETWORK ACCESS REQUIRED
-Some of the features on this page require network access. In network restricted environments, ensure the necessary routes and firewall rules are in place before use.
-:::
+<NetworkAccessRequiredSomeFeatures />
 
 ## Key Functions
 

--- a/docs/docs/documentation/components/gateways.md
+++ b/docs/docs/documentation/components/gateways.md
@@ -16,6 +16,10 @@ Gateways are a crucial component of the Agent Mesh framework that expose the age
 Gateways are the external interfaces that connect various systems to the A2A agent mesh through standardized protocols.
 :::
 
+:::info NETWORK ACCESS REQUIRED
+Some of the features on this page require network access. In network restricted environments, ensure the necessary routes and firewall rules are in place before use.
+:::
+
 ## Key Functions
 
 1. **Entry Points**: Gateways act as the entry points from the outside world and translate external requests into A2A protocol messages and route them through the Solace event mesh to appropriate agents.

--- a/docs/docs/documentation/components/plugins.md
+++ b/docs/docs/documentation/components/plugins.md
@@ -3,6 +3,8 @@ title: Plugins
 sidebar_position: 270
 ---
 
+import NetworkAccessRequiredSomeFeatures from '@site/docs/partials/network-access-required-some-features.mdx';
+
 Plugins provide a mechanism to extend the functionality of Agent Mesh in a modular, shareable, and reusable way. The current plugin ecosystem includes agents, gateways, and specialized integrations.
 
 :::tip[In one sentence]
@@ -16,6 +18,8 @@ Plugins are packaged as Python modules that can be installed using various packa
 - **Custom Plugins**: Custom integrations such as HR providers.
 
 All plugin interactions (create, build, add) are managed through the Agent Mesh CLI.
+
+<NetworkAccessRequiredSomeFeatures />
 
 :::info
 Run `sam plugin --help` to see the list of available commands for plugins.

--- a/docs/docs/documentation/components/speech.md
+++ b/docs/docs/documentation/components/speech.md
@@ -1,3 +1,5 @@
+import NetworkAccessRequiredSingleFeature from '@site/docs/partials/network-access-required.mdx';
+
 # Speech Integration
 
 :::warning Experimental Feature
@@ -11,6 +13,8 @@ Agent Mesh provides speech capabilities through integrated Speech-to-Text (STT) 
 The speech system consists of two complementary services that work together to enable voice interactions. The STT service converts spoken audio into text that agents can process, while the TTS service transforms agent responses into natural-sounding speech. Both services support multiple providers and can be configured independently based on your requirements.
 
 The system integrates with the WebUI gateway to provide seamless voice interactions in chat interfaces. When you enable speech features, users see microphone and speaker controls that allow them to speak their questions and hear agent responses without typing.
+
+<NetworkAccessRequiredSingleFeature />
 
 ## Configuring Speech Services
 

--- a/docs/docs/documentation/developing/create-gateways.md
+++ b/docs/docs/documentation/developing/create-gateways.md
@@ -13,6 +13,10 @@ This guide walks you through creating custom gateways using the gateway adapter 
 Gateway adapters are custom interfaces that connect external platforms to the agent mesh by translating events and responses between platform formats and the A2A protocol.
 :::
 
+:::info NETWORK ACCESS REQUIRED
+This feature requires network access. In network restricted environments, ensure the necessary routes and firewall rules are in place before use.
+:::
+
 ## Key Functions
 
 Gateway adapters provide the following capabilities:

--- a/docs/docs/documentation/developing/create-gateways.md
+++ b/docs/docs/documentation/developing/create-gateways.md
@@ -15,7 +15,9 @@ This guide walks you through creating custom gateways using the gateway adapter 
 Gateway adapters are custom interfaces that connect external platforms to the agent mesh by translating events and responses between platform formats and the A2A protocol.
 :::
 
-<NetworkAccessRequiredSingleFeature />
+:::info NETWORK ACCESS REQUIRED
+This feature may require network access. In network restricted environments, ensure the necessary routes and firewall rules are in place before use.
+:::
 
 ## Key Functions
 

--- a/docs/docs/documentation/developing/create-gateways.md
+++ b/docs/docs/documentation/developing/create-gateways.md
@@ -3,6 +3,8 @@ title: Creating Custom Gateways
 sidebar_position: 430
 ---
 
+import NetworkAccessRequiredSingleFeature from '@site/docs/partials/network-access-required.mdx';
+
 # Creating Custom Gateways
 
 Gateway adapters connect external systems to the Agent Mesh through custom interfaces. They translate between platform-specific formats (Slack messages, HTTP requests, webhook payloads) and the standardized A2A protocol that agents understand. Gateway adapters handle platform events, extract user identity, and deliver agent responses back to users in the appropriate format.
@@ -13,9 +15,7 @@ This guide walks you through creating custom gateways using the gateway adapter 
 Gateway adapters are custom interfaces that connect external platforms to the agent mesh by translating events and responses between platform formats and the A2A protocol.
 :::
 
-:::info NETWORK ACCESS REQUIRED
-This feature requires network access. In network restricted environments, ensure the necessary routes and firewall rules are in place before use.
-:::
+<NetworkAccessRequiredSingleFeature />
 
 ## Key Functions
 

--- a/docs/docs/documentation/enterprise/connect-external-agents.md
+++ b/docs/docs/documentation/enterprise/connect-external-agents.md
@@ -9,6 +9,10 @@ The Connect External Agent feature allows you to integrate external A2A (Agent-t
 
 This feature provides a user-friendly alternative to manually configuring YAML proxy files. The wizard guides you through providing agent location details, configuring authentication, and reviewing the final configuration before connecting the agent.
 
+:::info NETWORK ACCESS REQUIRED
+This feature requires network access. In network restricted environments, ensure the necessary routes and firewall rules are in place before use.
+:::
+
 ## How External Agent Connections Work
 
 When you connect an external agent through the Enterprise UI, the system creates a proxy configuration that bridges the external agent to your Solace event mesh. The proxy performs protocol translation between A2A over HTTPS (used by the external agent) and A2A over Solace event mesh (used by agents in your mesh).

--- a/docs/docs/documentation/enterprise/connect-external-agents.md
+++ b/docs/docs/documentation/enterprise/connect-external-agents.md
@@ -3,15 +3,15 @@ title: Connect External Agents
 sidebar_position: 9
 ---
 
+import NetworkAccessRequiredSingleFeature from '@site/docs/partials/network-access-required.mdx';
+
 # Connect External Agents
 
 The Connect External Agent feature allows you to integrate external A2A (Agent-to-Agent) protocol agents into your Agent Mesh deployment through a guided wizard interface. External agents run on separate infrastructure and communicate over HTTPS, but once connected, they appear and behave like native agents within your mesh.
 
 This feature provides a user-friendly alternative to manually configuring YAML proxy files. The wizard guides you through providing agent location details, configuring authentication, and reviewing the final configuration before connecting the agent.
 
-:::info NETWORK ACCESS REQUIRED
-This feature requires network access. In network restricted environments, ensure the necessary routes and firewall rules are in place before use.
-:::
+<NetworkAccessRequiredSingleFeature />
 
 ## How External Agent Connections Work
 

--- a/docs/docs/documentation/enterprise/connectors/connectors.md
+++ b/docs/docs/documentation/enterprise/connectors/connectors.md
@@ -3,13 +3,13 @@ title: Connectors
 sidebar_position: 10
 ---
 
+import NetworkAccessRequiredSomeFeatures from '@site/docs/partials/network-access-required-some-features.mdx';
+
 # Connectors
 
 Connectors allow your agents to access external data sources and services. You configure each connector with credentials and connection details for a specific system. Agents use connectors to retrieve information, execute queries, and interact with external platforms through natural language conversations.
 
-:::info NETWORK ACCESS REQUIRED
-Some of the features on this page require network access. In network restricted environments, ensure the necessary routes and firewall rules are in place before use.
-:::
+<NetworkAccessRequiredSomeFeatures />
 
 ## Connector Types
 

--- a/docs/docs/documentation/enterprise/connectors/connectors.md
+++ b/docs/docs/documentation/enterprise/connectors/connectors.md
@@ -7,6 +7,10 @@ sidebar_position: 10
 
 Connectors allow your agents to access external data sources and services. You configure each connector with credentials and connection details for a specific system. Agents use connectors to retrieve information, execute queries, and interact with external platforms through natural language conversations.
 
+:::info NETWORK ACCESS REQUIRED
+Some of the features on this page require network access. In network restricted environments, ensure the necessary routes and firewall rules are in place before use.
+:::
+
 ## Connector Types
 
 Agent Mesh Enterprise provides multiple connector types. Each type integrates with different external systems.

--- a/docs/docs/documentation/enterprise/connectors/knowledgebase-connectors.md
+++ b/docs/docs/documentation/enterprise/connectors/knowledgebase-connectors.md
@@ -13,6 +13,10 @@ The connector retrieves information from knowledge bases, which can contain both
 
 This reduces hallucinations and ensures agents provide answers consistent with company policies, procedures, and documentation.
 
+:::info NETWORK ACCESS REQUIRED
+This feature requires network access. In network restricted environments, ensure the necessary routes and firewall rules are in place before use.
+:::
+
 ## Supported Knowledge Bases
 
 Agent Mesh Enterprise supports the following knowledge base platforms:

--- a/docs/docs/documentation/enterprise/connectors/knowledgebase-connectors.md
+++ b/docs/docs/documentation/enterprise/connectors/knowledgebase-connectors.md
@@ -3,6 +3,8 @@ title: Knowledge Base Connectors
 sidebar_position: 1
 ---
 
+import NetworkAccessRequiredSingleFeature from '@site/docs/partials/network-access-required.mdx';
+
 Knowledge Base connectors allow agents to retrieve context from enterprise documentation stored in cloud-based knowledge repositories.
 
 ## Overview
@@ -13,9 +15,7 @@ The connector retrieves information from knowledge bases, which can contain both
 
 This reduces hallucinations and ensures agents provide answers consistent with company policies, procedures, and documentation.
 
-:::info NETWORK ACCESS REQUIRED
-This feature requires network access. In network restricted environments, ensure the necessary routes and firewall rules are in place before use.
-:::
+<NetworkAccessRequiredSingleFeature />
 
 ## Supported Knowledge Bases
 

--- a/docs/docs/documentation/enterprise/connectors/mcp-connectors.md
+++ b/docs/docs/documentation/enterprise/connectors/mcp-connectors.md
@@ -3,6 +3,8 @@ title: MCP Connectors
 sidebar_position: 2
 ---
 
+import NetworkAccessRequiredSingleFeature from '@site/docs/partials/network-access-required.mdx';
+
 MCP connectors allow agents to communicate with remote MCP servers and access external tools.
 
 ## Overview
@@ -13,9 +15,7 @@ MCP connectors establish connections to remote MCP servers using one of two tran
 
 Agent Mesh Enterprise supports remote MCP servers only through the connector interface. The system does not support local MCP servers that use stdio (standard input/output) for communication. The connector requires network-accessible MCP servers using SSE or Streamable HTTP transport protocols. The connector supports multiple authentication methods and provides tool selection capabilities to control which MCP tools are available to agents.
 
-:::info NETWORK ACCESS REQUIRED
-This feature requires network access. In network restricted environments, ensure the necessary routes and firewall rules are in place before use.
-:::
+<NetworkAccessRequiredSingleFeature />
 
 ## Prerequisites
 

--- a/docs/docs/documentation/enterprise/connectors/mcp-connectors.md
+++ b/docs/docs/documentation/enterprise/connectors/mcp-connectors.md
@@ -13,6 +13,10 @@ MCP connectors establish connections to remote MCP servers using one of two tran
 
 Agent Mesh Enterprise supports remote MCP servers only through the connector interface. The system does not support local MCP servers that use stdio (standard input/output) for communication. The connector requires network-accessible MCP servers using SSE or Streamable HTTP transport protocols. The connector supports multiple authentication methods and provides tool selection capabilities to control which MCP tools are available to agents.
 
+:::info NETWORK ACCESS REQUIRED
+This feature requires network access. In network restricted environments, ensure the necessary routes and firewall rules are in place before use.
+:::
+
 ## Prerequisites
 
 Before you create an MCP connector, ensure you have the following:

--- a/docs/docs/documentation/enterprise/connectors/openapi-connectors.md
+++ b/docs/docs/documentation/enterprise/connectors/openapi-connectors.md
@@ -3,6 +3,8 @@ title: OpenAPI Connectors
 sidebar_position: 3
 ---
 
+import NetworkAccessRequiredSingleFeature from '@site/docs/partials/network-access-required.mdx';
+
 OpenAPI connectors allow agents to interact with REST APIs that use OpenAPI specifications.
 
 ## Overview
@@ -21,9 +23,7 @@ The connector converts API operations into tools that agents invoke. It derives 
 
 The connector supports OpenAPI 3.0+ specifications in JSON or YAML format and provides flexible authentication options to accommodate different API security models.
 
-:::info NETWORK ACCESS REQUIRED
-This feature requires network access. In network restricted environments, ensure the necessary routes and firewall rules are in place before use.
-:::
+<NetworkAccessRequiredSingleFeature />
 
 ## Prerequisites
 

--- a/docs/docs/documentation/enterprise/connectors/openapi-connectors.md
+++ b/docs/docs/documentation/enterprise/connectors/openapi-connectors.md
@@ -21,6 +21,10 @@ The connector converts API operations into tools that agents invoke. It derives 
 
 The connector supports OpenAPI 3.0+ specifications in JSON or YAML format and provides flexible authentication options to accommodate different API security models.
 
+:::info NETWORK ACCESS REQUIRED
+This feature requires network access. In network restricted environments, ensure the necessary routes and firewall rules are in place before use.
+:::
+
 ## Prerequisites
 
 Before you create an OpenAPI connector, ensure you have the following:

--- a/docs/docs/documentation/enterprise/gateways/gateways.md
+++ b/docs/docs/documentation/enterprise/gateways/gateways.md
@@ -3,13 +3,13 @@ title: Gateways
 sidebar_position: 10
 ---
 
+import NetworkAccessRequiredSomeFeatures from '@site/docs/partials/network-access-required-some-features.mdx';
+
 # Gateways
 
 Gateways connect your Agent Mesh deployment to external systems, enabling agents to receive requests from and send responses to platforms like Slack, Microsoft Teams, and Solace Event Mesh brokers. You configure each gateway with connection details and routing rules for a specific integration target.
 
-:::info NETWORK ACCESS REQUIRED
-Some of the features on this page require network access. In network restricted environments, ensure the necessary routes and firewall rules are in place before use.
-:::
+<NetworkAccessRequiredSomeFeatures />
 
 ## Gateway Types
 

--- a/docs/docs/documentation/enterprise/gateways/gateways.md
+++ b/docs/docs/documentation/enterprise/gateways/gateways.md
@@ -7,6 +7,10 @@ sidebar_position: 10
 
 Gateways connect your Agent Mesh deployment to external systems, enabling agents to receive requests from and send responses to platforms like Slack, Microsoft Teams, and Solace Event Mesh brokers. You configure each gateway with connection details and routing rules for a specific integration target.
 
+:::info NETWORK ACCESS REQUIRED
+Some of the features on this page require network access. In network restricted environments, ensure the necessary routes and firewall rules are in place before use.
+:::
+
 ## Gateway Types
 
 Agent Mesh Enterprise provides multiple gateway types, each integrating with a different external system.

--- a/docs/docs/documentation/enterprise/gateways/slack-gateway.md
+++ b/docs/docs/documentation/enterprise/gateways/slack-gateway.md
@@ -3,6 +3,8 @@ title: Slack Gateway
 sidebar_position: 2
 ---
 
+import NetworkAccessRequiredSingleFeature from '@site/docs/partials/network-access-required.mdx';
+
 # Slack Gateway
 
 Slack gateways integrate Agent Mesh with Slack workspaces, enabling users to interact with agents through Slack channels and direct messages. The gateway uses Socket Mode for real-time message processing without requiring public endpoints.
@@ -13,9 +15,7 @@ Slack gateways connect to Slack workspaces using the Slack Events API and Socket
 
 Socket Mode establishes a WebSocket connection from the gateway to Slack's servers, eliminating the need for public-facing endpoints or webhook URLs.
 
-:::info NETWORK ACCESS REQUIRED
-This feature requires network access. In network restricted environments, ensure the necessary routes and firewall rules are in place before use.
-:::
+<NetworkAccessRequiredSingleFeature />
 
 ## Prerequisites
 

--- a/docs/docs/documentation/enterprise/gateways/slack-gateway.md
+++ b/docs/docs/documentation/enterprise/gateways/slack-gateway.md
@@ -13,6 +13,10 @@ Slack gateways connect to Slack workspaces using the Slack Events API and Socket
 
 Socket Mode establishes a WebSocket connection from the gateway to Slack's servers, eliminating the need for public-facing endpoints or webhook URLs.
 
+:::info NETWORK ACCESS REQUIRED
+This feature requires network access. In network restricted environments, ensure the necessary routes and firewall rules are in place before use.
+:::
+
 ## Prerequisites
 
 Before creating a Slack gateway, verify that you have the following:

--- a/docs/docs/documentation/enterprise/openapi-tools.md
+++ b/docs/docs/documentation/enterprise/openapi-tools.md
@@ -3,6 +3,8 @@ title: OpenAPI Tools
 sidebar_position: 16
 ---
 
+import NetworkAccessRequiredSingleFeature from '@site/docs/partials/network-access-required.mdx';
+
 This guide walks you through configuring OpenAPI-based tools for Agent Mesh Enterprise. You will learn how to integrate REST APIs into your agents using OpenAPI specifications, enabling them to interact with any OpenAPI-compliant service.
 
 ## Table of Contents
@@ -42,6 +44,8 @@ Agent Mesh Enterprise's OpenAPI tool integration supports:
 - **Tool filtering**: Include or exclude specific API operations using allow/deny lists
 - **Authentication**: API key, HTTP (bearer token and basic auth), OAuth2/OIDC, and service account authentication
 - **Automatic name conversion**: Handles camelCase operation IDs correctly
+
+<NetworkAccessRequiredSingleFeature />
 
 ## Understanding OpenAPI Tools
 

--- a/docs/docs/documentation/installing-and-configuring/large_language_models.md
+++ b/docs/docs/documentation/installing-and-configuring/large_language_models.md
@@ -5,6 +5,10 @@ sidebar_position: 340
 
 Large Language Models (LLMs) serve as the intelligence foundation for Agent Mesh, powering everything from natural language understanding to complex reasoning and decision-making. The system provides flexible configuration options that allow you to connect with various LLM providers through a unified interface, making it easy to switch between providers or use multiple models for different purposes.
 
+:::info NETWORK ACCESS REQUIRED
+This feature requires network access. In network restricted environments, ensure the necessary routes and firewall rules are in place before use.
+:::
+
 You can configure LLM settings in two locations within your Agent Mesh deployment. The `apps.app_config.model` field allows you to specify model settings for individual agents or gateways, providing fine-grained control over which models specific components use. Alternatively, you can define models globally in the `shared_config.yaml` file under the `models` section, creating reusable configurations that multiple components can reference. For detailed information about the overall configuration structure and shared configuration management, see the [Configuring Agent Mesh](./configurations.md).
 
 ## Understanding LiteLLM Integration

--- a/docs/docs/documentation/installing-and-configuring/large_language_models.md
+++ b/docs/docs/documentation/installing-and-configuring/large_language_models.md
@@ -3,11 +3,11 @@ title: Configuring LLMs
 sidebar_position: 340
 ---
 
+import NetworkAccessRequiredSingleFeature from '@site/docs/partials/network-access-required.mdx';
+
 Large Language Models (LLMs) serve as the intelligence foundation for Agent Mesh, powering everything from natural language understanding to complex reasoning and decision-making. The system provides flexible configuration options that allow you to connect with various LLM providers through a unified interface, making it easy to switch between providers or use multiple models for different purposes.
 
-:::info NETWORK ACCESS REQUIRED
-This feature requires network access. In network restricted environments, ensure the necessary routes and firewall rules are in place before use.
-:::
+<NetworkAccessRequiredSingleFeature />
 
 You can configure LLM settings in two locations within your Agent Mesh deployment. The `apps.app_config.model` field allows you to specify model settings for individual agents or gateways, providing fine-grained control over which models specific components use. Alternatively, you can define models globally in the `shared_config.yaml` file under the `models` section, creating reusable configurations that multiple components can reference. For detailed information about the overall configuration structure and shared configuration management, see the [Configuring Agent Mesh](./configurations.md).
 

--- a/docs/docs/documentation/installing-and-configuring/large_language_models.md
+++ b/docs/docs/documentation/installing-and-configuring/large_language_models.md
@@ -7,9 +7,9 @@ import NetworkAccessRequiredSingleFeature from '@site/docs/partials/network-acce
 
 Large Language Models (LLMs) serve as the intelligence foundation for Agent Mesh, powering everything from natural language understanding to complex reasoning and decision-making. The system provides flexible configuration options that allow you to connect with various LLM providers through a unified interface, making it easy to switch between providers or use multiple models for different purposes.
 
-<NetworkAccessRequiredSingleFeature />
-
 You can configure LLM settings in two locations within your Agent Mesh deployment. The `apps.app_config.model` field allows you to specify model settings for individual agents or gateways, providing fine-grained control over which models specific components use. Alternatively, you can define models globally in the `shared_config.yaml` file under the `models` section, creating reusable configurations that multiple components can reference. For detailed information about the overall configuration structure and shared configuration management, see the [Configuring Agent Mesh](./configurations.md).
+
+<NetworkAccessRequiredSingleFeature />
 
 ## Understanding LiteLLM Integration
 

--- a/docs/docs/partials/network-access-required-some-features.mdx
+++ b/docs/docs/partials/network-access-required-some-features.mdx
@@ -1,0 +1,3 @@
+:::info NETWORK ACCESS REQUIRED
+Some of the features on this page require network access. In network restricted environments, ensure the necessary routes and firewall rules are in place before use.
+:::

--- a/docs/docs/partials/network-access-required.mdx
+++ b/docs/docs/partials/network-access-required.mdx
@@ -1,0 +1,3 @@
+:::info NETWORK ACCESS REQUIRED
+This feature requires network access. In network restricted environments, ensure the necessary routes and firewall rules are in place before use.
+:::


### PR DESCRIPTION
## Summary

- Added blue `:::info` banners to documentation pages for features that require network access in air-gapped/network-restricted environments
- Two banner variants used depending on page content:
  - **`<NetworkAccessRequiredSingleFeature />`**: "This feature requires network access. In network restricted environments, ensure the necessary routes and firewall rules are in place before use."
  - **`<NetworkAccessRequiredSomeFeatures />`**: "Some of the features on this page require network access. In network restricted environments, ensure the necessary routes and firewall rules are in place before use."

### Partials approach

Banner content is defined once in reusable MDX partials under `docs/partials/` and imported into each page, rather than duplicating the raw `:::info` block inline. This keeps the banner text in a single source of truth — if the wording needs to change, it only needs to be updated in one place.

- `docs/partials/network-access-required.mdx` — single feature variant
- `docs/partials/network-access-required-some-features.mdx` — some features variant

## Updated Pages

### LLM Configuration
- [Configuring LLMs](http://localhost:3000/solace-agent-mesh/docs/documentation/installing-and-configuring/large_language_models) — single feature

<img width="1728" height="1117" alt="Screenshot 2026-04-13 at 11 38 32 AM" src="https://github.com/user-attachments/assets/21a505c2-cef1-4ec8-8b45-639d3adedde8" />



### Built-in Tools
- [Configuring Built-in Tools](http://localhost:3000/solace-agent-mesh/docs/documentation/components/builtin-tools) — some features
<img width="1728" height="1117" alt="Screenshot 2026-04-13 at 11 39 04 AM" src="https://github.com/user-attachments/assets/06bd9714-a848-450a-9025-0d91729812e6" />

- [Research Tools](http://localhost:3000/solace-agent-mesh/docs/documentation/components/builtin-tools/research-tools) — single feature
<img width="1728" height="1117" alt="Screenshot 2026-04-13 at 11 39 26 AM" src="https://github.com/user-attachments/assets/9d72a94d-1aa7-48f2-8516-2c7d1da07e9a" />

- [Image Tools](http://localhost:3000/solace-agent-mesh/docs/documentation/components/builtin-tools/image-tools) — some features
<img width="1728" height="1117" alt="Screenshot 2026-04-13 at 11 39 32 AM" src="https://github.com/user-attachments/assets/ed0a97bf-991f-444c-8fc3-0ac88b40a346" />

- [Audio Tools](http://localhost:3000/solace-agent-mesh/docs/documentation/components/builtin-tools/audio-tools) — single feature
<img width="1728" height="1117" alt="Screenshot 2026-04-13 at 11 39 43 AM" src="https://github.com/user-attachments/assets/ad1296b1-2fba-493c-bc03-7f863ff4df65" />

### Remote A2A Agents
- [Connect External Agents](http://localhost:3000/solace-agent-mesh/docs/documentation/enterprise/connect-external-agents) — single feature
<img width="1728" height="1117" alt="Screenshot 2026-04-13 at 11 40 02 AM" src="https://github.com/user-attachments/assets/3106e2d7-3cb3-4c11-9ce2-731a22221dd9" />

### Connectors
- [Connectors Overview](http://localhost:3000/solace-agent-mesh/docs/documentation/enterprise/connectors) — some features
<img width="1728" height="1117" alt="Screenshot 2026-04-13 at 11 40 10 AM" src="https://github.com/user-attachments/assets/7cab631b-3b88-4b84-9139-526517915884" />

- [Knowledge Base Connectors](http://localhost:3000/solace-agent-mesh/docs/documentation/enterprise/connectors/knowledgebase-connectors) — single feature
<img width="1728" height="1117" alt="Screenshot 2026-04-13 at 11 40 23 AM" src="https://github.com/user-attachments/assets/5fb99e59-ea30-4fb7-ac6d-68df43eab507" />

- [MCP Connectors](http://localhost:3000/solace-agent-mesh/docs/documentation/enterprise/connectors/mcp-connectors) — single feature
<img width="1728" height="1117" alt="Screenshot 2026-04-13 at 11 40 36 AM" src="https://github.com/user-attachments/assets/e02e04a1-967b-48d3-8e3b-966deacc721b" />

- [OpenAPI Connectors](http://localhost:3000/solace-agent-mesh/docs/documentation/enterprise/connectors/openapi-connectors) — single feature
<img width="1728" height="1117" alt="Screenshot 2026-04-13 at 11 40 42 AM" src="https://github.com/user-attachments/assets/7ee6de3d-6f52-46fb-95e1-4f00c72a5b40" />

### Gateways
- [Gateways (Component Overview)](http://localhost:3000/solace-agent-mesh/docs/documentation/components/gateways) — some features
<img width="1728" height="1117" alt="Screenshot 2026-04-13 at 11 40 56 AM" src="https://github.com/user-attachments/assets/d2684ee3-1fe5-4d24-9c00-5abecf41427b" />

- [Gateways (Enterprise Overview)](http://localhost:3000/solace-agent-mesh/docs/documentation/enterprise/gateways) — some features
<img width="1728" height="1117" alt="Screenshot 2026-04-13 at 11 41 03 AM" src="https://github.com/user-attachments/assets/dc6fbf66-4736-45c8-95c2-81b931778778" />

- [Slack Gateway](http://localhost:3000/solace-agent-mesh/docs/documentation/enterprise/gateways/slack-gateway) — single feature
<img width="1728" height="1117" alt="Screenshot 2026-04-13 at 11 41 10 AM" src="https://github.com/user-attachments/assets/6ce5d8f0-8925-4afb-9446-50d5a81ad352" />

- [Creating Custom Gateways](http://localhost:3000/solace-agent-mesh/docs/documentation/developing/create-gateways) — single feature (Special: MAY)
<img width="1728" height="1117" alt="Screenshot 2026-04-13 at 11 41 54 AM" src="https://github.com/user-attachments/assets/ddb1d553-319e-47dc-a801-d9b37d0e500f" />


### Plugins
- [Plugins](http://localhost:3000/solace-agent-mesh/docs/documentation/components/plugins) — some features
<img width="1728" height="1117" alt="Screenshot 2026-04-13 at 11 42 03 AM" src="https://github.com/user-attachments/assets/e3bf1344-0d75-494d-bfec-1934a3dac10f" />

### Speech
- [Speech Integration](http://localhost:3000/solace-agent-mesh/docs/documentation/components/speech) — single feature
<img width="1728" height="1117" alt="Screenshot 2026-04-13 at 11 42 09 AM" src="https://github.com/user-attachments/assets/62ca98a6-b220-4c05-9003-8c85a77afb64" />

### Enterprise Tools
- [OpenAPI Tools](http://localhost:3000/solace-agent-mesh/docs/documentation/enterprise/openapi-tools) — single feature
<img width="1728" height="1117" alt="Screenshot 2026-04-13 at 11 42 26 AM" src="https://github.com/user-attachments/assets/7d5a0908-8343-4e3a-974d-98b14208a4be" />

## Test Plan
- [X] Verify each link above renders the blue info banner correctly
- [X] Confirm banner placement is after the intro/overview section on each page
- [X] Verify no broken formatting in surrounding content
