### PR TITLE
fix(DATAGO-130514): use partial for "may require network access"

### DIFF
--- a/docs/docs/documentation/developing/create-gateways.md
+++ b/docs/docs/documentation/developing/create-gateways.md
@@ -3,7 +3,7 @@ title: Creating Custom Gateways
 sidebar_position: 430
 ---
 
-import NetworkAccessRequiredSingleFeature from '@site/docs/partials/network-access-required.mdx';
+import NetworkAccessMayBeRequired from '@site/docs/partials/network-access-may-be-required.mdx';
 
 # Creating Custom Gateways
 
@@ -15,9 +15,7 @@ This guide walks you through creating custom gateways using the gateway adapter 
 Gateway adapters are custom interfaces that connect external platforms to the agent mesh by translating events and responses between platform formats and the A2A protocol.
 :::
 
-:::info NETWORK ACCESS REQUIRED
-This feature may require network access. In network restricted environments, ensure the necessary routes and firewall rules are in place before use.
-:::
+<NetworkAccessMayBeRequired />
 
 ## Key Functions
 

--- a/docs/docs/partials/network-access-may-be-required.mdx
+++ b/docs/docs/partials/network-access-may-be-required.mdx
@@ -1,0 +1,3 @@
+:::info NETWORK ACCESS REQUIRED
+This feature may require network access. In network restricted environments, ensure the necessary routes and firewall rules are in place before use.
+:::


### PR DESCRIPTION
### What is the purpose of this change?

Brief PR to create and use a partial instead of hard-coding the special case where the feature may require network access (creating custom gateways doc page).

### How was this change tested?

- [ ] Manual testing: generated docs

<img width="1728" height="1117" alt="Screenshot 2026-04-13 at 11 41 54 AM" src="https://github.com/user-attachments/assets/2590ada3-c991-4dae-8845-50953fb28a79" />

