### PR TITLE
updating for vulnerability

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -71,6 +71,7 @@ RUN echo "deb http://deb.debian.org/debian unstable main" > /etc/apt/sources.lis
     ffmpeg=7:7.1.3-0+deb13u1  \
     git \
     libc6=2.41-12+deb13u2 \
+    libgdk-pixbuf2.0-0=2.42.12+dfsg-4+deb13u1 \
     libtasn1-6/unstable \
     libpng16-16t64=1.6.48-1+deb13u4 \
     libsqlite3-0=3.46.1-7+deb13u1 \
@@ -168,6 +169,7 @@ RUN echo "deb http://deb.debian.org/debian unstable main" > /etc/apt/sources.lis
     git \
     libatomic1 \
     libc6=2.41-12+deb13u2 \
+    libgdk-pixbuf2.0-0=2.42.12+dfsg-4+deb13u1 \
     libtasn1-6/unstable \
     libpng16-16t64=1.6.48-1+deb13u4 \
     libsqlite3-0=3.46.1-7+deb13u1 \


### PR DESCRIPTION
### What is the purpose of this change?

Update for: https://security-tracker.debian.org/tracker/CVE-2026-5201

### How was this change implemented?

>  - Base image: python:3.13.11-slim-trixie (Debian 13)
>   - gdk-pixbuf is not explicitly installed — it's pulled in transitively, likely via the pinned ffmpeg=7:7.1.3-0+deb13u1
>   - The community Dockerfile already has a CVE pinning pattern for ~8 system packages (libpng, libssl, openssl, etc.) but gdk-pixbuf was missed
>   - Enterprise image inherits from community, so fixing community fixes both

### How was this change tested?

- [ ] Manual testing: [describe scenarios]
- [ ] Unit tests: [new/modified tests]
- [ ] Integration tests: [if applicable]
- [ ] Known limitations: [what wasn't tested]

### Is there anything the reviewers should focus on/be aware of?

    Special attention areas, potential risks, or open questions
