### PR TITLE
ci(DATAGO-131317): fix: add packages: read for GHCR image pull

### DIFF
--- a/.github/workflows/fossa-scan.yaml
+++ b/.github/workflows/fossa-scan.yaml
@@ -18,6 +18,7 @@ permissions:
   issues: write         # required by sca-scan-and-guard for PR/issue comments
   checks: write
   statuses: write       # required by sca-scan-and-guard to update commit status
+  packages: read        # required to pull GHCR image in sca-scan-and-guard
 
 jobs:
   fossa_scan:

--- a/.github/workflows/fossa-scan.yaml
+++ b/.github/workflows/fossa-scan.yaml
@@ -19,6 +19,7 @@ permissions:
   checks: write
   statuses: write       # required by sca-scan-and-guard to update commit status
   packages: read        # required to pull GHCR image in sca-scan-and-guard
+  id-token: write       # required by sca-scan-and-guard reusable workflow declaration
 
 jobs:
   fossa_scan:


### PR DESCRIPTION
## Summary

Adds `packages: read` permission to `.github/workflows/fossa-scan.yaml`.

## Context

An upcoming change in `solace-public-workflows` updates the composite actions (`fossa-guard`, `cicd-helper`, `generate-fossa-report`) to pull the `maas-build-actions` container image from GHCR using explicit `docker login` + `docker run`. Pulling from GHCR requires the calling workflow's token to have at least `packages: read` — without it, `docker login` returns a 403 and the job fails.