### PR TITLE
fix(DATAGO-130934): clear auth credentials when selecting None auth type

### DIFF
--- a/client/webui/frontend/src/lib/components/models/ModelEdit.tsx
+++ b/client/webui/frontend/src/lib/components/models/ModelEdit.tsx
@@ -510,6 +510,7 @@ export const ModelEdit = ({ isNew, modelToEdit, onSave, onDirtyStateChange, mode
 
                                             return (
                                                 <ComboBox
+                                                    key={selectedAuthType}
                                                     value={field.value}
                                                     onValueChange={field.onChange}
                                                     items={displayItems}

--- a/client/webui/frontend/src/lib/components/models/ModelEdit.tsx
+++ b/client/webui/frontend/src/lib/components/models/ModelEdit.tsx
@@ -184,6 +184,18 @@ export const ModelEdit = ({ isNew, modelToEdit, onSave, onDirtyStateChange, mode
         }
     }, [selectedAuthType, apiKey, apiBase, selectedProvider]);
 
+    // Clear all authentication fields when auth type changes to "none"
+    useEffect(() => {
+        if (selectedAuthType === "none") {
+            for (const fields of Object.values(AUTH_FIELDS)) {
+                for (const field of fields) {
+                    setValue(field.name, "");
+                }
+            }
+            setStoredCredentialFields(new Set());
+        }
+    }, [selectedAuthType, setValue]);
+
     // When the model dropdown opens, commit the current form credentials as query params.
     // React Query handles caching: if params haven't changed since the last successful
     // fetch the cached result is returned; if they changed a fresh request is made.

--- a/client/webui/frontend/src/lib/components/models/ModelEdit.tsx
+++ b/client/webui/frontend/src/lib/components/models/ModelEdit.tsx
@@ -184,16 +184,15 @@ export const ModelEdit = ({ isNew, modelToEdit, onSave, onDirtyStateChange, mode
         }
     }, [selectedAuthType, apiKey, apiBase, selectedProvider]);
 
-    // Clear all authentication fields when auth type changes to "none"
+    // Clear all authentication fields when switching between auth types
     useEffect(() => {
-        if (selectedAuthType === "none") {
-            for (const fields of Object.values(AUTH_FIELDS)) {
-                for (const field of fields) {
-                    setValue(field.name, "");
-                }
+        if (!selectedAuthType) return;
+        for (const fields of Object.values(AUTH_FIELDS)) {
+            for (const field of fields) {
+                setValue(field.name, "");
             }
-            setStoredCredentialFields(new Set());
         }
+        setStoredCredentialFields(new Set());
     }, [selectedAuthType, setValue]);
 
     // When the model dropdown opens, commit the current form credentials as query params.

--- a/client/webui/frontend/src/lib/components/models/ModelEdit.tsx
+++ b/client/webui/frontend/src/lib/components/models/ModelEdit.tsx
@@ -184,17 +184,21 @@ export const ModelEdit = ({ isNew, modelToEdit, onSave, onDirtyStateChange, mode
         }
     }, [selectedAuthType, apiKey, apiBase, selectedProvider]);
 
-    // Clear all authentication fields when switching between auth types
-    useEffect(() => {
-        if (!selectedAuthType) return;
-        for (const fields of Object.values(AUTH_FIELDS)) {
-            for (const field of fields) {
-                setValue(field.name, "");
+    // Clear all authentication and model fields when the user switches auth type
+    const handleAuthTypeChange = useCallback(
+        (newAuthType: string, formOnChange: (value: string) => void) => {
+            formOnChange(newAuthType);
+            for (const fields of Object.values(AUTH_FIELDS)) {
+                for (const field of fields) {
+                    setValue(field.name, "");
+                }
             }
-        }
-        setStoredCredentialFields(new Set());
-        setValue("modelName", "");
-    }, [selectedAuthType, setValue]);
+            setStoredCredentialFields(new Set());
+            setValue("modelName", "");
+            setQueryParams(null);
+        },
+        [setValue]
+    );
 
     // When the model dropdown opens, commit the current form credentials as query params.
     // React Query handles caching: if params haven't changed since the last successful
@@ -464,7 +468,7 @@ export const ModelEdit = ({ isNew, modelToEdit, onSave, onDirtyStateChange, mode
                                                 <div className="flex gap-4">
                                                     {providerConfig.allowedAuthTypes.map(authType => (
                                                         <label key={authType} className="flex cursor-pointer items-center gap-2">
-                                                            <input type="radio" value={authType} checked={field.value === authType} onChange={() => field.onChange(authType)} />
+                                                            <input type="radio" value={authType} checked={field.value === authType} onChange={() => handleAuthTypeChange(authType, field.onChange)} />
                                                             <span className="text-sm">{AUTH_TYPE_LABELS[authType as AuthType]}</span>
                                                         </label>
                                                     ))}

--- a/client/webui/frontend/src/lib/components/models/ModelEdit.tsx
+++ b/client/webui/frontend/src/lib/components/models/ModelEdit.tsx
@@ -193,6 +193,7 @@ export const ModelEdit = ({ isNew, modelToEdit, onSave, onDirtyStateChange, mode
             }
         }
         setStoredCredentialFields(new Set());
+        setValue("modelName", "");
     }, [selectedAuthType, setValue]);
 
     // When the model dropdown opens, commit the current form credentials as query params.


### PR DESCRIPTION
### What is the purpose of this change?

When a user selects "None" as the authentication type in the model edit form, previously entered authentication credentials (API keys, OAuth secrets, AWS credentials, GCP service account details) were not cleared. Switching back to a different auth type would show stale values. This fix clears all auth fields when "None" is selected.

Resolves: [DATAGO-130934](https://sol-jira.atlassian.net/browse/DATAGO-130934)

### How was this change implemented?

Added a `useEffect` in `ModelEdit.tsx` that watches `selectedAuthType`. When it changes to `"none"`, it iterates over all fields defined in `AUTH_FIELDS` and resets them to empty strings via `setValue()`. It also clears the `storedCredentialFields` set so server-side stored credential indicators are reset.

### How was this change tested?

- [ ] Manual testing: Select a provider with auth configured, fill in credentials, switch auth type to "None", verify fields are cleared, switch back to previous auth type and verify fields remain empty
- [ ] Unit tests: Existing form behavior tests cover the rendering; this is a state-clearing side effect best verified manually
- [ ] Known limitations: None

### Is there anything the reviewers should focus on/be aware of?

The effect fires on initial render if a model already has `authType: "none"` — this is safe since such models shouldn't have credential fields populated.

[DATAGO-130934]: https://sol-jira.atlassian.net/browse/DATAGO-130934?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

https://github.com/user-attachments/assets/0f1ddef6-ae5e-4873-bdcb-ca0b7ed32a31


