### PR TITLE
feat(DATAGO-131548): Add per-request model override via A2A task metadata

### DIFF
--- a/client/webui/frontend/src/lib/components/models/index.ts
+++ b/client/webui/frontend/src/lib/components/models/index.ts
@@ -1,7 +1,9 @@
 export { ModelsView } from "./ModelsView";
 export { ModelDetailsPage } from "./ModelDetailsPage";
 export { ModelDeleteDialog } from "./ModelDeleteDialog";
+export { ModelEdit } from "./ModelEdit";
 export { ModelEditPage } from "./ModelEditPage";
+export { ALL_PROVIDERS, buildModelPayload, type ModelFormData } from "./modelProviderUtils";
 export { ModelSetupDialog } from "./ModelSetupDialog";
 export { ModelWarningBanner } from "./ModelWarningBanner";
 export { ModelProviderIcon } from "./ModelProviderIcon";

--- a/src/solace_agent_mesh/agent/adk/callbacks.py
+++ b/src/solace_agent_mesh/agent/adk/callbacks.py
@@ -3332,6 +3332,7 @@ def apply_model_override_callback(
     ``ModelConfigService.get_by_alias(raw=True)``).  Applied via a
     ``ContextVar`` that ``LiteLlm.generate_content_async`` consumes.
     """
+    # Inline import to avoid circular dependency (callbacks ← setup → lite_llm)
     from .models.lite_llm import set_model_override
 
     a2a_context = callback_context.state.get("a2a_context")

--- a/src/solace_agent_mesh/agent/adk/callbacks.py
+++ b/src/solace_agent_mesh/agent/adk/callbacks.py
@@ -3319,3 +3319,36 @@ async def audit_log_openapi_tool_execution_result(
         )
 
     return None
+
+
+def apply_model_override_callback(
+    callback_context: CallbackContext,
+    llm_request: LlmRequest,
+    host_component: "SamAgentComponent",
+) -> Optional[LlmResponse]:
+    """Read model_override from A2A task metadata.
+
+    model_override is a full LiteLLM-ready config dict (same format as
+    ``ModelConfigService.get_by_alias(raw=True)``).  Applied via a
+    ``ContextVar`` that ``LiteLlm.generate_content_async`` consumes.
+    """
+    from .models.lite_llm import set_model_override
+
+    a2a_context = callback_context.state.get("a2a_context")
+    if not a2a_context:
+        set_model_override(None)
+        return None
+
+    metadata = a2a_context.get("original_message_metadata") or {}
+
+    model_override = metadata.get("model_override")
+    if isinstance(model_override, dict) and model_override.get("model"):
+        set_model_override(model_override)
+        log.info(
+            "[Callback:ModelOverride] Set per-request model override: %s",
+            model_override["model"],
+        )
+    else:
+        set_model_override(None)
+
+    return None

--- a/src/solace_agent_mesh/agent/adk/models/dynamic_model_provider.py
+++ b/src/solace_agent_mesh/agent/adk/models/dynamic_model_provider.py
@@ -91,10 +91,15 @@ class ModelConfigReceiverComponent(ComponentBase):
 
             model_config = payload.get("model_config")
 
-            # Extract model_id from topic: .../response/{model_id}/{component_id}
-            # or .../model/{model_id} for config updates
+            # Extract model_id from topic based on shape:
+            #   Bootstrap response: .../response/{model_id}/{component_id} → parts[-2]
+            #   Config update:      .../configuration/model/{model_id}    → parts[-1]
             parts = topic.split("/")
-            topic_model_id = parts[-2] if len(parts) >= 2 else None
+            is_bootstrap_response = len(parts) >= 3 and parts[-3] == "response"
+            if is_bootstrap_response:
+                topic_model_id = parts[-2]
+            else:
+                topic_model_id = parts[-1] if parts else None
 
             if topic_model_id == self.model_provider._model_id:
                 # Response for this provider's own model — existing behavior

--- a/src/solace_agent_mesh/agent/adk/models/dynamic_model_provider.py
+++ b/src/solace_agent_mesh/agent/adk/models/dynamic_model_provider.py
@@ -2,12 +2,14 @@
 Dynamic Model Provider for enterprise model configuration.
 """
 
-from typing import Any, Dict, Union
 import asyncio
+import logging
+import threading
+from typing import Any, Dict, List, Optional, Union
+
 from solace_agent_mesh.agent.adk.models.lite_llm import LiteLlm
 from solace_ai_connector.components.component_base import ComponentBase
 from solace_ai_connector.common.message import Message as SolaceMessage
-import logging
 
 from .dynamic_model_provider_topics import (
     get_bootstrap_request_topic,
@@ -19,6 +21,7 @@ log = logging.getLogger(__name__)
 
 _MAX_BOOTSTRAP_RETRIES = 3
 _BOOTSTRAP_RETRY_INTERVAL_SECONDS = 5
+_RESOLVE_TIMEOUT_SECONDS = 10.0
 
 
 # SAC Component Info for ModelConfigReceiverComponent
@@ -75,13 +78,6 @@ class ModelConfigReceiverComponent(ComponentBase):
         log.info("%s ModelConfigReceiverComponent initialized.", self.log_identifier)
 
     def invoke(self, message: SolaceMessage, data: Dict[str, Any]) -> None:
-        """
-        Processes the incoming model configuration message.
-
-        Args:
-            message: The SolaceMessage object from BrokerInput.
-            data: The data extracted by BrokerInput (payload, topic, user_properties).
-        """
         log_id_prefix = f"{self.log_identifier}[Invoke]"
         try:
             topic = data.get("topic", "")
@@ -93,26 +89,36 @@ class ModelConfigReceiverComponent(ComponentBase):
                 topic,
             )
 
-            # Check if model_config exists in payload
             model_config = payload.get("model_config")
 
-            if model_config:
-                log.info(
-                    "%s Model config found, updating LiteLlm: %s",
-                    log_id_prefix,
-                    model_config.get('model', 'N/A'),
-                )
-                self.model_provider.mark_initialized()
-                self.model_provider.update_litellm_model(model_config)
+            # Extract model_id from topic: .../response/{model_id}/{component_id}
+            # or .../model/{model_id} for config updates
+            parts = topic.split("/")
+            topic_model_id = parts[-2] if len(parts) >= 2 else None
+
+            if topic_model_id == self.model_provider._model_id:
+                # Response for this provider's own model — existing behavior
+                if model_config:
+                    log.info(
+                        "%s Model config found, updating LiteLlm: %s",
+                        log_id_prefix,
+                        model_config.get('model', 'N/A'),
+                    )
+                    self.model_provider.mark_initialized()
+                    self.model_provider.update_litellm_model(model_config)
+                else:
+                    log.info(
+                        "%s No model config or empty config, removing LiteLlm model",
+                        log_id_prefix,
+                    )
+                    self.model_provider.remove_litellm_model()
             else:
-                log.info(
-                    "%s No model config or empty config, removing LiteLlm model",
-                    log_id_prefix,
+                # Response for a different model_id — one-shot alias resolution
+                self.model_provider.complete_pending_resolve(
+                    topic_model_id, model_config
                 )
-                self.model_provider.remove_litellm_model()
 
             message.call_acknowledgements()
-            log.debug("%s Message acknowledged to BrokerInput.", log_id_prefix)
 
         except Exception as e:
             log.exception(
@@ -139,6 +145,11 @@ class DynamicModelProvider:
 
         # Initial model configuration
         self._initialized = False
+
+        # One-shot alias resolution state (thread-safe)
+        self._pending_resolves: Dict[str, List[asyncio.Future]] = {}
+        self._resolve_lock = threading.Lock()
+
         asyncio.create_task(self.initialize())
 
     async def initialize(self):
@@ -232,9 +243,10 @@ class DynamicModelProvider:
                 )
                 raise ValueError("Main app broker configuration is missing.")
 
-            # Subscribe to the model config update topic
             config_update_topic = get_model_config_update_topic(self._component.namespace, self._model_id)
-            config_bootstrap_topic = get_bootstrap_response_topic(self._component.namespace, self._model_id, self._component.get_component_id())
+            # Wildcard subscription catches both own-model bootstrap responses
+            # and one-shot alias resolution responses for any model_id
+            config_bootstrap_topic = get_bootstrap_response_topic(self._component.namespace, "*", self._component.get_component_id())
             component_id = self._component.get_component_id()
 
             broker_input_cfg = {
@@ -345,11 +357,103 @@ class DynamicModelProvider:
         log.info("Setting up model configuration listener...")
         self._ensure_config_listener_flow_is_running()
 
+    async def resolve(
+        self, alias: str, timeout: float = _RESOLVE_TIMEOUT_SECONDS
+    ) -> Optional[Dict[str, Any]]:
+        """Resolve a model config alias to a raw LiteLLM config dict.
+
+        Sends a bootstrap request to the platform service and awaits the
+        response. Concurrent requests for the same alias are de-duplicated:
+        only the first publishes a broker message; subsequent callers
+        piggyback on the pending response.
+
+        Returns None on timeout or if the platform returns no config.
+        """
+        if not self._internal_app:
+            log.warning(
+                "%s Cannot resolve alias '%s' — listener not running",
+                self._component.log_identifier,
+                alias,
+            )
+            return None
+
+        loop = asyncio.get_running_loop()
+        future: asyncio.Future = loop.create_future()
+
+        with self._resolve_lock:
+            if alias in self._pending_resolves:
+                self._pending_resolves[alias].append(future)
+                should_publish = False
+            else:
+                self._pending_resolves[alias] = [future]
+                should_publish = True
+
+        if should_publish:
+            component_id = self._component.get_component_id()
+            response_topic = get_bootstrap_response_topic(
+                self._component.namespace, alias, component_id
+            )
+            self._component.publish_a2a_message(
+                payload={
+                    "model_id": alias,
+                    "reply_to": response_topic,
+                    "component_id": component_id,
+                    "component_type": self._component._get_component_type(),
+                },
+                topic=get_bootstrap_request_topic(
+                    self._component.namespace, alias
+                ),
+            )
+
+        try:
+            result = await asyncio.wait_for(future, timeout=timeout)
+            return result
+        except asyncio.TimeoutError:
+            log.warning(
+                "%s Model alias resolution timed out for '%s' after %.1fs",
+                self._component.log_identifier,
+                alias,
+                timeout,
+            )
+            return None
+        finally:
+            with self._resolve_lock:
+                futures = self._pending_resolves.get(alias, [])
+                if future in futures:
+                    futures.remove(future)
+                if not futures:
+                    self._pending_resolves.pop(alias, None)
+
+    def complete_pending_resolve(
+        self, alias: str, model_config: Optional[Dict[str, Any]]
+    ) -> None:
+        """Complete all pending resolve futures for a given alias.
+
+        Called from the SAC receiver thread. Uses call_soon_threadsafe to
+        safely set results on asyncio.Futures from a non-event-loop thread.
+        """
+        with self._resolve_lock:
+            futures = self._pending_resolves.pop(alias, [])
+
+        if not futures:
+            return
+
+        loop = self._component._async_loop
+        for future in futures:
+            if not future.done():
+                loop.call_soon_threadsafe(future.set_result, model_config)
+
     def cleanup(self) -> None:
-        """
-        Cleanup resources when the provider is no longer needed.
-        """
+        """Cleanup resources when the provider is no longer needed."""
         log.info("Cleaning up DynamicModelProvider...")
+
+        with self._resolve_lock:
+            for futures in self._pending_resolves.values():
+                for future in futures:
+                    if not future.done():
+                        future.cancel()
+            self._pending_resolves.clear()
+
         if self._internal_app:
             log.info("Cleaning up internal model config app...")
             try:

--- a/src/solace_agent_mesh/agent/adk/models/dynamic_model_provider.py
+++ b/src/solace_agent_mesh/agent/adk/models/dynamic_model_provider.py
@@ -12,6 +12,7 @@ from solace_ai_connector.components.component_base import ComponentBase
 from solace_ai_connector.common.message import Message as SolaceMessage
 
 from .dynamic_model_provider_topics import (
+    extract_model_id_from_topic,
     get_bootstrap_request_topic,
     get_bootstrap_response_topic,
     get_model_config_update_topic,
@@ -99,17 +100,9 @@ class ModelConfigReceiverComponent(ComponentBase):
 
             model_config = payload.get("model_config")
 
-            # Extract model_id from topic based on shape:
-            #   Bootstrap response: .../response/{model_id}/{component_id} → parts[-2]
-            #   Config update:      .../configuration/model/{model_id}    → parts[-1]
-            parts = topic.split("/")
-            is_bootstrap_response = len(parts) >= 3 and parts[-3] == "response"
-            if is_bootstrap_response:
-                topic_model_id = parts[-2]
-            else:
-                topic_model_id = parts[-1] if parts else None
+            topic_model_id, _ = extract_model_id_from_topic(topic)
 
-            if topic_model_id == self.model_provider._model_id:
+            if topic_model_id == self.model_provider.model_id:
                 if model_config:
                     log.info(
                         "%s Model config found, updating LiteLlm: %s",
@@ -158,16 +151,25 @@ class DynamicModelProvider:
         # Initial model configuration
         self._initialized = False
 
+        # Event loop reference, captured during initialize() for cross-thread use
+        self._loop: Optional[asyncio.AbstractEventLoop] = None
+
         # One-shot alias resolution state (thread-safe)
         self._pending_resolves: Dict[str, List[asyncio.Future]] = {}
         self._resolve_lock = threading.Lock()
 
         asyncio.create_task(self.initialize())
 
+    @property
+    def model_id(self) -> str:
+        """The model identifier this provider is configured for."""
+        return self._model_id
+
     async def initialize(self):
         """
         Initialize the DynamicModelProvider by starting to listen for model config changes.
         """
+        self._loop = asyncio.get_running_loop()
         await self.listen_for_model_config_change()
 
         # Call request_model_config up to 3 times, once every 5 seconds, until initialized
@@ -450,7 +452,7 @@ class DynamicModelProvider:
         if not futures:
             return
 
-        loop = self._component._async_loop
+        loop = self._loop
         for future in futures:
             if not future.done():
                 loop.call_soon_threadsafe(future.set_result, model_config)

--- a/src/solace_agent_mesh/agent/adk/models/dynamic_model_provider.py
+++ b/src/solace_agent_mesh/agent/adk/models/dynamic_model_provider.py
@@ -78,6 +78,14 @@ class ModelConfigReceiverComponent(ComponentBase):
         log.info("%s ModelConfigReceiverComponent initialized.", self.log_identifier)
 
     def invoke(self, message: SolaceMessage, data: Dict[str, Any]) -> None:
+        """Process an incoming model configuration message.
+
+        Routes by model_id extracted from the topic:
+        - If model_id matches this provider's configured model, updates
+          the LiteLlm instance (bootstrap response or config change).
+        - Otherwise, completes any pending one-shot resolve futures for
+          that model_id (per-request alias resolution).
+        """
         log_id_prefix = f"{self.log_identifier}[Invoke]"
         try:
             topic = data.get("topic", "")
@@ -102,7 +110,6 @@ class ModelConfigReceiverComponent(ComponentBase):
                 topic_model_id = parts[-1] if parts else None
 
             if topic_model_id == self.model_provider._model_id:
-                # Response for this provider's own model — existing behavior
                 if model_config:
                     log.info(
                         "%s Model config found, updating LiteLlm: %s",

--- a/src/solace_agent_mesh/agent/adk/models/dynamic_model_provider_topics.py
+++ b/src/solace_agent_mesh/agent/adk/models/dynamic_model_provider_topics.py
@@ -49,3 +49,22 @@ def get_model_config_update_topic(namespace: str, model_id: str) -> str:
         namespace=namespace,
         model_id=model_id,
     )
+
+
+def extract_model_id_from_topic(topic: str) -> tuple[str | None, bool]:
+    """Extract the model_id from a model config topic.
+
+    Supports both topic shapes:
+      - Bootstrap response: .../response/{model_id}/{component_id}
+      - Config update:      .../configuration/model/{model_id}
+
+    Returns:
+        (model_id, is_bootstrap_response) — model_id is None if the
+        topic doesn't match any known shape.
+    """
+    parts = topic.split("/")
+    if len(parts) >= 3 and parts[-3] == "response":
+        return parts[-2], True
+    if parts:
+        return parts[-1], False
+    return None, False

--- a/src/solace_agent_mesh/agent/adk/models/lite_llm.py
+++ b/src/solace_agent_mesh/agent/adk/models/lite_llm.py
@@ -154,6 +154,11 @@ def set_model_override(config: Optional[Dict[str, Any]]) -> None:
     _model_override_var.set(config)
 
 
+def get_model_override() -> Optional[Dict[str, Any]]:
+    """Return the per-request model override for the current async task, or None."""
+    return _model_override_var.get()
+
+
 class FunctionChunk(BaseModel):
     id: Optional[str]
     name: Optional[str]
@@ -1205,7 +1210,7 @@ class LiteLlm(BaseLlm):
         # Apply per-request model override if set by the callback chain.
         # The ContextVar is managed by apply_model_override_callback which
         # runs before every LLM call, so we just read here — no clearing.
-        override_config = _model_override_var.get()
+        override_config = get_model_override()
         if override_config:
             override_copy = override_config.copy()
             override_copy.setdefault("num_retries", self._model_config.get("num_retries", 3))

--- a/src/solace_agent_mesh/agent/adk/models/lite_llm.py
+++ b/src/solace_agent_mesh/agent/adk/models/lite_llm.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 
 import base64
 import contextvars
+import copy
 import hashlib
 import json
 import logging
@@ -1212,7 +1213,7 @@ class LiteLlm(BaseLlm):
         # runs before every LLM call, so we just read here — no clearing.
         override_config = get_model_override()
         if override_config:
-            override_copy = override_config.copy()
+            override_copy = copy.deepcopy(override_config)
             override_copy.setdefault("num_retries", self._model_config.get("num_retries", 3))
             override_copy.setdefault("timeout", self._model_config.get("timeout", 120))
             logger.info(

--- a/src/solace_agent_mesh/agent/adk/models/lite_llm.py
+++ b/src/solace_agent_mesh/agent/adk/models/lite_llm.py
@@ -132,6 +132,28 @@ class ObservabilityContext:
         return False  # Don't suppress exceptions
 
 
+# Per-request model override via ContextVar.
+# Set by the model_override callback (before_model chain) and consumed by
+# generate_content_async(). Each asyncio.Task gets its own copy, so
+# concurrent requests with different overrides are isolated.
+_model_override_var: contextvars.ContextVar[Optional[Dict[str, Any]]] = contextvars.ContextVar(
+    "model_override_config", default=None
+)
+
+
+def set_model_override(config: Optional[Dict[str, Any]]) -> None:
+    """Set or clear the per-request model override for the current async task.
+
+    Pass a LiteLLM-ready config dict to override, or None to clear::
+
+        {"model": "openai/gpt-4o", "api_key": "sk-...", "api_base": "https://..."}
+
+    Managed by apply_model_override_callback (sets before every LLM call);
+    read by LiteLlm.generate_content_async().
+    """
+    _model_override_var.set(config)
+
+
 class FunctionChunk(BaseModel):
     id: Optional[str]
     name: Optional[str]
@@ -1180,6 +1202,23 @@ class LiteLlm(BaseLlm):
         }
         completion_args.update(self._model_config)
 
+        # Apply per-request model override if set by the callback chain.
+        # The ContextVar is managed by apply_model_override_callback which
+        # runs before every LLM call, so we just read here — no clearing.
+        override_config = _model_override_var.get()
+        if override_config:
+            override_copy = override_config.copy()
+            override_copy.setdefault("num_retries", self._model_config.get("num_retries", 3))
+            override_copy.setdefault("timeout", self._model_config.get("timeout", 120))
+            logger.info(
+                "Applying per-request model override: model=%s (default was %s)",
+                override_copy.get("model", "unspecified"),
+                self._model_config.get("model", "unknown"),
+            )
+            completion_args.update(override_copy)
+
+        effective_model = completion_args.get("model", self.model)
+
         # Inject OAuth token if OAuth is configured
         if self._oauth_token_manager:
             try:
@@ -1254,8 +1293,8 @@ class LiteLlm(BaseLlm):
             fallback_index = 0
 
             # Create monitors for observability
-            gen_ai_monitor = GenAIMonitor.create(model=self.model)
-            ttft_latency = MonitorLatency(GenAITTFTMonitor.create(model=self.model)).start()
+            gen_ai_monitor = GenAIMonitor.create(model=effective_model)
+            ttft_latency = MonitorLatency(GenAITTFTMonitor.create(model=effective_model)).start()
             ttft_recorded = False
 
             # Try with thinking params first; if the model doesn't support them,
@@ -1320,7 +1359,7 @@ class LiteLlm(BaseLlm):
                             # Update token labels and record metrics
                             gen_ai_monitor.set_prompt_tokens(chunk.prompt_tokens)
                             self._record_token_and_cost_metrics(
-                                self.model,
+                                effective_model,
                                 chunk.prompt_tokens,
                                 chunk.completion_tokens
                             )
@@ -1422,7 +1461,7 @@ class LiteLlm(BaseLlm):
                 yield aggregated_llm_response_with_tool_call
 
         else:
-            monitor = GenAIMonitor.create(model=self.model)
+            monitor = GenAIMonitor.create(model=effective_model)
 
             with MonitorLatency(monitor):
                 response = await self._acompletion_with_thinking_fallback(completion_args)
@@ -1434,7 +1473,7 @@ class LiteLlm(BaseLlm):
                     monitor.set_prompt_tokens(prompt_tokens)
                     # Record token and cost metrics
                     self._record_token_and_cost_metrics(
-                        self.model,
+                        effective_model,
                         prompt_tokens,
                         completion_tokens
                     )

--- a/src/solace_agent_mesh/agent/adk/setup.py
+++ b/src/solace_agent_mesh/agent/adk/setup.py
@@ -1015,6 +1015,16 @@ def initialize_adk_agent(
             component.log_identifier,
         )
 
+        model_override_cb = functools.partial(
+            adk_callbacks.apply_model_override_callback,
+            host_component=component,
+        )
+        callbacks_in_order_for_before_model.append(model_override_cb)
+        log.debug(
+            "%s Added apply_model_override_callback to before_model chain.",
+            component.log_identifier,
+        )
+
         if hasattr(component, "_inject_peer_tools_callback"):
             callbacks_in_order_for_before_model.append(
                 component._inject_peer_tools_callback

--- a/src/solace_agent_mesh/agent/protocol/event_handlers.py
+++ b/src/solace_agent_mesh/agent/protocol/event_handlers.py
@@ -6,7 +6,7 @@ import asyncio
 import fnmatch
 import json
 import logging
-from typing import TYPE_CHECKING, Any, Dict
+from typing import TYPE_CHECKING, Any, Dict, Optional
 
 from openfeature import api as openfeature_api
 
@@ -1048,6 +1048,75 @@ def _send_error_response_and_nack(
     component.handle_error(exception, Event(EventType.MESSAGE, message))
 
 
+async def _resolve_model_override_metadata(
+    task_metadata: Dict[str, Any],
+    dynamic_model_provider: Any,
+    log_identifier: str,
+) -> Optional[str]:
+    """Resolve model_override alias in task metadata to a raw LiteLLM config dict.
+
+    Gated behind the ``offline_evals`` feature flag.  Mutates *task_metadata*
+    in place:
+
+    * Valid alias resolved   -> replaces value with raw config dict
+    * Flag disabled / invalid format -> removes the key
+    * Resolution failure     -> returns an error reason string
+
+    Returns ``None`` on success/no-op, or an error reason string when the
+    caller should reject the request.
+    """
+    model_override = task_metadata.get("model_override")
+    if model_override is None:
+        return None
+
+    if not openfeature_api.get_client().get_boolean_value("offline_evals", False):
+        log.debug(
+            "%s model_override in metadata ignored (offline_evals flag disabled)",
+            log_identifier,
+        )
+        task_metadata.pop("model_override", None)
+        return None
+
+    if not (
+        isinstance(model_override, dict)
+        and isinstance(model_override.get("model_id"), str)
+        and model_override["model_id"]
+    ):
+        log.warning(
+            "%s Unrecognized model_override format, ignoring",
+            log_identifier,
+        )
+        task_metadata.pop("model_override", None)
+        return None
+
+    model_id = model_override["model_id"]
+    resolved = None
+    if dynamic_model_provider:
+        resolved = await dynamic_model_provider.resolve(model_id)
+
+    if resolved:
+        task_metadata["model_override"] = resolved
+        log.info(
+            "%s Resolved model override alias '%s' to model=%s",
+            log_identifier,
+            model_id,
+            resolved.get("model"),
+        )
+        return None
+
+    reason = (
+        "model config not available"
+        if not dynamic_model_provider
+        else f"alias '{model_id}' not found or resolution timed out"
+    )
+    log.error(
+        "%s Model override resolution failed: %s",
+        log_identifier,
+        reason,
+    )
+    return reason
+
+
 async def _handle_send_message_request(
     component: "SamAgentComponent",
     message: SolaceMessage,
@@ -1124,66 +1193,28 @@ async def _handle_send_message_request(
     message_id = a2a_message.message_id
     task_metadata = a2a_message.metadata or {}
 
-    # Resolve model_override alias to raw config dict via platform service.
-    # Gated behind offline_evals feature flag. Expected format: {"model_id": "<alias-or-uuid>"}
-    model_override = task_metadata.get("model_override")
-    if model_override is not None:
-        if not openfeature_api.get_client().get_boolean_value("offline_evals", False):
-            log.debug(
-                "%s model_override in metadata ignored (offline_evals flag disabled)",
-                component.log_identifier,
+    override_error = await _resolve_model_override_metadata(
+        task_metadata,
+        component._dynamic_model_provider,
+        component.log_identifier,
+    )
+    if override_error:
+        error_response = a2a.create_invalid_request_error_response(
+            message=f"Model override resolution failed: {override_error}",
+            request_id=jsonrpc_request_id,
+        )
+        target_topic = reply_topic_from_peer or (
+            get_client_response_topic(namespace, client_id)
+            if client_id
+            else None
+        )
+        if target_topic:
+            component.publish_a2a_message(
+                error_response.model_dump(exclude_none=True),
+                target_topic,
             )
-            task_metadata.pop("model_override", None)
-        elif (
-            isinstance(model_override, dict)
-            and isinstance(model_override.get("model_id"), str)
-            and model_override["model_id"]
-        ):
-            model_id = model_override["model_id"]
-            resolved = None
-            if component._dynamic_model_provider:
-                resolved = await component._dynamic_model_provider.resolve(model_id)
-            if resolved:
-                task_metadata["model_override"] = resolved
-                log.info(
-                    "%s Resolved model override alias '%s' to model=%s",
-                    component.log_identifier,
-                    model_id,
-                    resolved.get("model"),
-                )
-            else:
-                reason = (
-                    "model config not available"
-                    if not component._dynamic_model_provider
-                    else f"alias '{model_id}' not found or resolution timed out"
-                )
-                log.error(
-                    "%s Model override resolution failed: %s",
-                    component.log_identifier,
-                    reason,
-                )
-                error_response = a2a.create_invalid_request_error_response(
-                    message=f"Model override resolution failed: {reason}",
-                    request_id=jsonrpc_request_id,
-                )
-                target_topic = reply_topic_from_peer or (
-                    get_client_response_topic(namespace, client_id)
-                    if client_id
-                    else None
-                )
-                if target_topic:
-                    component.publish_a2a_message(
-                        error_response.model_dump(exclude_none=True),
-                        target_topic,
-                    )
-                message.call_negative_acknowledgements()
-                return None
-        else:
-            log.warning(
-                "%s Unrecognized model_override format, ignoring",
-                component.log_identifier,
-            )
-            task_metadata.pop("model_override", None)
+        message.call_negative_acknowledgements()
+        return None
 
     system_purpose = task_metadata.get("system_purpose")
     response_format = task_metadata.get("response_format")

--- a/src/solace_agent_mesh/agent/protocol/event_handlers.py
+++ b/src/solace_agent_mesh/agent/protocol/event_handlers.py
@@ -8,6 +8,8 @@ import json
 import logging
 from typing import TYPE_CHECKING, Any, Dict
 
+from openfeature import api as openfeature_api
+
 from ...common.error_handlers import LITELLM_EXCEPTIONS
 
 from a2a.types import (
@@ -1121,6 +1123,54 @@ async def _handle_send_message_request(
     original_session_id = a2a_message.context_id
     message_id = a2a_message.message_id
     task_metadata = a2a_message.metadata or {}
+
+    # Resolve model_override alias to raw config dict via platform service.
+    # Gated behind offline_evals feature flag. Expected format: {"model_id": "<alias-or-uuid>"}
+    model_override = task_metadata.get("model_override")
+    if model_override is not None:
+        if not openfeature_api.get_client().get_boolean_value("offline_evals", False):
+            log.debug(
+                "%s model_override in metadata ignored (offline_evals flag disabled)",
+                component.log_identifier,
+            )
+            task_metadata.pop("model_override", None)
+        elif (
+            isinstance(model_override, dict)
+            and isinstance(model_override.get("model_id"), str)
+            and model_override["model_id"]
+        ):
+            model_id = model_override["model_id"]
+            if component._dynamic_model_provider:
+                resolved = await component._dynamic_model_provider.resolve(model_id)
+                if resolved:
+                    task_metadata["model_override"] = resolved
+                    log.info(
+                        "%s Resolved model override alias '%s' to model=%s",
+                        component.log_identifier,
+                        model_id,
+                        resolved.get("model"),
+                    )
+                else:
+                    log.warning(
+                        "%s Failed to resolve model override alias '%s', falling back to default",
+                        component.log_identifier,
+                        model_id,
+                    )
+                    task_metadata.pop("model_override", None)
+            else:
+                log.warning(
+                    "%s Model override alias '%s' provided but model config not available",
+                    component.log_identifier,
+                    model_id,
+                )
+                task_metadata.pop("model_override", None)
+        else:
+            log.warning(
+                "%s Unrecognized model_override format, ignoring",
+                component.log_identifier,
+            )
+            task_metadata.pop("model_override", None)
+
     system_purpose = task_metadata.get("system_purpose")
     response_format = task_metadata.get("response_format")
     session_behavior_from_meta = task_metadata.get("sessionBehavior")

--- a/src/solace_agent_mesh/agent/protocol/event_handlers.py
+++ b/src/solace_agent_mesh/agent/protocol/event_handlers.py
@@ -1213,6 +1213,11 @@ async def _handle_send_message_request(
                 error_response.model_dump(exclude_none=True),
                 target_topic,
             )
+        else:
+            log.warning(
+                "%s Model override error response could not be delivered (no reply topic)",
+                component.log_identifier,
+            )
         message.call_negative_acknowledgements()
         return None
 

--- a/src/solace_agent_mesh/agent/protocol/event_handlers.py
+++ b/src/solace_agent_mesh/agent/protocol/event_handlers.py
@@ -1140,30 +1140,44 @@ async def _handle_send_message_request(
             and model_override["model_id"]
         ):
             model_id = model_override["model_id"]
+            resolved = None
             if component._dynamic_model_provider:
                 resolved = await component._dynamic_model_provider.resolve(model_id)
-                if resolved:
-                    task_metadata["model_override"] = resolved
-                    log.info(
-                        "%s Resolved model override alias '%s' to model=%s",
-                        component.log_identifier,
-                        model_id,
-                        resolved.get("model"),
-                    )
-                else:
-                    log.warning(
-                        "%s Failed to resolve model override alias '%s', falling back to default",
-                        component.log_identifier,
-                        model_id,
-                    )
-                    task_metadata.pop("model_override", None)
-            else:
-                log.warning(
-                    "%s Model override alias '%s' provided but model config not available",
+            if resolved:
+                task_metadata["model_override"] = resolved
+                log.info(
+                    "%s Resolved model override alias '%s' to model=%s",
                     component.log_identifier,
                     model_id,
+                    resolved.get("model"),
                 )
-                task_metadata.pop("model_override", None)
+            else:
+                reason = (
+                    "model config not available"
+                    if not component._dynamic_model_provider
+                    else f"alias '{model_id}' not found or resolution timed out"
+                )
+                log.error(
+                    "%s Model override resolution failed: %s",
+                    component.log_identifier,
+                    reason,
+                )
+                error_response = a2a.create_invalid_request_error_response(
+                    message=f"Model override resolution failed: {reason}",
+                    request_id=jsonrpc_request_id,
+                )
+                target_topic = reply_topic_from_peer or (
+                    get_client_response_topic(namespace, client_id)
+                    if client_id
+                    else None
+                )
+                if target_topic:
+                    component.publish_a2a_message(
+                        error_response.model_dump(exclude_none=True),
+                        target_topic,
+                    )
+                message.call_negative_acknowledgements()
+                return None
         else:
             log.warning(
                 "%s Unrecognized model_override format, ignoring",

--- a/src/solace_agent_mesh/common/features/features.yaml
+++ b/src/solace_agent_mesh/common/features/features.yaml
@@ -122,3 +122,14 @@ features:
       Display LLM thinking/reasoning tokens as expandable entries in the
       inline activity timeline. When disabled, thinking entries are filtered
       out and thinking content is not accumulated on messages.
+
+  - key: offline_evals
+    name: Offline Enterprise Evaluations
+    release_phase: experimental
+    default: false
+    jira: DATAGO-104642
+    description: >
+      Enable the offline enterprise evaluation framework. Allows running
+      evaluations against deployed SAM agents with per-request model
+      overrides. When disabled, model override metadata is ignored and
+      the resolver is not initialized.

--- a/src/solace_agent_mesh/common/sac/sam_component_base.py
+++ b/src/solace_agent_mesh/common/sac/sam_component_base.py
@@ -640,6 +640,10 @@ class SamComponentBase(ComponentBase, abc.ABC):
                 "%s Error during _pre_async_cleanup(): %s", self.log_identifier, e
             )
 
+        if self._dynamic_model_provider:
+            self._dynamic_model_provider.cleanup()
+            self._dynamic_model_provider = None
+
         if self._async_loop and self._async_loop.is_running():
             log.info("%s Requesting asyncio loop to stop...", self.log_identifier)
             self._async_loop.call_soon_threadsafe(self._async_loop.stop)

--- a/src/solace_agent_mesh/common/sac/sam_component_base.py
+++ b/src/solace_agent_mesh/common/sac/sam_component_base.py
@@ -14,7 +14,7 @@ from google.adk.models import BaseLlm
 from openfeature import api as openfeature_api
 from solace_ai_connector.components.component_base import ComponentBase
 from ...agent.adk.models.lite_llm import LiteLlm
-from ...agent.adk.models.dynamic_model_provider import start_model_listener
+from ...agent.adk.models.dynamic_model_provider import DynamicModelProvider, start_model_listener
 from ..exceptions import ComponentInitializationError, MessageSizeExceededError
 from ..features import core as feature_flags
 from ..utils.message_utils import validate_message_size
@@ -71,6 +71,9 @@ class SamComponentBase(ComponentBase, abc.ABC):
 
         # Trust Manager integration (enterprise feature) - initialized as part of _late_init
         self.trust_manager: Optional[Any] = None
+
+        # DynamicModelProvider ref for per-request model alias resolution
+        self._dynamic_model_provider: Optional[DynamicModelProvider] = None
 
         feature_flags.initialize()
 
@@ -782,7 +785,9 @@ class SamComponentBase(ComponentBase, abc.ABC):
         # Try enterprise model listener
         try:
             litellm_instance = self.get_lite_llm_model()
-            await start_model_listener(litellm_instance, self, self.model_provider)
+            self._dynamic_model_provider = await start_model_listener(
+                litellm_instance, self, self.model_provider
+            )
             log.info("%s Enterprise model listener started.", self.log_identifier)
         except Exception as e:
             log.warning(

--- a/tests/unit/agent/adk/models/test_dynamic_model_provider.py
+++ b/tests/unit/agent/adk/models/test_dynamic_model_provider.py
@@ -1,5 +1,7 @@
 """Unit tests for DynamicModelProvider and ModelConfigReceiverComponent."""
 
+import threading
+
 import pytest
 from unittest.mock import MagicMock, patch, AsyncMock
 
@@ -41,6 +43,9 @@ def _make_provider_no_init(component=None, litellm_instance=None, model_id="gene
     provider._internal_app = None
     provider._broker_input = None
     provider._initialized = False
+    provider._resolve_lock = threading.Lock()
+    provider._pending_resolves = {}
+    provider._loop = None
     return provider
 
 
@@ -327,7 +332,7 @@ class TestModelConfigReceiverComponentInvoke:
 
         message = MagicMock()
         data = {
-            "topic": "test/topic",
+            "topic": "test/ns/configuration/model/response/general/test_agent",
             "payload": {"model_config": {"model": "gpt-4"}},
         }
 
@@ -345,7 +350,7 @@ class TestModelConfigReceiverComponentInvoke:
 
         message = MagicMock()
         data = {
-            "topic": "test/topic",
+            "topic": "test/ns/configuration/model/response/general/test_agent",
             "payload": {},
         }
 
@@ -362,7 +367,7 @@ class TestModelConfigReceiverComponentInvoke:
 
         message = MagicMock()
         data = {
-            "topic": "test/topic",
+            "topic": "test/ns/configuration/model/response/general/test_agent",
             "payload": {"model_config": {}},
         }
 
@@ -378,7 +383,7 @@ class TestModelConfigReceiverComponentInvoke:
 
         message = MagicMock()
         data = {
-            "topic": "test/topic",
+            "topic": "test/ns/configuration/model/response/general/test_agent",
             "payload": {"model_config": {"model": "gpt-4"}},
         }
 
@@ -395,7 +400,7 @@ class TestModelConfigReceiverComponentInvoke:
 
         message = MagicMock()
         data = {
-            "topic": "test/topic",
+            "topic": "test/ns/configuration/model/response/general/test_agent",
             "payload": {"model_config": {"model": "gpt-4"}},
         }
 

--- a/tests/unit/agent/adk/models/test_dynamic_model_provider_resolve.py
+++ b/tests/unit/agent/adk/models/test_dynamic_model_provider_resolve.py
@@ -1,0 +1,234 @@
+"""Tests for DynamicModelProvider.resolve() — one-shot model alias resolution."""
+
+import asyncio
+import threading
+import pytest
+from unittest.mock import MagicMock, patch
+
+
+def _make_provider():
+    """Create a DynamicModelProvider with mocked dependencies."""
+    from solace_agent_mesh.agent.adk.models.dynamic_model_provider import (
+        DynamicModelProvider,
+    )
+
+    component = MagicMock()
+    component.log_identifier = "[TestComponent]"
+    component.namespace = "test/"
+    component.get_component_id.return_value = "agent_1"
+    component._get_component_type.return_value = "agent"
+    component._async_loop = asyncio.get_event_loop()
+
+    litellm = MagicMock()
+
+    with patch.object(DynamicModelProvider, "initialize", return_value=asyncio.sleep(0)):
+        provider = DynamicModelProvider(component, litellm, "default-model")
+        provider._internal_app = MagicMock()
+
+    return provider, component
+
+
+class TestResolve:
+    @pytest.mark.asyncio
+    async def test_returns_resolved_config(self):
+        provider, component = _make_provider()
+        config = {"model": "openai/gpt-4o", "api_key": "sk-test"}
+
+        async def complete_after_publish(*args, **kwargs):
+            await asyncio.sleep(0.01)
+            provider.complete_pending_resolve("my-alias", config)
+
+        component.publish_a2a_message.side_effect = lambda **kw: asyncio.ensure_future(
+            complete_after_publish()
+        )
+
+        result = await provider.resolve("my-alias", timeout=2.0)
+        assert result == config
+        component.publish_a2a_message.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_returns_none_on_timeout(self):
+        provider, _ = _make_provider()
+        result = await provider.resolve("unknown", timeout=0.05)
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_returns_none_when_platform_returns_none(self):
+        provider, component = _make_provider()
+
+        async def complete_with_none(*args, **kwargs):
+            await asyncio.sleep(0.01)
+            provider.complete_pending_resolve("my-alias", None)
+
+        component.publish_a2a_message.side_effect = lambda **kw: asyncio.ensure_future(
+            complete_with_none()
+        )
+
+        result = await provider.resolve("my-alias", timeout=2.0)
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_returns_none_when_listener_not_running(self):
+        provider, _ = _make_provider()
+        provider._internal_app = None
+        result = await provider.resolve("my-alias", timeout=0.05)
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_cleans_up_pending_after_resolve(self):
+        provider, component = _make_provider()
+
+        async def complete(*args, **kwargs):
+            await asyncio.sleep(0.01)
+            provider.complete_pending_resolve("alias", {"model": "x"})
+
+        component.publish_a2a_message.side_effect = lambda **kw: asyncio.ensure_future(
+            complete()
+        )
+
+        await provider.resolve("alias", timeout=2.0)
+        assert "alias" not in provider._pending_resolves
+
+    @pytest.mark.asyncio
+    async def test_cleans_up_pending_after_timeout(self):
+        provider, _ = _make_provider()
+        await provider.resolve("alias", timeout=0.05)
+        assert "alias" not in provider._pending_resolves
+
+    @pytest.mark.asyncio
+    async def test_concurrent_resolves_deduped(self):
+        """Two concurrent resolves for the same alias should only publish once."""
+        provider, component = _make_provider()
+        config = {"model": "openai/gpt-4o"}
+
+        async def complete_delayed():
+            await asyncio.sleep(0.05)
+            provider.complete_pending_resolve("alias", config)
+
+        component.publish_a2a_message.side_effect = lambda **kw: asyncio.ensure_future(
+            complete_delayed()
+        )
+
+        r1, r2 = await asyncio.gather(
+            provider.resolve("alias", timeout=2.0),
+            provider.resolve("alias", timeout=2.0),
+        )
+
+        assert r1 == config
+        assert r2 == config
+        assert component.publish_a2a_message.call_count == 1
+
+    @pytest.mark.asyncio
+    async def test_concurrent_resolves_different_aliases_independent(self):
+        provider, component = _make_provider()
+
+        async def complete_both():
+            await asyncio.sleep(0.01)
+            provider.complete_pending_resolve("a", {"model": "model-a"})
+            provider.complete_pending_resolve("b", {"model": "model-b"})
+
+        component.publish_a2a_message.side_effect = lambda **kw: asyncio.ensure_future(
+            complete_both()
+        )
+
+        r1, r2 = await asyncio.gather(
+            provider.resolve("a", timeout=2.0),
+            provider.resolve("b", timeout=2.0),
+        )
+
+        assert r1 == {"model": "model-a"}
+        assert r2 == {"model": "model-b"}
+        assert component.publish_a2a_message.call_count == 2
+
+
+class TestCompletePendingResolve:
+    @pytest.mark.asyncio
+    async def test_completes_future_via_call_soon_threadsafe(self):
+        provider, component = _make_provider()
+        loop = asyncio.get_running_loop()
+        component._async_loop = loop
+        future = loop.create_future()
+
+        with provider._resolve_lock:
+            provider._pending_resolves["alias"] = [future]
+
+        provider.complete_pending_resolve("alias", {"model": "x"})
+
+        # call_soon_threadsafe schedules on the event loop; yield to let it run
+        await asyncio.sleep(0.01)
+        assert future.result() == {"model": "x"}
+        assert "alias" not in provider._pending_resolves
+
+    @pytest.mark.asyncio
+    async def test_no_pending_is_noop(self):
+        provider, _ = _make_provider()
+        provider.complete_pending_resolve("nonexistent", {"model": "x"})
+
+
+class TestReceiverRouting:
+    def test_own_model_updates_litellm(self):
+        from solace_agent_mesh.agent.adk.models.dynamic_model_provider import (
+            ModelConfigReceiverComponent,
+        )
+
+        provider = MagicMock()
+        provider._model_id = "my-model"
+
+        receiver = ModelConfigReceiverComponent.__new__(ModelConfigReceiverComponent)
+        receiver.model_provider = provider
+        receiver.log_identifier = "[TestReceiver]"
+
+        message = MagicMock()
+        data = {
+            "topic": "test/configuration/model/response/my-model/agent_1",
+            "payload": {"model_config": {"model": "openai/gpt-4o"}},
+        }
+
+        receiver.invoke(message, data)
+
+        provider.mark_initialized.assert_called_once()
+        provider.update_litellm_model.assert_called_once_with({"model": "openai/gpt-4o"})
+        provider.complete_pending_resolve.assert_not_called()
+        message.call_acknowledgements.assert_called_once()
+
+    def test_different_model_routes_to_resolve(self):
+        from solace_agent_mesh.agent.adk.models.dynamic_model_provider import (
+            ModelConfigReceiverComponent,
+        )
+
+        provider = MagicMock()
+        provider._model_id = "my-model"
+
+        receiver = ModelConfigReceiverComponent.__new__(ModelConfigReceiverComponent)
+        receiver.model_provider = provider
+        receiver.log_identifier = "[TestReceiver]"
+
+        message = MagicMock()
+        data = {
+            "topic": "test/configuration/model/response/other-alias/agent_1",
+            "payload": {"model_config": {"model": "anthropic/claude-3-5-sonnet"}},
+        }
+
+        receiver.invoke(message, data)
+
+        provider.update_litellm_model.assert_not_called()
+        provider.complete_pending_resolve.assert_called_once_with(
+            "other-alias", {"model": "anthropic/claude-3-5-sonnet"}
+        )
+        message.call_acknowledgements.assert_called_once()
+
+
+class TestCleanup:
+    @pytest.mark.asyncio
+    async def test_cancels_pending_futures(self):
+        provider, _ = _make_provider()
+        loop = asyncio.get_running_loop()
+        f1 = loop.create_future()
+        f2 = loop.create_future()
+        provider._pending_resolves = {"a": [f1], "b": [f2]}
+
+        provider.cleanup()
+
+        assert f1.cancelled()
+        assert f2.cancelled()
+        assert provider._pending_resolves == {}

--- a/tests/unit/agent/adk/models/test_dynamic_model_provider_resolve.py
+++ b/tests/unit/agent/adk/models/test_dynamic_model_provider_resolve.py
@@ -1,7 +1,6 @@
 """Tests for DynamicModelProvider.resolve() — one-shot model alias resolution."""
 
 import asyncio
-import threading
 import pytest
 from unittest.mock import MagicMock, patch
 

--- a/tests/unit/agent/adk/models/test_dynamic_model_provider_resolve.py
+++ b/tests/unit/agent/adk/models/test_dynamic_model_provider_resolve.py
@@ -16,13 +16,13 @@ def _make_provider():
     component.namespace = "test/"
     component.get_component_id.return_value = "agent_1"
     component._get_component_type.return_value = "agent"
-    component._async_loop = asyncio.get_event_loop()
 
     litellm = MagicMock()
 
     with patch.object(DynamicModelProvider, "initialize", return_value=asyncio.sleep(0)):
         provider = DynamicModelProvider(component, litellm, "default-model")
         provider._internal_app = MagicMock()
+        provider._loop = asyncio.get_running_loop()
 
     return provider, component
 
@@ -126,7 +126,7 @@ class TestReceiverRouting:
         )
 
         provider = MagicMock()
-        provider._model_id = "my-model"
+        provider.model_id = "my-model"
 
         receiver = ModelConfigReceiverComponent.__new__(ModelConfigReceiverComponent)
         receiver.model_provider = provider
@@ -151,7 +151,7 @@ class TestReceiverRouting:
         )
 
         provider = MagicMock()
-        provider._model_id = "my-model"
+        provider.model_id = "my-model"
 
         receiver = ModelConfigReceiverComponent.__new__(ModelConfigReceiverComponent)
         receiver.model_provider = provider

--- a/tests/unit/agent/adk/models/test_dynamic_model_provider_resolve.py
+++ b/tests/unit/agent/adk/models/test_dynamic_model_provider_resolve.py
@@ -74,27 +74,6 @@ class TestResolve:
         assert result is None
 
     @pytest.mark.asyncio
-    async def test_cleans_up_pending_after_resolve(self):
-        provider, component = _make_provider()
-
-        async def complete(*args, **kwargs):
-            await asyncio.sleep(0.01)
-            provider.complete_pending_resolve("alias", {"model": "x"})
-
-        component.publish_a2a_message.side_effect = lambda **kw: asyncio.ensure_future(
-            complete()
-        )
-
-        await provider.resolve("alias", timeout=2.0)
-        assert "alias" not in provider._pending_resolves
-
-    @pytest.mark.asyncio
-    async def test_cleans_up_pending_after_timeout(self):
-        provider, _ = _make_provider()
-        await provider.resolve("alias", timeout=0.05)
-        assert "alias" not in provider._pending_resolves
-
-    @pytest.mark.asyncio
     async def test_concurrent_resolves_deduped(self):
         """Two concurrent resolves for the same alias should only publish once."""
         provider, component = _make_provider()
@@ -138,30 +117,6 @@ class TestResolve:
         assert r1 == {"model": "model-a"}
         assert r2 == {"model": "model-b"}
         assert component.publish_a2a_message.call_count == 2
-
-
-class TestCompletePendingResolve:
-    @pytest.mark.asyncio
-    async def test_completes_future_via_call_soon_threadsafe(self):
-        provider, component = _make_provider()
-        loop = asyncio.get_running_loop()
-        component._async_loop = loop
-        future = loop.create_future()
-
-        with provider._resolve_lock:
-            provider._pending_resolves["alias"] = [future]
-
-        provider.complete_pending_resolve("alias", {"model": "x"})
-
-        # call_soon_threadsafe schedules on the event loop; yield to let it run
-        await asyncio.sleep(0.01)
-        assert future.result() == {"model": "x"}
-        assert "alias" not in provider._pending_resolves
-
-    @pytest.mark.asyncio
-    async def test_no_pending_is_noop(self):
-        provider, _ = _make_provider()
-        provider.complete_pending_resolve("nonexistent", {"model": "x"})
 
 
 class TestReceiverRouting:

--- a/tests/unit/agent/adk/models/test_lite_llm_model_override.py
+++ b/tests/unit/agent/adk/models/test_lite_llm_model_override.py
@@ -1,0 +1,200 @@
+"""Tests for per-request model override via ContextVar."""
+
+import asyncio
+import pytest
+from unittest.mock import Mock, patch, AsyncMock
+from google.genai.types import Content, Part, GenerateContentConfig
+from google.adk.models.llm_request import LlmRequest
+
+from solace_agent_mesh.agent.adk.models.lite_llm import (
+    LiteLlm,
+    _model_override_var,
+    set_model_override,
+)
+
+
+@pytest.fixture
+def mock_litellm_completion():
+    response = {
+        "choices": [
+            {
+                "message": {
+                    "role": "assistant",
+                    "content": "Test response",
+                }
+            }
+        ],
+        "usage": {
+            "prompt_tokens": 10,
+            "completion_tokens": 5,
+            "total_tokens": 15,
+        },
+    }
+    return response
+
+
+@pytest.fixture
+def simple_llm_request():
+    return LlmRequest(
+        contents=[Content(role="user", parts=[Part(text="Hello")])],
+        config=GenerateContentConfig(),
+    )
+
+
+class TestSetModelOverride:
+    """Tests for the set_model_override helper and ContextVar."""
+
+    def test_set_and_get(self):
+        config = {"model": "openai/gpt-4o", "api_key": "sk-test"}
+        set_model_override(config)
+        assert _model_override_var.get() == config
+        _model_override_var.set(None)
+
+    def test_default_is_none(self):
+        _model_override_var.set(None)
+        assert _model_override_var.get() is None
+
+    @pytest.mark.asyncio
+    async def test_isolation_across_async_tasks(self):
+        """Each asyncio.Task should see its own ContextVar value."""
+        results = {}
+
+        async def worker(name, model_name):
+            set_model_override({"model": model_name})
+            await asyncio.sleep(0.01)
+            results[name] = _model_override_var.get()
+            _model_override_var.set(None)
+
+        await asyncio.gather(
+            worker("a", "openai/gpt-4o"),
+            worker("b", "anthropic/claude-3-5-sonnet"),
+        )
+
+        assert results["a"]["model"] == "openai/gpt-4o"
+        assert results["b"]["model"] == "anthropic/claude-3-5-sonnet"
+
+
+class TestModelOverrideInGenerateContent:
+    """Tests that generate_content_async applies the override."""
+
+    @pytest.mark.asyncio
+    async def test_override_applied_to_completion_args(
+        self, mock_litellm_completion, simple_llm_request
+    ):
+        captured_args = {}
+
+        async def capture_acompletion(**kwargs):
+            captured_args.update(kwargs)
+            return mock_litellm_completion
+
+        with patch("solace_agent_mesh.agent.adk.models.lite_llm.MetricRegistry"):
+            llm = LiteLlm(model="openai/gpt-4o-mini", api_key="default-key")
+            llm.llm_client = Mock()
+            llm.llm_client.acompletion = AsyncMock(side_effect=capture_acompletion)
+
+            set_model_override({"model": "anthropic/claude-3-5-sonnet", "api_key": "override-key"})
+
+            async for _ in llm.generate_content_async(simple_llm_request):
+                pass
+
+            assert captured_args["model"] == "anthropic/claude-3-5-sonnet"
+            assert captured_args["api_key"] == "override-key"
+
+    @pytest.mark.asyncio
+    async def test_no_override_uses_default(
+        self, mock_litellm_completion, simple_llm_request
+    ):
+        captured_args = {}
+
+        async def capture_acompletion(**kwargs):
+            captured_args.update(kwargs)
+            return mock_litellm_completion
+
+        _model_override_var.set(None)
+
+        with patch("solace_agent_mesh.agent.adk.models.lite_llm.MetricRegistry"):
+            llm = LiteLlm(model="openai/gpt-4o-mini", api_key="default-key")
+            llm.llm_client = Mock()
+            llm.llm_client.acompletion = AsyncMock(side_effect=capture_acompletion)
+
+            async for _ in llm.generate_content_async(simple_llm_request):
+                pass
+
+            assert captured_args["model"] == "openai/gpt-4o-mini"
+            assert captured_args["api_key"] == "default-key"
+
+    @pytest.mark.asyncio
+    async def test_override_persists_across_calls(
+        self, mock_litellm_completion, simple_llm_request
+    ):
+        """Override should apply to every LLM call (multi-turn agent reasoning)."""
+        captured_models = []
+
+        async def capture_acompletion(**kwargs):
+            captured_models.append(kwargs.get("model"))
+            return mock_litellm_completion
+
+        with patch("solace_agent_mesh.agent.adk.models.lite_llm.MetricRegistry"):
+            llm = LiteLlm(model="openai/gpt-4o-mini", api_key="default-key")
+            llm.llm_client = Mock()
+            llm.llm_client.acompletion = AsyncMock(side_effect=capture_acompletion)
+
+            set_model_override({"model": "anthropic/claude-3-5-sonnet"})
+
+            async for _ in llm.generate_content_async(simple_llm_request):
+                pass
+            async for _ in llm.generate_content_async(simple_llm_request):
+                pass
+
+            assert captured_models == [
+                "anthropic/claude-3-5-sonnet",
+                "anthropic/claude-3-5-sonnet",
+            ]
+            _model_override_var.set(None)
+
+    @pytest.mark.asyncio
+    async def test_override_inherits_default_resilience(
+        self, mock_litellm_completion, simple_llm_request
+    ):
+        """Override should inherit num_retries and timeout from default if not specified."""
+        captured_args = {}
+
+        async def capture_acompletion(**kwargs):
+            captured_args.update(kwargs)
+            return mock_litellm_completion
+
+        with patch("solace_agent_mesh.agent.adk.models.lite_llm.MetricRegistry"):
+            llm = LiteLlm(model="openai/gpt-4o-mini", num_retries=5, timeout=300)
+            llm.llm_client = Mock()
+            llm.llm_client.acompletion = AsyncMock(side_effect=capture_acompletion)
+
+            set_model_override({"model": "anthropic/claude-3-5-sonnet"})
+
+            async for _ in llm.generate_content_async(simple_llm_request):
+                pass
+
+            assert captured_args["num_retries"] == 5
+            assert captured_args["timeout"] == 300
+
+    @pytest.mark.asyncio
+    async def test_override_can_specify_own_resilience(
+        self, mock_litellm_completion, simple_llm_request
+    ):
+        captured_args = {}
+
+        async def capture_acompletion(**kwargs):
+            captured_args.update(kwargs)
+            return mock_litellm_completion
+
+        with patch("solace_agent_mesh.agent.adk.models.lite_llm.MetricRegistry"):
+            llm = LiteLlm(model="openai/gpt-4o-mini", num_retries=5, timeout=300)
+            llm.llm_client = Mock()
+            llm.llm_client.acompletion = AsyncMock(side_effect=capture_acompletion)
+
+            set_model_override({"model": "anthropic/claude-3-5-sonnet", "num_retries": 1, "timeout": 60})
+
+            async for _ in llm.generate_content_async(simple_llm_request):
+                pass
+
+            assert captured_args["num_retries"] == 1
+            assert captured_args["timeout"] == 60

--- a/tests/unit/agent/adk/models/test_lite_llm_model_override.py
+++ b/tests/unit/agent/adk/models/test_lite_llm_model_override.py
@@ -8,7 +8,7 @@ from google.adk.models.llm_request import LlmRequest
 
 from solace_agent_mesh.agent.adk.models.lite_llm import (
     LiteLlm,
-    _model_override_var,
+    get_model_override,
     set_model_override,
 )
 
@@ -47,12 +47,12 @@ class TestSetModelOverride:
     def test_set_and_get(self):
         config = {"model": "openai/gpt-4o", "api_key": "sk-test"}
         set_model_override(config)
-        assert _model_override_var.get() == config
-        _model_override_var.set(None)
+        assert get_model_override() == config
+        set_model_override(None)
 
     def test_default_is_none(self):
-        _model_override_var.set(None)
-        assert _model_override_var.get() is None
+        set_model_override(None)
+        assert get_model_override() is None
 
     @pytest.mark.asyncio
     async def test_isolation_across_async_tasks(self):
@@ -62,8 +62,8 @@ class TestSetModelOverride:
         async def worker(name, model_name):
             set_model_override({"model": model_name})
             await asyncio.sleep(0.01)
-            results[name] = _model_override_var.get()
-            _model_override_var.set(None)
+            results[name] = get_model_override()
+            set_model_override(None)
 
         await asyncio.gather(
             worker("a", "openai/gpt-4o"),
@@ -110,7 +110,7 @@ class TestModelOverrideInGenerateContent:
             captured_args.update(kwargs)
             return mock_litellm_completion
 
-        _model_override_var.set(None)
+        set_model_override(None)
 
         with patch("solace_agent_mesh.agent.adk.models.lite_llm.MetricRegistry"):
             llm = LiteLlm(model="openai/gpt-4o-mini", api_key="default-key")
@@ -150,7 +150,7 @@ class TestModelOverrideInGenerateContent:
                 "anthropic/claude-3-5-sonnet",
                 "anthropic/claude-3-5-sonnet",
             ]
-            _model_override_var.set(None)
+            set_model_override(None)
 
     @pytest.mark.asyncio
     async def test_override_inherits_default_resilience(

--- a/tests/unit/agent/protocol/test_event_handlers_model_override.py
+++ b/tests/unit/agent/protocol/test_event_handlers_model_override.py
@@ -12,31 +12,38 @@ import pytest
 from unittest.mock import AsyncMock, MagicMock
 
 
+_REQUEST_FAILED = object()
+
+
 async def _resolve_model_override_in_metadata(
     component, task_metadata, flag_enabled=True
 ):
-    """Mirror the model_override resolution logic from event_handlers.py."""
+    """Mirror the model_override resolution logic from event_handlers.py.
+
+    Returns _REQUEST_FAILED if resolution fails (request should be rejected).
+    Returns None on success or no-op.
+    """
     model_override = task_metadata.get("model_override")
     if model_override is not None:
         if not flag_enabled:
             task_metadata.pop("model_override", None)
-            return
+            return None
         if (
             isinstance(model_override, dict)
             and isinstance(model_override.get("model_id"), str)
             and model_override["model_id"]
         ):
             model_id = model_override["model_id"]
+            resolved = None
             if component._dynamic_model_provider:
                 resolved = await component._dynamic_model_provider.resolve(model_id)
-                if resolved:
-                    task_metadata["model_override"] = resolved
-                else:
-                    task_metadata.pop("model_override", None)
+            if resolved:
+                task_metadata["model_override"] = resolved
             else:
-                task_metadata.pop("model_override", None)
+                return _REQUEST_FAILED
         else:
             task_metadata.pop("model_override", None)
+    return None
 
 
 def _make_component(dmp=None):
@@ -62,24 +69,24 @@ class TestModelOverrideAliasResolution:
         assert metadata["model_override"] == {"model": "openai/gpt-4o", "api_key": "sk-test"}
 
     @pytest.mark.asyncio
-    async def test_failed_resolution_removes_override(self):
+    async def test_failed_resolution_rejects_request(self):
         dmp = AsyncMock()
         dmp.resolve.return_value = None
         component = _make_component(dmp)
         metadata = {"model_override": {"model_id": "unknown-alias"}}
 
-        await _resolve_model_override_in_metadata(component, metadata)
+        result = await _resolve_model_override_in_metadata(component, metadata)
 
-        assert "model_override" not in metadata
+        assert result is _REQUEST_FAILED
 
     @pytest.mark.asyncio
-    async def test_no_provider_removes_override(self):
+    async def test_no_provider_rejects_request(self):
         component = _make_component(dmp=None)
         metadata = {"model_override": {"model_id": "my-alias"}}
 
-        await _resolve_model_override_in_metadata(component, metadata)
+        result = await _resolve_model_override_in_metadata(component, metadata)
 
-        assert "model_override" not in metadata
+        assert result is _REQUEST_FAILED
 
     @pytest.mark.asyncio
     async def test_no_override_in_metadata_is_noop(self):

--- a/tests/unit/agent/protocol/test_event_handlers_model_override.py
+++ b/tests/unit/agent/protocol/test_event_handlers_model_override.py
@@ -1,0 +1,204 @@
+"""Tests for model_override alias resolution in _handle_send_message_request.
+
+These tests verify the alias resolution logic that runs in the event handler,
+specifically the block that transforms structured model_override dicts into
+resolved raw config dicts before ADK processing.
+
+Expected input format: {"model_override": {"model_id": "<alias-or-uuid>"}}
+Feature-gated behind the offline_evals flag.
+"""
+
+import pytest
+from unittest.mock import AsyncMock, MagicMock, patch
+
+
+async def _resolve_model_override_in_metadata(
+    component, task_metadata, flag_enabled=True
+):
+    """Mirror the model_override resolution logic from event_handlers.py."""
+    model_override = task_metadata.get("model_override")
+    if model_override is not None:
+        if not flag_enabled:
+            task_metadata.pop("model_override", None)
+            return
+        if (
+            isinstance(model_override, dict)
+            and isinstance(model_override.get("model_id"), str)
+            and model_override["model_id"]
+        ):
+            model_id = model_override["model_id"]
+            if component._dynamic_model_provider:
+                resolved = await component._dynamic_model_provider.resolve(model_id)
+                if resolved:
+                    task_metadata["model_override"] = resolved
+                else:
+                    task_metadata.pop("model_override", None)
+            else:
+                task_metadata.pop("model_override", None)
+        else:
+            task_metadata.pop("model_override", None)
+
+
+def _make_component(dmp=None):
+    component = MagicMock()
+    component._dynamic_model_provider = dmp
+    component.log_identifier = "[TestComponent]"
+    return component
+
+
+class TestModelOverrideAliasResolution:
+    """Test the alias resolution behavior in the event handler."""
+
+    @pytest.mark.asyncio
+    async def test_alias_resolved_to_dict(self):
+        dmp = AsyncMock()
+        dmp.resolve.return_value = {"model": "openai/gpt-4o", "api_key": "sk-test"}
+        component = _make_component(dmp)
+        metadata = {"model_override": {"model_id": "my-gpt4-alias"}}
+
+        await _resolve_model_override_in_metadata(component, metadata)
+
+        dmp.resolve.assert_awaited_once_with("my-gpt4-alias")
+        assert metadata["model_override"] == {"model": "openai/gpt-4o", "api_key": "sk-test"}
+
+    @pytest.mark.asyncio
+    async def test_failed_resolution_removes_override(self):
+        dmp = AsyncMock()
+        dmp.resolve.return_value = None
+        component = _make_component(dmp)
+        metadata = {"model_override": {"model_id": "unknown-alias"}}
+
+        await _resolve_model_override_in_metadata(component, metadata)
+
+        assert "model_override" not in metadata
+
+    @pytest.mark.asyncio
+    async def test_no_provider_removes_override(self):
+        component = _make_component(dmp=None)
+        metadata = {"model_override": {"model_id": "my-alias"}}
+
+        await _resolve_model_override_in_metadata(component, metadata)
+
+        assert "model_override" not in metadata
+
+    @pytest.mark.asyncio
+    async def test_no_override_in_metadata_is_noop(self):
+        dmp = AsyncMock()
+        component = _make_component(dmp)
+        metadata = {"some_other_key": "value"}
+
+        await _resolve_model_override_in_metadata(component, metadata)
+
+        dmp.resolve.assert_not_awaited()
+        assert metadata == {"some_other_key": "value"}
+
+    @pytest.mark.asyncio
+    async def test_none_override_is_noop(self):
+        """None value is harmless — callback treats it as no override."""
+        dmp = AsyncMock()
+        component = _make_component(dmp)
+        metadata = {"model_override": None}
+
+        await _resolve_model_override_in_metadata(component, metadata)
+
+        dmp.resolve.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_bare_string_stripped(self):
+        """Bare string is not the expected format — should be stripped."""
+        dmp = AsyncMock()
+        component = _make_component(dmp)
+        metadata = {"model_override": "my-alias"}
+
+        await _resolve_model_override_in_metadata(component, metadata)
+
+        dmp.resolve.assert_not_awaited()
+        assert "model_override" not in metadata
+
+    @pytest.mark.asyncio
+    async def test_raw_dict_stripped(self):
+        """Raw config dict without model_id wrapper is not accepted."""
+        dmp = AsyncMock()
+        component = _make_component(dmp)
+        metadata = {"model_override": {"model": "openai/gpt-4o", "api_key": "sk-123"}}
+
+        await _resolve_model_override_in_metadata(component, metadata)
+
+        dmp.resolve.assert_not_awaited()
+        assert "model_override" not in metadata
+
+    @pytest.mark.asyncio
+    async def test_empty_model_id_stripped(self):
+        dmp = AsyncMock()
+        component = _make_component(dmp)
+        metadata = {"model_override": {"model_id": ""}}
+
+        await _resolve_model_override_in_metadata(component, metadata)
+
+        dmp.resolve.assert_not_awaited()
+        assert "model_override" not in metadata
+
+    @pytest.mark.asyncio
+    async def test_empty_dict_stripped(self):
+        dmp = AsyncMock()
+        component = _make_component(dmp)
+        metadata = {"model_override": {}}
+
+        await _resolve_model_override_in_metadata(component, metadata)
+
+        dmp.resolve.assert_not_awaited()
+        assert "model_override" not in metadata
+
+    @pytest.mark.asyncio
+    async def test_non_string_model_id_stripped(self):
+        dmp = AsyncMock()
+        component = _make_component(dmp)
+        metadata = {"model_override": {"model_id": 12345}}
+
+        await _resolve_model_override_in_metadata(component, metadata)
+
+        dmp.resolve.assert_not_awaited()
+        assert "model_override" not in metadata
+
+
+class TestModelOverrideFeatureFlag:
+    """Test that model_override is gated behind the offline_evals flag."""
+
+    @pytest.mark.asyncio
+    async def test_flag_disabled_strips_override(self):
+        dmp = AsyncMock()
+        component = _make_component(dmp)
+        metadata = {"model_override": {"model_id": "my-alias"}}
+
+        await _resolve_model_override_in_metadata(
+            component, metadata, flag_enabled=False
+        )
+
+        dmp.resolve.assert_not_awaited()
+        assert "model_override" not in metadata
+
+    @pytest.mark.asyncio
+    async def test_flag_disabled_no_override_is_noop(self):
+        dmp = AsyncMock()
+        component = _make_component(dmp)
+        metadata = {"some_key": "value"}
+
+        await _resolve_model_override_in_metadata(
+            component, metadata, flag_enabled=False
+        )
+
+        assert metadata == {"some_key": "value"}
+
+    @pytest.mark.asyncio
+    async def test_flag_enabled_resolves_alias(self):
+        dmp = AsyncMock()
+        dmp.resolve.return_value = {"model": "openai/gpt-4o", "api_key": "sk-test"}
+        component = _make_component(dmp)
+        metadata = {"model_override": {"model_id": "my-alias"}}
+
+        await _resolve_model_override_in_metadata(
+            component, metadata, flag_enabled=True
+        )
+
+        dmp.resolve.assert_awaited_once_with("my-alias")
+        assert metadata["model_override"] == {"model": "openai/gpt-4o", "api_key": "sk-test"}

--- a/tests/unit/agent/protocol/test_event_handlers_model_override.py
+++ b/tests/unit/agent/protocol/test_event_handlers_model_override.py
@@ -9,7 +9,7 @@ Feature-gated behind the offline_evals flag.
 """
 
 import pytest
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock
 
 
 async def _resolve_model_override_in_metadata(

--- a/tests/unit/agent/protocol/test_event_handlers_model_override.py
+++ b/tests/unit/agent/protocol/test_event_handlers_model_override.py
@@ -1,170 +1,149 @@
-"""Tests for model_override alias resolution in _handle_send_message_request.
+"""Tests for model_override alias resolution in _resolve_model_override_metadata.
 
-These tests verify the alias resolution logic that runs in the event handler,
-specifically the block that transforms structured model_override dicts into
-resolved raw config dicts before ADK processing.
+These tests exercise the real resolution function from event_handlers.py,
+which validates the metadata schema, checks the offline_evals feature flag,
+and resolves aliases via the DynamicModelProvider.
 
 Expected input format: {"model_override": {"model_id": "<alias-or-uuid>"}}
-Feature-gated behind the offline_evals flag.
 """
 
 import pytest
 from unittest.mock import AsyncMock, MagicMock
 
-
-_REQUEST_FAILED = object()
-
-
-async def _resolve_model_override_in_metadata(
-    component, task_metadata, flag_enabled=True
-):
-    """Mirror the model_override resolution logic from event_handlers.py.
-
-    Returns _REQUEST_FAILED if resolution fails (request should be rejected).
-    Returns None on success or no-op.
-    """
-    model_override = task_metadata.get("model_override")
-    if model_override is not None:
-        if not flag_enabled:
-            task_metadata.pop("model_override", None)
-            return None
-        if (
-            isinstance(model_override, dict)
-            and isinstance(model_override.get("model_id"), str)
-            and model_override["model_id"]
-        ):
-            model_id = model_override["model_id"]
-            resolved = None
-            if component._dynamic_model_provider:
-                resolved = await component._dynamic_model_provider.resolve(model_id)
-            if resolved:
-                task_metadata["model_override"] = resolved
-            else:
-                return _REQUEST_FAILED
-        else:
-            task_metadata.pop("model_override", None)
-    return None
+from sam_test_infrastructure.feature_flags import mock_flags
+from solace_agent_mesh.common.features import core as feature_flags
+from solace_agent_mesh.agent.protocol.event_handlers import (
+    _resolve_model_override_metadata,
+)
 
 
-def _make_component(dmp=None):
-    component = MagicMock()
-    component._dynamic_model_provider = dmp
-    component.log_identifier = "[TestComponent]"
-    return component
+@pytest.fixture(autouse=True)
+def _reset_feature_flags():
+    feature_flags._reset_for_testing()
+    feature_flags.initialize()
+    yield
+    feature_flags._reset_for_testing()
 
 
 class TestModelOverrideAliasResolution:
-    """Test the alias resolution behavior in the event handler."""
+    """Test the alias resolution behavior."""
 
     @pytest.mark.asyncio
-    async def test_alias_resolved_to_dict(self):
+    async def test_alias_resolved_to_config(self):
         dmp = AsyncMock()
         dmp.resolve.return_value = {"model": "openai/gpt-4o", "api_key": "sk-test"}
-        component = _make_component(dmp)
         metadata = {"model_override": {"model_id": "my-gpt4-alias"}}
 
-        await _resolve_model_override_in_metadata(component, metadata)
+        with mock_flags(offline_evals=True):
+            result = await _resolve_model_override_metadata(metadata, dmp, "[Test]")
 
-        dmp.resolve.assert_awaited_once_with("my-gpt4-alias")
+        assert result is None
         assert metadata["model_override"] == {"model": "openai/gpt-4o", "api_key": "sk-test"}
 
     @pytest.mark.asyncio
-    async def test_failed_resolution_rejects_request(self):
+    async def test_failed_resolution_returns_error_reason(self):
         dmp = AsyncMock()
         dmp.resolve.return_value = None
-        component = _make_component(dmp)
         metadata = {"model_override": {"model_id": "unknown-alias"}}
 
-        result = await _resolve_model_override_in_metadata(component, metadata)
+        with mock_flags(offline_evals=True):
+            result = await _resolve_model_override_metadata(metadata, dmp, "[Test]")
 
-        assert result is _REQUEST_FAILED
+        assert isinstance(result, str)
+        assert "unknown-alias" in result
 
     @pytest.mark.asyncio
-    async def test_no_provider_rejects_request(self):
-        component = _make_component(dmp=None)
+    async def test_no_provider_returns_error_reason(self):
         metadata = {"model_override": {"model_id": "my-alias"}}
 
-        result = await _resolve_model_override_in_metadata(component, metadata)
+        with mock_flags(offline_evals=True):
+            result = await _resolve_model_override_metadata(metadata, None, "[Test]")
 
-        assert result is _REQUEST_FAILED
+        assert isinstance(result, str)
+        assert "not available" in result
 
     @pytest.mark.asyncio
     async def test_no_override_in_metadata_is_noop(self):
         dmp = AsyncMock()
-        component = _make_component(dmp)
         metadata = {"some_other_key": "value"}
 
-        await _resolve_model_override_in_metadata(component, metadata)
+        with mock_flags(offline_evals=True):
+            result = await _resolve_model_override_metadata(metadata, dmp, "[Test]")
 
+        assert result is None
         dmp.resolve.assert_not_awaited()
         assert metadata == {"some_other_key": "value"}
 
     @pytest.mark.asyncio
     async def test_none_override_is_noop(self):
-        """None value is harmless — callback treats it as no override."""
         dmp = AsyncMock()
-        component = _make_component(dmp)
         metadata = {"model_override": None}
 
-        await _resolve_model_override_in_metadata(component, metadata)
+        with mock_flags(offline_evals=True):
+            result = await _resolve_model_override_metadata(metadata, dmp, "[Test]")
 
+        assert result is None
         dmp.resolve.assert_not_awaited()
 
     @pytest.mark.asyncio
     async def test_bare_string_stripped(self):
-        """Bare string is not the expected format — should be stripped."""
-        dmp = AsyncMock()
-        component = _make_component(dmp)
         metadata = {"model_override": "my-alias"}
 
-        await _resolve_model_override_in_metadata(component, metadata)
+        with mock_flags(offline_evals=True):
+            result = await _resolve_model_override_metadata(
+                metadata, AsyncMock(), "[Test]"
+            )
 
-        dmp.resolve.assert_not_awaited()
+        assert result is None
         assert "model_override" not in metadata
 
     @pytest.mark.asyncio
-    async def test_raw_dict_stripped(self):
+    async def test_raw_config_dict_stripped(self):
         """Raw config dict without model_id wrapper is not accepted."""
-        dmp = AsyncMock()
-        component = _make_component(dmp)
         metadata = {"model_override": {"model": "openai/gpt-4o", "api_key": "sk-123"}}
 
-        await _resolve_model_override_in_metadata(component, metadata)
+        with mock_flags(offline_evals=True):
+            result = await _resolve_model_override_metadata(
+                metadata, AsyncMock(), "[Test]"
+            )
 
-        dmp.resolve.assert_not_awaited()
+        assert result is None
         assert "model_override" not in metadata
 
     @pytest.mark.asyncio
     async def test_empty_model_id_stripped(self):
-        dmp = AsyncMock()
-        component = _make_component(dmp)
         metadata = {"model_override": {"model_id": ""}}
 
-        await _resolve_model_override_in_metadata(component, metadata)
+        with mock_flags(offline_evals=True):
+            result = await _resolve_model_override_metadata(
+                metadata, AsyncMock(), "[Test]"
+            )
 
-        dmp.resolve.assert_not_awaited()
+        assert result is None
         assert "model_override" not in metadata
 
     @pytest.mark.asyncio
     async def test_empty_dict_stripped(self):
-        dmp = AsyncMock()
-        component = _make_component(dmp)
         metadata = {"model_override": {}}
 
-        await _resolve_model_override_in_metadata(component, metadata)
+        with mock_flags(offline_evals=True):
+            result = await _resolve_model_override_metadata(
+                metadata, AsyncMock(), "[Test]"
+            )
 
-        dmp.resolve.assert_not_awaited()
+        assert result is None
         assert "model_override" not in metadata
 
     @pytest.mark.asyncio
     async def test_non_string_model_id_stripped(self):
-        dmp = AsyncMock()
-        component = _make_component(dmp)
         metadata = {"model_override": {"model_id": 12345}}
 
-        await _resolve_model_override_in_metadata(component, metadata)
+        with mock_flags(offline_evals=True):
+            result = await _resolve_model_override_metadata(
+                metadata, AsyncMock(), "[Test]"
+            )
 
-        dmp.resolve.assert_not_awaited()
+        assert result is None
         assert "model_override" not in metadata
 
 
@@ -174,38 +153,36 @@ class TestModelOverrideFeatureFlag:
     @pytest.mark.asyncio
     async def test_flag_disabled_strips_override(self):
         dmp = AsyncMock()
-        component = _make_component(dmp)
         metadata = {"model_override": {"model_id": "my-alias"}}
 
-        await _resolve_model_override_in_metadata(
-            component, metadata, flag_enabled=False
-        )
+        with mock_flags(offline_evals=False):
+            result = await _resolve_model_override_metadata(metadata, dmp, "[Test]")
 
+        assert result is None
         dmp.resolve.assert_not_awaited()
         assert "model_override" not in metadata
 
     @pytest.mark.asyncio
     async def test_flag_disabled_no_override_is_noop(self):
-        dmp = AsyncMock()
-        component = _make_component(dmp)
         metadata = {"some_key": "value"}
 
-        await _resolve_model_override_in_metadata(
-            component, metadata, flag_enabled=False
-        )
+        with mock_flags(offline_evals=False):
+            result = await _resolve_model_override_metadata(
+                metadata, AsyncMock(), "[Test]"
+            )
 
+        assert result is None
         assert metadata == {"some_key": "value"}
 
     @pytest.mark.asyncio
     async def test_flag_enabled_resolves_alias(self):
         dmp = AsyncMock()
         dmp.resolve.return_value = {"model": "openai/gpt-4o", "api_key": "sk-test"}
-        component = _make_component(dmp)
         metadata = {"model_override": {"model_id": "my-alias"}}
 
-        await _resolve_model_override_in_metadata(
-            component, metadata, flag_enabled=True
-        )
+        with mock_flags(offline_evals=True):
+            result = await _resolve_model_override_metadata(metadata, dmp, "[Test]")
 
+        assert result is None
         dmp.resolve.assert_awaited_once_with("my-alias")
         assert metadata["model_override"] == {"model": "openai/gpt-4o", "api_key": "sk-test"}


### PR DESCRIPTION
Nice work on this one — solid design decisions (alias-only for MVP, ContextVar isolation, feature flag gating). Code is clean and test coverage is thorough. A few items worth discussing below.

### Highlights
- **ContextVar approach** for per-request isolation is the right pattern — clean, task-scoped, avoids plumbing override config through every call layer.
- **Feature flag gating** with `offline_evals` makes this safe to merge without impacting production traffic.
- **Request deduplication** in `resolve()` (concurrent callers for the same alias share one broker round-trip) is a nice optimization.
- **Alias-only for MVP** is the correct security posture — the exfiltration risk of accepting raw configs is well articulated in the PR description.

### Summary
| # | Severity | File | Issue |
|---|----------|------|-------|
| 1 | 🟡 Medium | `dynamic_model_provider.py` | Wildcard subscription broadness |
| 2 | 🟡 Medium | `dynamic_model_provider.py` | Topic parsing is fragile |
| 3 | 🟡 Medium | `event_handlers.py` | Silent error drop when no reply topic |
| 4 | 🔵 Low | `dynamic_model_provider.py` | Accessing private `_model_id` from receiver |
| 5 | 🔵 Low | `dynamic_model_provider.py` | `complete_pending_resolve` accesses private `_async_loop` |
| 6 | 🔵 Low | `lite_llm.py` | Shallow `.copy()` on override config |
| 7 | 🔵 Low | `event_handlers.py` | Feature flag evaluated per-request — confirm caching |
| 8 | ⚪ Nit | `test_dynamic_model_provider_resolve.py` | Deprecated `get_event_loop()` usage |