### PR TITLE
feat(DATAGO-131400): Add configurable task timeout to gateway framework

### DIFF
--- a/src/solace_agent_mesh/gateway/base/app.py
+++ b/src/solace_agent_mesh/gateway/base/app.py
@@ -129,6 +129,18 @@ BASE_GATEWAY_APP_SCHEMA: Dict[str, List[Dict[str, Any]]] = {
             "default": constants.DEFAULT_MAX_BATCH_UPLOAD_SIZE_BYTES,
             "description": "Maximum total size in bytes for all files in a single batch upload request.",
         },
+        # --- Task Timeout Configuration ---
+        {
+            "name": "task_timeout_seconds",
+            "required": False,
+            "type": "integer",
+            "default": constants.DEFAULT_TASK_TIMEOUT_SECONDS,
+            "description": (
+                "Maximum time in seconds to wait for agent activity before canceling a task. "
+                "The timer resets on each streaming update, so only truly idle tasks are canceled. "
+                "Set to 0 to disable the timeout."
+            ),
+        },
         # --- Default User Identity Configuration ---
         {
             "name": "default_user_identity",

--- a/src/solace_agent_mesh/gateway/base/component.py
+++ b/src/solace_agent_mesh/gateway/base/component.py
@@ -24,6 +24,7 @@ from ...common.services.identity_service import (
 )
 from .task_context import TaskContextManager
 from .auth_interface import AuthHandler
+from .. import constants
 from ...common.a2a.types import ContentPart
 from ...common.utils.rbac_utils import validate_agent_access
 from a2a.types import (
@@ -203,6 +204,11 @@ class BaseGatewayComponent(SamComponentBase):
         self._gateway_card_config = self.get_config("gateway_card", {})
         self._gateway_card_timer_id = f"publish_gateway_card_{self.gateway_id}"
 
+        # Task timeout: max idle time (seconds) waiting for agent activity before canceling
+        self.task_timeout_seconds: int = self.get_config(
+            "task_timeout_seconds", constants.DEFAULT_TASK_TIMEOUT_SECONDS
+        )
+
         # Authentication handler (optional, enterprise feature)
         self.auth_handler: Optional[AuthHandler] = None
 
@@ -377,6 +383,7 @@ class BaseGatewayComponent(SamComponentBase):
         external_request_context["a2a_user_config"] = user_config
         external_request_context["api_version"] = api_version
         external_request_context["is_streaming"] = is_streaming
+        external_request_context["target_agent_name"] = target_agent_name
         log.debug(
             "%s Stored user_identity, configuration, api_version (%s), and is_streaming (%s) in external_request_context.",
             log_id_prefix,
@@ -1981,6 +1988,12 @@ class BaseGatewayComponent(SamComponentBase):
                         external_request_context, parsed_event, final_chunk_flag
                     )
 
+        # Manage task timeout timer: cancel on final events, reset on intermediate activity
+        if is_truly_final_event_for_context_cleanup:
+            self._cancel_task_timeout(a2a_task_id)
+        else:
+            self._start_task_timeout(a2a_task_id)
+
         if is_truly_final_event_for_context_cleanup:
             log.info(
                 "%s Truly final event processed for task %s. Closing connections and removing context.",
@@ -2106,6 +2119,58 @@ class BaseGatewayComponent(SamComponentBase):
                 f"{task_id_from_topic}_stream_buffer"
             )
             return False
+
+    # --- Task Timeout Methods ---
+
+    def _task_timeout_timer_id(self, task_id: str) -> str:
+        return f"task_timeout_{task_id}"
+
+    def _start_task_timeout(self, task_id: str) -> None:
+        """Start (or restart) the idle timeout timer for a task."""
+        if self.task_timeout_seconds <= 0:
+            return
+        timer_id = self._task_timeout_timer_id(task_id)
+        # Cancel existing timer before starting a new one (reset)
+        self.cancel_timer(timer_id)
+        log.debug(
+            "%s Starting task timeout timer for task %s (%d seconds)",
+            self.log_identifier,
+            task_id,
+            self.task_timeout_seconds,
+        )
+        SamComponentBase.add_timer(
+            self,
+            delay_ms=self.task_timeout_seconds * 1000,
+            timer_id=timer_id,
+            interval_ms=None,
+            callback=lambda td, tid=task_id: self._on_task_timeout(tid),
+        )
+
+    def _cancel_task_timeout(self, task_id: str) -> None:
+        """Cancel the idle timeout timer for a task."""
+        if self.task_timeout_seconds <= 0:
+            return
+        self.cancel_timer(self._task_timeout_timer_id(task_id))
+
+    def _on_task_timeout(self, task_id: str) -> None:
+        """Timer callback when a task times out. Schedules async cleanup on the event loop."""
+        log.warning(
+            "%s Task %s timed out after %d seconds of inactivity",
+            self.log_identifier,
+            task_id,
+            self.task_timeout_seconds,
+        )
+        asyncio.run_coroutine_threadsafe(
+            self._handle_task_timeout(task_id), self.get_async_loop()
+        )
+
+    async def _handle_task_timeout(self, task_id: str) -> None:
+        """Handle a timed-out task. Subclasses should override to send errors to the adapter."""
+        log.warning(
+            "%s Task %s timed out but _handle_task_timeout is not overridden",
+            self.log_identifier,
+            task_id,
+        )
 
     async def _async_setup_and_run(self) -> None:
         """Main async logic for the gateway component."""

--- a/src/solace_agent_mesh/gateway/constants.py
+++ b/src/solace_agent_mesh/gateway/constants.py
@@ -23,3 +23,7 @@ DEFAULT_MAX_PROJECT_SIZE_BYTES = 104857600  # 100MB - total project size limit
 # ===== FIELD LENGTH LIMITS =====
 
 DEFAULT_MAX_PROJECT_FILE_DESCRIPTION_LENGTH = 1000  # max characters for file/artifact descriptions
+
+# ===== TASK TIMEOUT =====
+
+DEFAULT_TASK_TIMEOUT_SECONDS = 300  # 5 minutes; max idle time on gateways waiting for agent activity before canceling a task (0 = disabled)

--- a/src/solace_agent_mesh/gateway/generic/component.py
+++ b/src/solace_agent_mesh/gateway/generic/component.py
@@ -412,6 +412,7 @@ class GenericGatewayComponent(BaseGatewayComponent, GatewayContext):
                 user_identity=user_identity,
                 is_streaming=sam_task.is_streaming,
             )
+            self._start_task_timeout(task_id)
             return task_id
 
         except Exception as e:
@@ -930,6 +931,58 @@ class GenericGatewayComponent(BaseGatewayComponent, GatewayContext):
         # Also signal task completion, as an error is a final state
         await self.adapter.handle_task_complete(response_context)
 
+    async def _handle_task_timeout(self, task_id: str) -> None:
+        """Handle a timed-out task by notifying the adapter and cleaning up."""
+        context = self.task_context_manager.get_context(task_id)
+        if not context:
+            return
+
+        log.warning(
+            "%s Task %s timed out after %d seconds of inactivity",
+            self.log_identifier,
+            task_id,
+            self.task_timeout_seconds,
+        )
+
+        # Inject task_id so _create_response_context can build a proper ResponseContext
+        context["a2a_task_id_for_event"] = task_id
+
+        timeout_error = JSONRPCError(
+            code=-32001,
+            message=f"Task timed out after {self.task_timeout_seconds} seconds of inactivity",
+            data={"taskStatus": "timeout"},
+        )
+        try:
+            await self._send_error_to_external(context, timeout_error)
+        except Exception:
+            log.warning(
+                "%s Failed to send timeout error to adapter for task %s",
+                self.log_identifier,
+                task_id,
+            )
+
+        # Cancel the A2A task so the agent knows to stop
+        try:
+            await self.cancel_task(task_id)
+        except Exception:
+            log.warning(
+                "%s Failed to cancel timed-out task %s",
+                self.log_identifier,
+                task_id,
+            )
+
+        # Clean up context — always remove even if close fails
+        try:
+            await self._close_external_connections(context)
+        except Exception:
+            log.warning(
+                "%s Failed to close external connections for timed-out task %s",
+                self.log_identifier,
+                task_id,
+            )
+        self.task_context_manager.remove_context(task_id)
+        self.task_context_manager.remove_context(f"{task_id}_stream_buffer")
+
     # --- Unused BaseGatewayComponent Abstract Methods ---
     # These are part of the old gateway pattern and are replaced by the adapter flow.
 
@@ -1035,6 +1088,8 @@ class GenericGatewayComponent(BaseGatewayComponent, GatewayContext):
                 category = "FAILED"
             elif task_status == TaskState.canceled:
                 category = "CANCELED"
+            elif task_status == "timeout":
+                category = "TIMED_OUT"
 
         return SamError(
             message=error.message,

--- a/tests/unit/gateway/base/test_task_timeout.py
+++ b/tests/unit/gateway/base/test_task_timeout.py
@@ -1,0 +1,267 @@
+"""
+Unit tests for task timeout in BaseGatewayComponent and GenericGatewayComponent.
+
+Tests focus on observable outcomes:
+- Context is cleaned up after timeout
+- Error is delivered with correct content
+- Cleanup completes even when individual steps fail
+- Timeout is a no-op when disabled or context already removed
+"""
+
+import pytest
+from unittest.mock import AsyncMock, Mock, patch
+
+from a2a.types import JSONRPCError
+
+from solace_agent_mesh.gateway.base.component import BaseGatewayComponent
+from solace_agent_mesh.gateway.generic.component import GenericGatewayComponent
+from solace_agent_mesh.gateway.base.task_context import TaskContextManager
+
+
+TASK_ID = "test-task-timeout-123"
+
+
+def _build_generic_component(timeout_seconds=300):
+    """Build a mock GenericGatewayComponent with real TaskContextManager."""
+    component = Mock(spec=GenericGatewayComponent)
+    component.log_identifier = "[TestGenericGateway]"
+    component.task_timeout_seconds = timeout_seconds
+    component.task_context_manager = TaskContextManager()
+
+    # Bind real methods
+    for cls, methods in [
+        (BaseGatewayComponent, [
+            "_task_timeout_timer_id",
+            "_start_task_timeout",
+            "_cancel_task_timeout",
+            "_on_task_timeout",
+            "_handle_task_timeout",
+        ]),
+        (GenericGatewayComponent, [
+            "_handle_task_timeout",
+        ]),
+    ]:
+        for method_name in methods:
+            setattr(component, method_name, getattr(cls, method_name).__get__(component))
+
+    # Mock infrastructure
+    component.add_timer = Mock()
+    component.cancel_timer = Mock()
+    component.get_async_loop = Mock()
+
+    # Mock methods called during timeout handling
+    component._send_error_to_external = AsyncMock()
+    component.cancel_task = AsyncMock()
+    component._close_external_connections = AsyncMock()
+
+    return component
+
+
+def _store_context(component, task_id=TASK_ID, with_stream_buffer=False):
+    """Store a task context and optionally a stream buffer."""
+    ctx = {"a2a_session_id": "session-1", "user_identity": {"id": "user@test.com"}}
+    component.task_context_manager.store_context(task_id, ctx)
+    if with_stream_buffer:
+        component.task_context_manager.store_context(
+            f"{task_id}_stream_buffer", "buffered text"
+        )
+    return ctx
+
+
+class TestTimeoutDisabled:
+    """When task_timeout_seconds=0, timeout has no effect."""
+
+    def test_start_and_cancel_leave_context_intact(self):
+        component = _build_generic_component(timeout_seconds=0)
+        _store_context(component)
+
+        component._start_task_timeout(TASK_ID)
+        component._cancel_task_timeout(TASK_ID)
+
+        # Context still exists — nothing was touched
+        assert component.task_context_manager.get_context(TASK_ID) is not None
+
+
+class TestTimeoutCleanup:
+    """Timeout removes task context and stream buffer."""
+
+    @pytest.mark.asyncio
+    async def test_context_removed_after_timeout(self):
+        component = _build_generic_component()
+        _store_context(component)
+
+        await component._handle_task_timeout(TASK_ID)
+
+        assert component.task_context_manager.get_context(TASK_ID) is None
+
+    @pytest.mark.asyncio
+    async def test_stream_buffer_removed_after_timeout(self):
+        component = _build_generic_component()
+        _store_context(component, with_stream_buffer=True)
+
+        await component._handle_task_timeout(TASK_ID)
+
+        assert component.task_context_manager.get_context(f"{TASK_ID}_stream_buffer") is None
+
+    @pytest.mark.asyncio
+    async def test_other_task_context_not_affected(self):
+        component = _build_generic_component()
+        _store_context(component, task_id=TASK_ID)
+        other_ctx = {"keep": "this"}
+        component.task_context_manager.store_context("other-task", other_ctx)
+
+        await component._handle_task_timeout(TASK_ID)
+
+        assert component.task_context_manager.get_context("other-task") is not None
+
+
+class TestTimeoutErrorContent:
+    """Timeout delivers a properly structured error."""
+
+    @pytest.mark.asyncio
+    async def test_error_has_timeout_code(self):
+        component = _build_generic_component(timeout_seconds=120)
+        _store_context(component)
+
+        await component._handle_task_timeout(TASK_ID)
+
+        error_arg = component._send_error_to_external.call_args[0][1]
+        assert isinstance(error_arg, JSONRPCError)
+        assert error_arg.code == -32001
+
+    @pytest.mark.asyncio
+    async def test_error_message_includes_timeout_duration(self):
+        component = _build_generic_component(timeout_seconds=120)
+        _store_context(component)
+
+        await component._handle_task_timeout(TASK_ID)
+
+        error_arg = component._send_error_to_external.call_args[0][1]
+        assert "120" in error_arg.message
+
+    @pytest.mark.asyncio
+    async def test_error_has_timeout_task_status(self):
+        component = _build_generic_component()
+        _store_context(component)
+
+        await component._handle_task_timeout(TASK_ID)
+
+        error_arg = component._send_error_to_external.call_args[0][1]
+        assert isinstance(error_arg.data, dict)
+        assert error_arg.data["taskStatus"] == "timeout"
+
+    @pytest.mark.asyncio
+    async def test_error_converts_to_timed_out_category(self):
+        """Verify _a2a_error_to_sam_error maps timeout to TIMED_OUT category."""
+        from solace_agent_mesh.gateway.adapter.types import SamError
+
+        component = _build_generic_component()
+        # Bind real _a2a_error_to_sam_error
+        component._a2a_error_to_sam_error = (
+            GenericGatewayComponent._a2a_error_to_sam_error.__get__(component)
+        )
+
+        timeout_error = JSONRPCError(
+            code=-32001,
+            message="Task timed out after 300 seconds of inactivity",
+            data={"taskStatus": "timeout"},
+        )
+
+        sam_error = component._a2a_error_to_sam_error(timeout_error)
+
+        assert sam_error.category == "TIMED_OUT"
+        assert "timed out" in sam_error.message
+
+    @pytest.mark.asyncio
+    async def test_context_has_task_id_injected(self):
+        component = _build_generic_component()
+        _store_context(component)
+
+        await component._handle_task_timeout(TASK_ID)
+
+        ctx_arg = component._send_error_to_external.call_args[0][0]
+        assert ctx_arg["a2a_task_id_for_event"] == TASK_ID
+
+
+class TestTimeoutRaceCondition:
+    """When task completes normally before timeout fires, timeout is a no-op."""
+
+    @pytest.mark.asyncio
+    async def test_noop_when_context_already_removed(self):
+        """Race condition: task completed normally before timeout fires."""
+        component = _build_generic_component()
+        # Don't store context — simulates normal completion already cleaned up
+        # Store a different task to verify it's not affected
+        component.task_context_manager.store_context("other-task", {"keep": "this"})
+
+        await component._handle_task_timeout(TASK_ID)
+
+        # Other task's context is untouched — timeout didn't corrupt anything
+        assert component.task_context_manager.get_context("other-task") is not None
+        # No context was created for the timed-out task
+        assert component.task_context_manager.get_context(TASK_ID) is None
+
+
+class TestTimeoutResilience:
+    """Cleanup completes even when individual steps fail."""
+
+    @pytest.mark.asyncio
+    async def test_cleanup_completes_when_send_error_fails(self):
+        component = _build_generic_component()
+        _store_context(component, with_stream_buffer=True)
+        component._send_error_to_external.side_effect = RuntimeError("adapter broken")
+
+        await component._handle_task_timeout(TASK_ID)
+
+        assert component.task_context_manager.get_context(TASK_ID) is None
+        assert component.task_context_manager.get_context(f"{TASK_ID}_stream_buffer") is None
+
+    @pytest.mark.asyncio
+    async def test_cleanup_completes_when_cancel_task_fails(self):
+        component = _build_generic_component()
+        _store_context(component, with_stream_buffer=True)
+        component.cancel_task.side_effect = RuntimeError("cancel failed")
+
+        await component._handle_task_timeout(TASK_ID)
+
+        assert component.task_context_manager.get_context(TASK_ID) is None
+        assert component.task_context_manager.get_context(f"{TASK_ID}_stream_buffer") is None
+
+    @pytest.mark.asyncio
+    async def test_cleanup_completes_when_close_connections_fails(self):
+        component = _build_generic_component()
+        _store_context(component, with_stream_buffer=True)
+        component._close_external_connections.side_effect = RuntimeError("close failed")
+
+        await component._handle_task_timeout(TASK_ID)
+
+        assert component.task_context_manager.get_context(TASK_ID) is None
+        assert component.task_context_manager.get_context(f"{TASK_ID}_stream_buffer") is None
+
+    @pytest.mark.asyncio
+    async def test_cleanup_completes_when_all_steps_fail(self):
+        component = _build_generic_component()
+        _store_context(component, with_stream_buffer=True)
+        component._send_error_to_external.side_effect = RuntimeError("error failed")
+        component.cancel_task.side_effect = RuntimeError("cancel failed")
+        component._close_external_connections.side_effect = RuntimeError("close failed")
+
+        await component._handle_task_timeout(TASK_ID)
+
+        assert component.task_context_manager.get_context(TASK_ID) is None
+        assert component.task_context_manager.get_context(f"{TASK_ID}_stream_buffer") is None
+
+
+class TestBaseHandleTaskTimeout:
+    """Base class _handle_task_timeout is a safe no-op."""
+
+    @pytest.mark.asyncio
+    async def test_does_not_crash(self):
+        component = Mock(spec=BaseGatewayComponent)
+        component.log_identifier = "[TestBase]"
+        component._handle_task_timeout = (
+            BaseGatewayComponent._handle_task_timeout.__get__(component)
+        )
+
+        # Should log warning and return, not raise
+        await component._handle_task_timeout(TASK_ID)


### PR DESCRIPTION
### What is the purpose of this change?

Add task_timeout_seconds config (default 300s) to BaseGatewayComponent. When enabled, a per-task idle timer starts after task submission and resets on each streaming update. If no agent activity arrives within the window, the gateway sends a TIMED_OUT error to the adapter, cancels the A2A task, and cleans up context.

### How was this change implemented?

- Add DEFAULT_TASK_TIMEOUT_SECONDS constant (300s)
- Add task_timeout_seconds to BASE_GATEWAY_APP_SCHEMA
- Add timer management methods to BaseGatewayComponent
- Add _handle_task_timeout override in GenericGatewayComponent
- Add TIMED_OUT category mapping in _a2a_error_to_sam_error
- Store target_agent_name in context to fix cancel_task
- Add 15 unit tests covering cleanup, error content, race conditions, resilience, and disabled timeout

### Key Design Decisions _(optional - delete if not applicable)_

    Why did you choose this approach over alternatives?

### How was this change tested?

- [x] Manual testing: Test sending msg to Teams Gateway without Agent starting up; Test sending msg to Teams Gateway with request finished after time out; Test success path when request finished within timeout.
- [x] Unit tests: [new/modified tests]
- [ ] Integration tests: [if applicable]
- [ ] Known limitations: [what wasn't tested]

### Is there anything the reviewers should focus on/be aware of?

    Special attention areas, potential risks, or open questions
