### PR TITLE
fix(DATAGO-131516): Chat title generation occasionally outputs markdown formatting

### DIFF
--- a/src/solace_agent_mesh/gateway/http_sse/services/title_generation_service.py
+++ b/src/solace_agent_mesh/gateway/http_sse/services/title_generation_service.py
@@ -3,6 +3,7 @@ Service for generating chat session titles using LLM.
 """
 import asyncio
 import logging
+import re
 from typing import Optional
 from google.adk.models import BaseLlm
 from ....agent.adk.models.lite_llm import LiteLlm
@@ -133,6 +134,7 @@ class TitleGenerationService:
 
         # Use a clear prompt that generates specific, meaningful titles
         prompt = f'''Generate a concise, specific title (under {TITLE_CHAR_LIMIT} characters) for this conversation.
+Output ONLY plain text. Do NOT use any markdown formatting such as bold (**), italic (*), headings (#), or backticks.
 Avoid generic titles like "New Chat" or "Conversation".
 Focus on the main topic or question.
 
@@ -175,6 +177,9 @@ Title:'''
             # Remove quotes if present
             title = title.strip('"\'')
 
+            # Strip any markdown formatting the LLM may have included
+            title = self._strip_markdown(title)
+
             # Ensure title is not empty
             if not title or len(title.strip()) == 0:
                 log.warning("[_call_litellm] LiteLLM returned empty title, using fallback")
@@ -186,6 +191,25 @@ Title:'''
         except Exception as e:
             log.error(f"[_call_litellm] Error generating title via LiteLLM: {e}", exc_info=True)
             return self._fallback_title(user_message)
+
+    def _strip_markdown(self, text: str) -> str:
+        """Strip common markdown formatting from text.
+
+        Removes bold (**text** / __text__), italic (*text* / _text_),
+        heading markers (# ), inline code (`text`), and strikethrough (~~text~~).
+        """
+        if not text:
+            return text
+        # Remove bold/italic markers: **text** or __text__
+        text = re.sub(r'\*{1,3}(.*?)\*{1,3}', r'\1', text)
+        text = re.sub(r'_{1,3}(.*?)_{1,3}', r'\1', text)
+        # Remove strikethrough: ~~text~~
+        text = re.sub(r'~~(.*?)~~', r'\1', text)
+        # Remove inline code: `text`
+        text = re.sub(r'`(.*?)`', r'\1', text)
+        # Remove heading markers at the start: # , ## , ### , etc.
+        text = re.sub(r'^#{1,6}\s+', '', text)
+        return text.strip()
 
     def _truncate_text(self, text: str, max_length: int) -> str:
         """Truncate text to max length."""

--- a/tests/unit/gateway/http_sse/services/test_title_generation_service.py
+++ b/tests/unit/gateway/http_sse/services/test_title_generation_service.py
@@ -196,3 +196,64 @@ class TestTitleGenerationService:
         llm_request = mock_llm.generate_content_async.call_args[0][0]
         assert len(llm_request.contents) == 1
         assert llm_request.contents[0].role == "user"
+
+    def test_strip_markdown_bold(self):
+        """Test stripping bold markdown (**text**)."""
+        service = _create_service_with_mock_llm()
+        assert service._strip_markdown("**bold title**") == "bold title"
+        assert service._strip_markdown("__bold title__") == "bold title"
+
+    def test_strip_markdown_italic(self):
+        """Test stripping italic markdown (*text*)."""
+        service = _create_service_with_mock_llm()
+        assert service._strip_markdown("*italic title*") == "italic title"
+        assert service._strip_markdown("_italic title_") == "italic title"
+
+    def test_strip_markdown_bold_italic(self):
+        """Test stripping bold+italic markdown (***text***)."""
+        service = _create_service_with_mock_llm()
+        assert service._strip_markdown("***bold italic***") == "bold italic"
+        assert service._strip_markdown("___bold italic___") == "bold italic"
+
+    def test_strip_markdown_headings(self):
+        """Test stripping heading markers (# text)."""
+        service = _create_service_with_mock_llm()
+        assert service._strip_markdown("# Heading Title") == "Heading Title"
+        assert service._strip_markdown("## Heading Title") == "Heading Title"
+        assert service._strip_markdown("### Heading Title") == "Heading Title"
+
+    def test_strip_markdown_inline_code(self):
+        """Test stripping inline code backticks (`text`)."""
+        service = _create_service_with_mock_llm()
+        assert service._strip_markdown("`code title`") == "code title"
+
+    def test_strip_markdown_strikethrough(self):
+        """Test stripping strikethrough (~~text~~)."""
+        service = _create_service_with_mock_llm()
+        assert service._strip_markdown("~~strikethrough~~") == "strikethrough"
+
+    def test_strip_markdown_plain_text_unchanged(self):
+        """Test that plain text is returned unchanged."""
+        service = _create_service_with_mock_llm()
+        assert service._strip_markdown("Plain Title") == "Plain Title"
+
+    def test_strip_markdown_empty_and_none(self):
+        """Test that empty/None input is handled."""
+        service = _create_service_with_mock_llm()
+        assert service._strip_markdown("") == ""
+        assert service._strip_markdown(None) is None
+
+    def test_strip_markdown_mixed(self):
+        """Test stripping mixed markdown formatting."""
+        service = _create_service_with_mock_llm()
+        assert service._strip_markdown("**Bold** and *italic*") == "Bold and italic"
+
+    @pytest.mark.asyncio
+    async def test_call_litellm_strips_markdown(self):
+        """Test that markdown formatting is stripped from LLM-generated titles."""
+        mock_resp = _mock_llm_response("**Bold Title**")
+        service = _create_service_with_mock_llm(llm_return=mock_resp)
+
+        result = await service._call_litellm("Hello", "Hi")
+
+        assert result == "Bold Title"


### PR DESCRIPTION
This pull request improves the title generation service to ensure that generated conversation titles do not contain any markdown formatting, resulting in cleaner and more user-friendly titles. The main changes include adding logic to strip markdown from titles, updating the LLM prompt to explicitly request plain text, and introducing comprehensive tests to verify the new behavior.

**Title formatting improvements:**

* Added a `_strip_markdown` method to `title_generation_service.py` that removes common markdown formatting (bold, italic, headings, inline code, strikethrough) from generated titles.
* Updated the LLM prompt in `_call_litellm` to instruct the model to output only plain text, without any markdown formatting.
* Integrated `_strip_markdown` into the title generation flow to ensure all titles are sanitized before being returned.

**Testing improvements:**

* Added a comprehensive suite of unit tests for `_strip_markdown`, covering all supported markdown formats, mixed formatting, and edge cases (empty/None input).
* Added an async test to verify that markdown is stripped from LLM-generated titles in the end-to-end flow.

**Codebase maintenance:**

* Imported the `re` module to support regex-based markdown stripping.