### PR TITLE
fix(DATAGO-131944): Image+prompt tasks very slow due to multi-agent delegation chain

### DIFF
--- a/src/solace_agent_mesh/agent/adk/callbacks.py
+++ b/src/solace_agent_mesh/agent/adk/callbacks.py
@@ -2309,6 +2309,27 @@ def log_streaming_chunk_callback(
     return None
 
 
+def _sanitize_bytes_in_dict(obj):
+    """Recursively replace bytes values in a dict/list with a placeholder string.
+
+    This is needed because LLM request dumps may contain inline_data with raw
+    bytes (e.g., from inline vision images) which cannot be JSON-serialized
+    for publishing over the Solace broker.
+    """
+    if isinstance(obj, dict):
+        for key, value in obj.items():
+            if isinstance(value, (bytes, bytearray)):
+                obj[key] = f"<binary data: {len(value)} bytes>"
+            elif isinstance(value, (dict, list)):
+                _sanitize_bytes_in_dict(value)
+    elif isinstance(obj, list):
+        for i, item in enumerate(obj):
+            if isinstance(item, (bytes, bytearray)):
+                obj[i] = f"<binary data: {len(item)} bytes>"
+            elif isinstance(item, (dict, list)):
+                _sanitize_bytes_in_dict(item)
+
+
 def solace_llm_invocation_callback(
     callback_context: CallbackContext,
     llm_request: LlmRequest,
@@ -2353,7 +2374,11 @@ def solace_llm_invocation_callback(
             model_name = model_name.get("model", "unknown")
         callback_context.state["model_name"] = model_name
 
-        llm_data = LlmInvocationData(request=llm_request.model_dump(exclude_none=True))
+        request_dump = llm_request.model_dump(exclude_none=True)
+        # Sanitize binary data (e.g., inline_data from images) to make it JSON-serializable.
+        # The raw bytes cannot be sent over the Solace broker in status events.
+        _sanitize_bytes_in_dict(request_dump)
+        llm_data = LlmInvocationData(request=request_dump)
         status_update_event = a2a.create_data_signal_event(
             task_id=logical_task_id,
             context_id=context_id,

--- a/src/solace_agent_mesh/agent/adk/callbacks.py
+++ b/src/solace_agent_mesh/agent/adk/callbacks.py
@@ -2309,8 +2309,10 @@ def log_streaming_chunk_callback(
     return None
 
 
-def _sanitize_bytes_in_dict(obj):
-    """Recursively replace bytes values in a dict/list with a placeholder string.
+def _sanitize_bytes_in_dict_inplace(obj):
+    """Recursively replace bytes values **in place** in a dict/list with a placeholder string.
+
+    Mutates *obj* directly — callers should not rely on a return value.
 
     This is needed because LLM request dumps may contain inline_data with raw
     bytes (e.g., from inline vision images) which cannot be JSON-serialized
@@ -2321,13 +2323,13 @@ def _sanitize_bytes_in_dict(obj):
             if isinstance(value, (bytes, bytearray)):
                 obj[key] = f"<binary data: {len(value)} bytes>"
             elif isinstance(value, (dict, list)):
-                _sanitize_bytes_in_dict(value)
+                _sanitize_bytes_in_dict_inplace(value)
     elif isinstance(obj, list):
         for i, item in enumerate(obj):
             if isinstance(item, (bytes, bytearray)):
                 obj[i] = f"<binary data: {len(item)} bytes>"
             elif isinstance(item, (dict, list)):
-                _sanitize_bytes_in_dict(item)
+                _sanitize_bytes_in_dict_inplace(item)
 
 
 def solace_llm_invocation_callback(
@@ -2377,7 +2379,7 @@ def solace_llm_invocation_callback(
         request_dump = llm_request.model_dump(exclude_none=True)
         # Sanitize binary data (e.g., inline_data from images) to make it JSON-serializable.
         # The raw bytes cannot be sent over the Solace broker in status events.
-        _sanitize_bytes_in_dict(request_dump)
+        _sanitize_bytes_in_dict_inplace(request_dump)
         llm_data = LlmInvocationData(request=request_dump)
         status_update_event = a2a.create_data_signal_event(
             task_id=logical_task_id,

--- a/src/solace_agent_mesh/agent/adk/models/lite_llm.py
+++ b/src/solace_agent_mesh/agent/adk/models/lite_llm.py
@@ -269,13 +269,50 @@ def _content_to_message_param(
     tool_messages = []
     for part in content.parts:
         if part.function_response:
-            tool_messages.append(
-                ChatCompletionToolMessage(
-                    role="tool",
-                    tool_call_id=_truncate_tool_call_id(part.function_response.id),
-                    content=_safe_json_serialize(part.function_response.response),
+            response_data = part.function_response.response
+            # Check for inline vision image data URL in tool response.
+            # When load_artifact returns an image with enable_inline_vision,
+            # it includes a _vision_image_data_url key with a base64 data URL.
+            vision_data_url = None
+            if isinstance(response_data, dict):
+                vision_data_url = response_data.pop("_vision_image_data_url", None)
+
+            if vision_data_url:
+                # Tool response with vision image: send the text result as a
+                # normal tool message, then inject a user message with the image.
+                # This is the universally compatible approach — all LLM providers
+                # support image_url in user messages, but not all support it in
+                # tool messages (e.g., OpenAI gpt-4o-mini rejects it).
+                tool_messages.append(
+                    ChatCompletionToolMessage(
+                        role="tool",
+                        tool_call_id=_truncate_tool_call_id(part.function_response.id),
+                        content=_safe_json_serialize(response_data),
+                    )
                 )
-            )
+                tool_messages.append(
+                    ChatCompletionUserMessage(
+                        role="user",
+                        content=[
+                            ChatCompletionTextObject(
+                                type="text",
+                                text="[System: The tool returned the following image for your analysis]",
+                            ),
+                            ChatCompletionImageUrlObject(
+                                type="image_url",
+                                image_url={"url": vision_data_url},
+                            ),
+                        ],
+                    )
+                )
+            else:
+                tool_messages.append(
+                    ChatCompletionToolMessage(
+                        role="tool",
+                        tool_call_id=_truncate_tool_call_id(part.function_response.id),
+                        content=_safe_json_serialize(response_data),
+                    )
+                )
     if tool_messages:
         return tool_messages if len(tool_messages) > 1 else tool_messages[0]
 

--- a/src/solace_agent_mesh/agent/protocol/event_handlers.py
+++ b/src/solace_agent_mesh/agent/protocol/event_handlers.py
@@ -952,32 +952,64 @@ async def _prepare_adk_content_with_artifacts(
     )
 
     if invoked_artifacts:
-        log.info(
-            "%s Task %s invoked with %d artifact(s). Preparing context from metadata.",
-            component.log_identifier,
-            logical_task_id,
-            len(invoked_artifacts),
-        )
-        header_text = (
-            "The user has provided the following artifacts as context for your task. "
-            "Use the information contained within their metadata to complete your objective."
-        )
-        artifact_summary = await generate_artifact_metadata_summary(
-            component=component,
-            artifact_identifiers=invoked_artifacts,
-            user_id=user_id,
-            session_id=effective_session_id,
-            app_name=agent_name,
-            header_text=header_text,
-        )
+        enable_inline_vision = getattr(component, "enable_inline_vision", False)
 
-        task_description = get_text_from_message(a2a_message_for_adk)
-        final_prompt = f"{task_description}\n\n{artifact_summary}"
+        # When inline vision is enabled, image artifacts will be passed directly
+        # as inline_data to the LLM (handled in _prepare_a2a_filepart_for_adk).
+        # Filter them out from the metadata summary to avoid redundancy.
+        artifacts_for_summary = invoked_artifacts
+        if enable_inline_vision:
+            _IMAGE_EXTENSIONS = {".png", ".jpg", ".jpeg", ".gif", ".webp", ".bmp", ".svg"}
+            artifacts_for_summary = [
+                a for a in invoked_artifacts
+                if not any(
+                    a.get("filename", "").lower().endswith(ext)
+                    for ext in _IMAGE_EXTENSIONS
+                )
+            ]
+            skipped_count = len(invoked_artifacts) - len(artifacts_for_summary)
+            if skipped_count > 0:
+                log.info(
+                    "%s Task %s: inline vision enabled, skipping metadata summary for %d image artifact(s).",
+                    component.log_identifier,
+                    logical_task_id,
+                    skipped_count,
+                )
 
-        a2a_message_for_adk = a2a.update_message_parts(
-            message=a2a_message_for_adk,
-            new_parts=[a2a.create_text_part(text=final_prompt)],
-        )
+        if artifacts_for_summary:
+            log.info(
+                "%s Task %s invoked with %d artifact(s). Preparing context from metadata.",
+                component.log_identifier,
+                logical_task_id,
+                len(artifacts_for_summary),
+            )
+            header_text = (
+                "The user has provided the following artifacts as context for your task. "
+                "Use the information contained within their metadata to complete your objective."
+            )
+            artifact_summary = await generate_artifact_metadata_summary(
+                component=component,
+                artifact_identifiers=artifacts_for_summary,
+                user_id=user_id,
+                session_id=effective_session_id,
+                app_name=agent_name,
+                header_text=header_text,
+            )
+
+            task_description = get_text_from_message(a2a_message_for_adk)
+            final_prompt = f"{task_description}\n\n{artifact_summary}"
+
+            a2a_message_for_adk = a2a.update_message_parts(
+                message=a2a_message_for_adk,
+                new_parts=[a2a.create_text_part(text=final_prompt)],
+            )
+        elif invoked_artifacts:
+            log.info(
+                "%s Task %s: all %d artifact(s) are images handled by inline vision.",
+                component.log_identifier,
+                logical_task_id,
+                len(invoked_artifacts),
+            )
         log.debug(
             "%s Generated new prompt for task %s with artifact context.",
             component.log_identifier,

--- a/src/solace_agent_mesh/agent/protocol/event_handlers.py
+++ b/src/solace_agent_mesh/agent/protocol/event_handlers.py
@@ -34,6 +34,7 @@ from ...agent.adk.runner import TaskCancelledError, run_adk_async_task_thread_wr
 from ...agent.utils.artifact_helpers import generate_artifact_metadata_summary
 from ...common import a2a
 from ...common.error_handlers import get_error_message
+from ...common.utils.mime_helpers import is_image_artifact
 from ...common.utils.embeds.constants import (
     EMBED_DELIMITER_OPEN,
     EMBED_DELIMITER_CLOSE,
@@ -952,19 +953,17 @@ async def _prepare_adk_content_with_artifacts(
     )
 
     if invoked_artifacts:
-        enable_inline_vision = getattr(component, "enable_inline_vision", False)
+        enable_inline_vision = component.enable_inline_vision
 
         # When inline vision is enabled, image artifacts will be passed directly
         # as inline_data to the LLM (handled in _prepare_a2a_filepart_for_adk).
         # Filter them out from the metadata summary to avoid redundancy.
         artifacts_for_summary = invoked_artifacts
         if enable_inline_vision:
-            _IMAGE_EXTENSIONS = {".png", ".jpg", ".jpeg", ".gif", ".webp", ".bmp", ".svg"}
             artifacts_for_summary = [
                 a for a in invoked_artifacts
-                if not any(
-                    a.get("filename", "").lower().endswith(ext)
-                    for ext in _IMAGE_EXTENSIONS
+                if not is_image_artifact(
+                    a.get("filename"), a.get("mime_type")
                 )
             ]
             skipped_count = len(invoked_artifacts) - len(artifacts_for_summary)
@@ -1003,6 +1002,11 @@ async def _prepare_adk_content_with_artifacts(
                 message=a2a_message_for_adk,
                 new_parts=[a2a.create_text_part(text=final_prompt)],
             )
+            log.debug(
+                "%s Generated new prompt for task %s with artifact context.",
+                component.log_identifier,
+                logical_task_id,
+            )
         elif invoked_artifacts:
             log.info(
                 "%s Task %s: all %d artifact(s) are images handled by inline vision.",
@@ -1010,11 +1014,6 @@ async def _prepare_adk_content_with_artifacts(
                 logical_task_id,
                 len(invoked_artifacts),
             )
-        log.debug(
-            "%s Generated new prompt for task %s with artifact context.",
-            component.log_identifier,
-            logical_task_id,
-        )
 
     adk_content = await translate_a2a_to_adk_content(
         a2a_message=a2a_message_for_adk,

--- a/src/solace_agent_mesh/agent/sac/app.py
+++ b/src/solace_agent_mesh/agent/sac/app.py
@@ -407,6 +407,13 @@ class SamAgentAppConfig(SamConfigBase):
         default="ignore",
         description="How to represent created artifacts in A2A messages.",
     )
+    enable_inline_vision: bool = Field(
+        default=False,
+        description="When True, image files attached to incoming messages are passed "
+        "directly as inline_data to the LLM for native vision processing, "
+        "instead of being converted to text metadata summaries. Requires a "
+        "vision-capable model (e.g., Claude Sonnet 4, GPT-4o).",
+    )
     schema_max_keys: int = Field(
         default=DEFAULT_SCHEMA_MAX_KEYS,
         ge=0,

--- a/src/solace_agent_mesh/agent/sac/app.py
+++ b/src/solace_agent_mesh/agent/sac/app.py
@@ -414,6 +414,19 @@ class SamAgentAppConfig(SamConfigBase):
         "instead of being converted to text metadata summaries. Requires a "
         "vision-capable model (e.g., Claude Sonnet 4, GPT-4o).",
     )
+    max_inline_vision_images: int = Field(
+        default=5,
+        ge=1,
+        description="Maximum number of images to inline per message when enable_inline_vision "
+        "is True. Additional images fall back to text metadata summaries.",
+    )
+    max_inline_vision_bytes: int = Field(
+        default=20971520,  # 20MB
+        ge=0,
+        description="Maximum total bytes of inline image data per message. "
+        "Once exceeded, remaining images fall back to text metadata summaries. "
+        "Default: 20MB (20971520 bytes).",
+    )
     schema_max_keys: int = Field(
         default=DEFAULT_SCHEMA_MAX_KEYS,
         ge=0,

--- a/src/solace_agent_mesh/agent/sac/component.py
+++ b/src/solace_agent_mesh/agent/sac/component.py
@@ -225,6 +225,14 @@ class SamAgentComponent(SamComponentBase):
                 self.log_identifier,
                 self.artifact_handling_mode,
             )
+            self.enable_inline_vision = self.get_config(
+                "enable_inline_vision", False
+            )
+            if self.enable_inline_vision:
+                log.info(
+                    "%s Inline vision enabled: image files will be passed directly to the LLM.",
+                    self.log_identifier,
+                )
             if self.artifact_handling_mode == "reference":
                 log.warning(
                     "%s Artifact handling mode 'reference' selected, but this component does not currently host an endpoint to serve artifacts. Clients may not be able to retrieve referenced artifacts.",

--- a/src/solace_agent_mesh/agent/sac/component.py
+++ b/src/solace_agent_mesh/agent/sac/component.py
@@ -229,10 +229,19 @@ class SamAgentComponent(SamComponentBase):
             self.enable_inline_vision = self.get_config(
                 "enable_inline_vision", False
             )
+            self.max_inline_vision_images = self.get_config(
+                "max_inline_vision_images", 5
+            )
+            self.max_inline_vision_bytes = self.get_config(
+                "max_inline_vision_bytes", 20971520  # 20MB
+            )
             if self.enable_inline_vision:
                 log.info(
-                    "%s Inline vision enabled: image files will be passed directly to the LLM.",
+                    "%s Inline vision enabled: image files will be passed directly to the LLM "
+                    "(max %d images, max %d bytes).",
                     self.log_identifier,
+                    self.max_inline_vision_images,
+                    self.max_inline_vision_bytes,
                 )
             if self.artifact_handling_mode == "reference":
                 log.warning(

--- a/src/solace_agent_mesh/agent/sac/component.py
+++ b/src/solace_agent_mesh/agent/sac/component.py
@@ -127,6 +127,7 @@ class SamAgentComponent(SamComponentBase):
     CORRELATION_DATA_PREFIX = CORRELATION_DATA_PREFIX
     HOST_COMPONENT_VERSION = "1.0.0-alpha"
     HEALTH_CHECK_TIMER_ID = "agent_health_check"
+    enable_inline_vision = False
 
     def __init__(self, **kwargs):
         """

--- a/src/solace_agent_mesh/agent/tools/builtin_artifact_tools.py
+++ b/src/solace_agent_mesh/agent/tools/builtin_artifact_tools.py
@@ -39,7 +39,7 @@ from ...agent.utils.context_helpers import get_original_session_id
 from ...agent.adk.models.lite_llm import LiteLlm
 from google.adk.models import LlmRequest
 from google.adk.models.registry import LLMRegistry
-from ...common.utils.mime_helpers import is_text_based_file
+from ...common.utils.mime_helpers import is_text_based_file, is_image_artifact
 
 log = logging.getLogger(__name__)
 
@@ -419,6 +419,50 @@ async def load_artifact(
         session_id = get_original_session_id(tool_context._invocation_context)
         agent = getattr(tool_context._invocation_context, "agent", None)
         host_component = getattr(agent, "host_component", None) if agent else None
+
+        # Check if inline vision is enabled and this is an image artifact
+        enable_inline_vision = getattr(host_component, "enable_inline_vision", False) if host_component else False
+        is_image = is_image_artifact(filename, None)
+
+        if enable_inline_vision and is_image and not load_metadata_only:
+            # Load raw bytes for image artifacts so the LLM can see them
+            result = await load_artifact_content_or_metadata(
+                artifact_service=artifact_service,
+                app_name=app_name,
+                user_id=user_id,
+                session_id=session_id,
+                filename=filename,
+                version=version,
+                load_metadata_only=False,
+                return_raw_bytes=True,
+                log_identifier_prefix="[BuiltinArtifactTool:load_artifact:vision]",
+            )
+            status = result.pop("status", "success")
+            if status in ("error", "not_found"):
+                message = result.pop("message", "Unknown error")
+                return ToolResult.error(message, data=result)
+
+            raw_bytes = result.get("raw_bytes")
+            mime_type = result.get("mime_type", "image/png")
+            if raw_bytes:
+                import base64 as b64
+                b64_data = b64.b64encode(raw_bytes).decode("utf-8")
+                data_url = f"data:{mime_type};base64,{b64_data}"
+                log.info(
+                    "%s Inline vision: returning image '%s' (%d bytes) as data URL for LLM viewing.",
+                    log_identifier, filename, len(raw_bytes),
+                )
+                return ToolResult.ok(
+                    f"Image '{filename}' loaded for viewing. The image is included inline below.",
+                    data={
+                        "filename": result.get("filename", filename),
+                        "version": result.get("version", version),
+                        "mime_type": mime_type,
+                        "size_bytes": len(raw_bytes),
+                        "_vision_image_data_url": data_url,
+                    }
+                )
+
         result = await load_artifact_content_or_metadata(
             artifact_service=artifact_service,
             app_name=app_name,
@@ -1706,7 +1750,7 @@ list_artifacts_tool_def = BuiltinTool(
 load_artifact_tool_def = BuiltinTool(
     name="load_artifact",
     implementation=load_artifact,
-    description="Loads the content or metadata of a specific artifact version. If load_metadata_only is True, loads the full metadata dictionary. Otherwise, loads text content (potentially truncated) or a summary for binary types. Line numbers can be optionally included for precise line range identification.",
+    description="Loads the content or metadata of a specific artifact version. If load_metadata_only is True, loads the full metadata dictionary. Otherwise, loads text content (potentially truncated) or a summary for binary types. For image artifacts (PNG, JPG, etc.) on vision-enabled agents, the image is returned inline so you can see and analyze it directly. Use this to view images created by tools or uploaded by users. Line numbers can be optionally included for precise line range identification.",
     category="artifact_management",
     category_name=CATEGORY_NAME,
     category_description=CATEGORY_DESCRIPTION,

--- a/src/solace_agent_mesh/common/a2a/translation.py
+++ b/src/solace_agent_mesh/common/a2a/translation.py
@@ -25,7 +25,7 @@ from a2a.types import (
 )
 
 from .. import a2a
-from ..utils.mime_helpers import resolve_mime_type
+from ..utils.mime_helpers import resolve_mime_type, is_image_artifact
 from ...agent.utils.context_helpers import get_original_session_id
 
 log = logging.getLogger(__name__)
@@ -37,6 +37,73 @@ if TYPE_CHECKING:
 
 A2A_LLM_STREAM_CHUNKS_PROCESSED_KEY = "temp:llm_stream_chunks_processed"
 A2A_STATUS_SIGNAL_STORAGE_KEY = "temp:a2a_status_signals_collected"
+
+
+async def _try_inline_vision_part(
+    load_artifact_content_or_metadata,
+    artifact_service: "BaseArtifactService",
+    app_name: str,
+    user_id: str,
+    session_id: str,
+    filename: str,
+    version: int,
+    mime_type: str,
+    content_bytes: Optional[bytes],
+    log_id: str,
+) -> Optional[adk_types.Part]:
+    """Attempt to build an inline-vision Part for an image artifact.
+
+    Returns an ``adk_types.Part`` with ``inline_data`` on success, or ``None``
+    if the image bytes could not be obtained (callers should fall back to a
+    text metadata summary).
+    """
+    if content_bytes is None:
+        load_result = await load_artifact_content_or_metadata(
+            artifact_service=artifact_service,
+            app_name=app_name,
+            user_id=user_id,
+            session_id=get_original_session_id(session_id),
+            filename=filename,
+            version=version,
+            load_metadata_only=False,
+            return_raw_bytes=True,
+        )
+        if load_result["status"] == "success":
+            raw_bytes = load_result.get("raw_bytes")
+            if raw_bytes:
+                content_bytes = raw_bytes
+            else:
+                log.warning(
+                    "%s Could not extract image bytes from artifact '%s'. "
+                    "Falling back to text metadata.",
+                    log_id,
+                    filename,
+                )
+        else:
+            log.warning(
+                "%s Failed to load image artifact '%s': %s. "
+                "Falling back to text metadata.",
+                log_id,
+                filename,
+                load_result.get("message", "unknown error"),
+            )
+
+    if content_bytes:
+        log.info(
+            "%s Inline vision: passing image '%s' (%d bytes, %s) directly to LLM.",
+            log_id,
+            filename,
+            len(content_bytes),
+            mime_type,
+        )
+        return adk_types.Part(
+            inline_data=adk_types.Blob(
+                mime_type=mime_type,
+                data=content_bytes,
+            )
+        )
+
+    return None
 
 
 async def _prepare_a2a_filepart_for_adk(
@@ -63,7 +130,7 @@ async def _prepare_a2a_filepart_for_adk(
     log_id = f"{component.log_identifier}[PrepareFilePartForADK]"
     app_name = component.get_config("agent_name")
     artifact_service = component.artifact_service
-    enable_inline_vision = getattr(component, "enable_inline_vision", False)
+    enable_inline_vision = component.enable_inline_vision
 
     if not artifact_service:
         log.error(
@@ -130,53 +197,21 @@ async def _prepare_a2a_filepart_for_adk(
 
         # Inline vision: for image files, pass the image bytes directly to the LLM
         # so vision-capable models can reason about the image natively.
-        if enable_inline_vision and mime_type and mime_type.startswith("image/"):
-            if content_bytes is None:
-                # Load actual content from artifact store (for FileWithUri case)
-                load_result = await load_artifact_content_or_metadata(
-                    artifact_service=artifact_service,
-                    app_name=app_name,
-                    user_id=user_id,
-                    session_id=get_original_session_id(session_id),
-                    filename=filename,
-                    version=version,
-                    load_metadata_only=False,
-                    return_raw_bytes=True,
-                )
-                if load_result["status"] == "success":
-                    raw_bytes = load_result.get("raw_bytes")
-                    if raw_bytes:
-                        content_bytes = raw_bytes
-                    else:
-                        log.warning(
-                            "%s Could not extract image bytes from artifact '%s'. "
-                            "Falling back to text metadata.",
-                            log_id,
-                            filename,
-                        )
-                else:
-                    log.warning(
-                        "%s Failed to load image artifact '%s': %s. "
-                        "Falling back to text metadata.",
-                        log_id,
-                        filename,
-                        load_result.get("message", "unknown error"),
-                    )
-
-            if content_bytes:
-                log.info(
-                    "%s Inline vision: passing image '%s' (%d bytes, %s) directly to LLM.",
-                    log_id,
-                    filename,
-                    len(content_bytes),
-                    mime_type,
-                )
-                return adk_types.Part(
-                    inline_data=adk_types.Blob(
-                        mime_type=mime_type,
-                        data=content_bytes,
-                    )
-                )
+        if enable_inline_vision and is_image_artifact(filename, mime_type):
+            vision_part = await _try_inline_vision_part(
+                load_artifact_content_or_metadata=load_artifact_content_or_metadata,
+                artifact_service=artifact_service,
+                app_name=app_name,
+                user_id=user_id,
+                session_id=session_id,
+                filename=filename,
+                version=version,
+                mime_type=mime_type,
+                content_bytes=content_bytes,
+                log_id=log_id,
+            )
+            if vision_part is not None:
+                return vision_part
 
         # Default: fetch metadata only and return text summary
         load_result = await load_artifact_content_or_metadata(

--- a/src/solace_agent_mesh/common/a2a/translation.py
+++ b/src/solace_agent_mesh/common/a2a/translation.py
@@ -111,6 +111,7 @@ async def _prepare_a2a_filepart_for_adk(
     component: "SamAgentComponent",
     user_id: str,
     session_id: str,
+    inline_vision_tracker: Optional[Dict[str, int]] = None,
 ) -> Optional[adk_types.Part]:
     """
     Prepares an incoming A2A FilePart for the ADK.
@@ -120,6 +121,11 @@ async def _prepare_a2a_filepart_for_adk(
     - For image files when enable_inline_vision is True: returns an inline_data
       Part so the LLM can process the image natively via its vision capability.
     - Otherwise: formats metadata into a text string for the LLM.
+
+    Args:
+        inline_vision_tracker: Mutable dict tracking {"images_inlined": int, "bytes_inlined": int}
+            across multiple FileParts in a single message. Used to enforce
+            max_inline_vision_images and max_inline_vision_bytes limits.
     """
     from ...agent.utils.artifact_helpers import (
         save_artifact_with_metadata,
@@ -130,7 +136,7 @@ async def _prepare_a2a_filepart_for_adk(
     log_id = f"{component.log_identifier}[PrepareFilePartForADK]"
     app_name = component.get_config("agent_name")
     artifact_service = component.artifact_service
-    enable_inline_vision = component.enable_inline_vision
+    enable_inline_vision = getattr(component, "enable_inline_vision", False)
 
     if not artifact_service:
         log.error(
@@ -198,20 +204,42 @@ async def _prepare_a2a_filepart_for_adk(
         # Inline vision: for image files, pass the image bytes directly to the LLM
         # so vision-capable models can reason about the image natively.
         if enable_inline_vision and is_image_artifact(filename, mime_type):
-            vision_part = await _try_inline_vision_part(
-                load_artifact_content_or_metadata=load_artifact_content_or_metadata,
-                artifact_service=artifact_service,
-                app_name=app_name,
-                user_id=user_id,
-                session_id=session_id,
-                filename=filename,
-                version=version,
-                mime_type=mime_type,
-                content_bytes=content_bytes,
-                log_id=log_id,
-            )
-            if vision_part is not None:
-                return vision_part
+            # Check limits before attempting inline vision
+            tracker = inline_vision_tracker or {"images_inlined": 0, "bytes_inlined": 0}
+            max_images = getattr(component, "max_inline_vision_images", 5)
+            max_bytes = getattr(component, "max_inline_vision_bytes", 20971520)
+
+            if tracker["images_inlined"] >= max_images:
+                log.info(
+                    "%s Inline vision limit reached (%d/%d images). "
+                    "Falling back to text metadata for '%s'.",
+                    log_id, tracker["images_inlined"], max_images, filename,
+                )
+            elif tracker["bytes_inlined"] >= max_bytes:
+                log.info(
+                    "%s Inline vision byte limit reached (%d/%d bytes). "
+                    "Falling back to text metadata for '%s'.",
+                    log_id, tracker["bytes_inlined"], max_bytes, filename,
+                )
+            else:
+                vision_part = await _try_inline_vision_part(
+                    load_artifact_content_or_metadata=load_artifact_content_or_metadata,
+                    artifact_service=artifact_service,
+                    app_name=app_name,
+                    user_id=user_id,
+                    session_id=session_id,
+                    filename=filename,
+                    version=version,
+                    mime_type=mime_type,
+                    content_bytes=content_bytes,
+                    log_id=log_id,
+                )
+                if vision_part is not None:
+                    # Update tracker with the inlined image
+                    image_size = len(vision_part.inline_data.data) if vision_part.inline_data and vision_part.inline_data.data else 0
+                    tracker["images_inlined"] += 1
+                    tracker["bytes_inlined"] += image_size
+                    return vision_part
 
         # Default: fetch metadata only and return text summary
         load_result = await load_artifact_content_or_metadata(
@@ -257,11 +285,15 @@ async def translate_a2a_to_adk_content(
 ) -> adk_types.Content:
     """
     Translates an A2A Message object to ADK Content.
-    FileParts are converted to textual metadata summaries.
+    FileParts are converted to textual metadata summaries, or to inline_data
+    Parts for images when enable_inline_vision is True (subject to limits).
     """
     adk_parts: List[adk_types.Part] = []
     unwrapped_parts = a2a.get_parts_from_message(a2a_message)
     log_identifier = component.log_identifier
+
+    # Track inline vision usage across all FileParts in this message
+    inline_vision_tracker: Dict[str, int] = {"images_inlined": 0, "bytes_inlined": 0}
 
     for part in unwrapped_parts:
         try:
@@ -269,7 +301,8 @@ async def translate_a2a_to_adk_content(
                 adk_parts.append(adk_types.Part(text=a2a.get_text_from_text_part(part)))
             elif isinstance(part, FilePart):
                 adk_part = await _prepare_a2a_filepart_for_adk(
-                    part, component, user_id, session_id
+                    part, component, user_id, session_id,
+                    inline_vision_tracker=inline_vision_tracker,
                 )
                 if adk_part:
                     adk_parts.append(adk_part)

--- a/src/solace_agent_mesh/common/a2a/translation.py
+++ b/src/solace_agent_mesh/common/a2a/translation.py
@@ -46,12 +46,13 @@ async def _prepare_a2a_filepart_for_adk(
     session_id: str,
 ) -> Optional[adk_types.Part]:
     """
-    Prepares an incoming A2A FilePart for the ADK by converting it into a
-    textual summary of its metadata.
+    Prepares an incoming A2A FilePart for the ADK.
 
     - If the part has bytes, it saves it to the artifact store first.
     - If the part has a URI, it loads metadata from the store.
-    - It then formats this information into a text string for the LLM.
+    - For image files when enable_inline_vision is True: returns an inline_data
+      Part so the LLM can process the image natively via its vision capability.
+    - Otherwise: formats metadata into a text string for the LLM.
     """
     from ...agent.utils.artifact_helpers import (
         save_artifact_with_metadata,
@@ -62,6 +63,7 @@ async def _prepare_a2a_filepart_for_adk(
     log_id = f"{component.log_identifier}[PrepareFilePartForADK]"
     app_name = component.get_config("agent_name")
     artifact_service = component.artifact_service
+    enable_inline_vision = getattr(component, "enable_inline_vision", False)
 
     if not artifact_service:
         log.error(
@@ -74,6 +76,7 @@ async def _prepare_a2a_filepart_for_adk(
     filename = None
     version = None
     mime_type = None
+    content_bytes = None
 
     try:
         if isinstance(part.file, FileWithBytes):
@@ -116,7 +119,7 @@ async def _prepare_a2a_filepart_for_adk(
             filename = path_parts[-1]
             version_str = parse_qs(parsed_uri.query).get("version", [None])[0]
             version = int(version_str) if version_str else None
-            mime_type = part.file.mime_type
+            mime_type = part.file.mime_type or resolve_mime_type(filename, None)
 
         else:
             raise TypeError("FilePart contains neither bytes nor a valid URI.")
@@ -125,7 +128,57 @@ async def _prepare_a2a_filepart_for_adk(
         if filename is None or version is None:
             raise ValueError("Could not determine filename and version for artifact.")
 
-        # Fetch metadata only.
+        # Inline vision: for image files, pass the image bytes directly to the LLM
+        # so vision-capable models can reason about the image natively.
+        if enable_inline_vision and mime_type and mime_type.startswith("image/"):
+            if content_bytes is None:
+                # Load actual content from artifact store (for FileWithUri case)
+                load_result = await load_artifact_content_or_metadata(
+                    artifact_service=artifact_service,
+                    app_name=app_name,
+                    user_id=user_id,
+                    session_id=get_original_session_id(session_id),
+                    filename=filename,
+                    version=version,
+                    load_metadata_only=False,
+                    return_raw_bytes=True,
+                )
+                if load_result["status"] == "success":
+                    raw_bytes = load_result.get("raw_bytes")
+                    if raw_bytes:
+                        content_bytes = raw_bytes
+                    else:
+                        log.warning(
+                            "%s Could not extract image bytes from artifact '%s'. "
+                            "Falling back to text metadata.",
+                            log_id,
+                            filename,
+                        )
+                else:
+                    log.warning(
+                        "%s Failed to load image artifact '%s': %s. "
+                        "Falling back to text metadata.",
+                        log_id,
+                        filename,
+                        load_result.get("message", "unknown error"),
+                    )
+
+            if content_bytes:
+                log.info(
+                    "%s Inline vision: passing image '%s' (%d bytes, %s) directly to LLM.",
+                    log_id,
+                    filename,
+                    len(content_bytes),
+                    mime_type,
+                )
+                return adk_types.Part(
+                    inline_data=adk_types.Blob(
+                        mime_type=mime_type,
+                        data=content_bytes,
+                    )
+                )
+
+        # Default: fetch metadata only and return text summary
         load_result = await load_artifact_content_or_metadata(
             artifact_service=artifact_service,
             app_name=app_name,

--- a/src/solace_agent_mesh/common/utils/mime_helpers.py
+++ b/src/solace_agent_mesh/common/utils/mime_helpers.py
@@ -191,6 +191,39 @@ _EXTENSION_TO_MIME.update({
 })
 
 
+# Raster image extensions that vision-capable LLMs can process as inline binary.
+# SVG is excluded: it is XML-based and cannot be processed as inline binary by LLMs.
+_INLINE_VISION_EXTENSIONS = {".png", ".jpg", ".jpeg", ".gif", ".webp", ".bmp"}
+
+
+def is_image_artifact(filename: Optional[str], mime_type: Optional[str]) -> bool:
+    """Determine whether an artifact should be treated as an inline vision image.
+
+    Uses *mime_type* as the source of truth.  Falls back to file extension only
+    when mime_type is missing or ``application/octet-stream``.
+
+    SVG (``image/svg+xml``) is explicitly excluded because it is XML-based and
+    most LLMs cannot process it as inline binary vision data.
+    """
+    if mime_type:
+        normalized = mime_type.lower().split(";")[0].strip()
+        if normalized == "image/svg+xml":
+            return False
+        if normalized.startswith("image/"):
+            return True
+        # Known non-image mime type — do not fall through to extension check
+        if normalized != _OCTET_STREAM:
+            return False
+
+    # Fallback: check file extension when mime_type is absent / octet-stream
+    if filename:
+        ext = os.path.splitext(filename)[1].lower()
+        if ext in _INLINE_VISION_EXTENSIONS:
+            return True
+
+    return False
+
+
 def get_extension_for_mime_type(
     mime_type: Optional[str], default_extension: str = ".dat"
 ) -> str:

--- a/tests/unit/agent/adk/test_callbacks.py
+++ b/tests/unit/agent/adk/test_callbacks.py
@@ -2,7 +2,10 @@
 
 import pytest
 
-from solace_agent_mesh.agent.adk.callbacks import _parse_tags_param
+from solace_agent_mesh.agent.adk.callbacks import (
+    _parse_tags_param,
+    _sanitize_bytes_in_dict_inplace,
+)
 
 
 class TestParseTagsParam:
@@ -43,3 +46,53 @@ class TestParseTagsParam:
     def test_whitespace_only_string(self):
         """Whitespace-only string should return empty list."""
         assert _parse_tags_param("   ") == []
+
+
+class TestSanitizeBytesInDictInplace:
+    """Tests for _sanitize_bytes_in_dict_inplace()."""
+
+    def test_bytes_in_flat_dict(self):
+        obj = {"key": b"hello"}
+        _sanitize_bytes_in_dict_inplace(obj)
+        assert obj == {"key": "<binary data: 5 bytes>"}
+
+    def test_bytearray_in_flat_dict(self):
+        obj = {"key": bytearray(b"abc")}
+        _sanitize_bytes_in_dict_inplace(obj)
+        assert obj == {"key": "<binary data: 3 bytes>"}
+
+    def test_nested_dict_with_bytes(self):
+        obj = {"outer": {"inner": b"\x00\x01\x02"}}
+        _sanitize_bytes_in_dict_inplace(obj)
+        assert obj == {"outer": {"inner": "<binary data: 3 bytes>"}}
+
+    def test_bytes_in_list(self):
+        obj = [b"data", "text"]
+        _sanitize_bytes_in_dict_inplace(obj)
+        assert obj == ["<binary data: 4 bytes>", "text"]
+
+    def test_nested_list_in_dict(self):
+        obj = {"items": [{"data": b"img"}, "ok"]}
+        _sanitize_bytes_in_dict_inplace(obj)
+        assert obj == {"items": [{"data": "<binary data: 3 bytes>"}, "ok"]}
+
+    def test_clean_data_unchanged(self):
+        obj = {"key": "value", "num": 42, "nested": {"a": [1, 2]}}
+        original = {"key": "value", "num": 42, "nested": {"a": [1, 2]}}
+        _sanitize_bytes_in_dict_inplace(obj)
+        assert obj == original
+
+    def test_empty_dict(self):
+        obj = {}
+        _sanitize_bytes_in_dict_inplace(obj)
+        assert obj == {}
+
+    def test_empty_list(self):
+        obj = []
+        _sanitize_bytes_in_dict_inplace(obj)
+        assert obj == []
+
+    def test_empty_bytes(self):
+        obj = {"data": b""}
+        _sanitize_bytes_in_dict_inplace(obj)
+        assert obj == {"data": "<binary data: 0 bytes>"}

--- a/tests/unit/common/a2a/test_inline_vision.py
+++ b/tests/unit/common/a2a/test_inline_vision.py
@@ -1,0 +1,399 @@
+"""
+Tests for inline vision feature — both Layer 1 (force-inline on first message)
+and Layer 2 (on-demand via load_artifact tool).
+
+These tests verify:
+1. Image files are inlined when enable_inline_vision=True
+2. Non-image files fall back to text metadata
+3. Limits (max_inline_vision_images, max_inline_vision_bytes) are enforced
+4. The LiteLLM layer creates multipart tool messages for vision data URLs
+5. The _sanitize_bytes_in_dict helper works correctly
+6. The _vision_image_data_url key is detected and handled in tool responses
+"""
+
+import base64
+import json
+import pytest
+from unittest.mock import AsyncMock, MagicMock, patch
+from typing import Dict, Any, Optional
+
+from google.genai import types as adk_types
+
+# ─── Test helpers ───────────────────────────────────────────────────────────
+
+def _make_png_bytes(size: int = 100) -> bytes:
+    """Create fake PNG bytes of a given size."""
+    # Minimal PNG header + padding
+    header = b"\x89PNG\r\n\x1a\n"
+    return header + b"\x00" * (size - len(header))
+
+
+def _make_mock_component(
+    enable_inline_vision: bool = False,
+    max_inline_vision_images: int = 5,
+    max_inline_vision_bytes: int = 20971520,
+    agent_name: str = "TestAgent",
+):
+    """Create a mock SamAgentComponent with inline vision config."""
+    component = MagicMock()
+    component.log_identifier = "[TestComponent]"
+    component.enable_inline_vision = enable_inline_vision
+    component.max_inline_vision_images = max_inline_vision_images
+    component.max_inline_vision_bytes = max_inline_vision_bytes
+    component.get_config = MagicMock(side_effect=lambda key, default=None: {
+        "agent_name": agent_name,
+        "enable_inline_vision": enable_inline_vision,
+        "max_inline_vision_images": max_inline_vision_images,
+        "max_inline_vision_bytes": max_inline_vision_bytes,
+    }.get(key, default))
+    component.artifact_service = MagicMock()
+    return component
+
+
+# ─── Layer 1 Tests: _prepare_a2a_filepart_for_adk ──────────────────────────
+
+class TestPrepareFilePartForADK:
+    """Tests for _prepare_a2a_filepart_for_adk with inline vision."""
+
+    @pytest.mark.asyncio
+    async def test_image_inlined_when_vision_enabled(self):
+        """When enable_inline_vision=True and file is an image, return inline_data Part."""
+        from solace_agent_mesh.common.a2a.translation import _prepare_a2a_filepart_for_adk
+        from a2a.types import FilePart, FileWithBytes
+
+        png_bytes = _make_png_bytes(200)
+        b64_bytes = base64.b64encode(png_bytes).decode("utf-8")
+        part = FilePart(file=FileWithBytes(bytes=b64_bytes, name="test.png", mime_type="image/png"))
+        component = _make_mock_component(enable_inline_vision=True)
+
+        # Mock save_artifact_with_metadata to succeed (patched at source module)
+        with patch(
+            "solace_agent_mesh.agent.utils.artifact_helpers.save_artifact_with_metadata",
+            new_callable=AsyncMock,
+            return_value={"status": "success", "data_version": 0},
+        ):
+            result = await _prepare_a2a_filepart_for_adk(
+                part, component, "user1", "session1"
+            )
+
+        assert result is not None
+        assert result.inline_data is not None
+        assert result.inline_data.mime_type == "image/png"
+        assert result.inline_data.data == png_bytes
+        assert result.text is None  # Should NOT be text
+
+    @pytest.mark.asyncio
+    async def test_non_image_returns_text_when_vision_enabled(self):
+        """Non-image files should still return text metadata even with vision enabled."""
+        from solace_agent_mesh.common.a2a.translation import _prepare_a2a_filepart_for_adk
+        from a2a.types import FilePart, FileWithBytes
+
+        csv_bytes = b"col1,col2\nval1,val2"
+        b64_bytes = base64.b64encode(csv_bytes).decode("utf-8")
+        part = FilePart(file=FileWithBytes(bytes=b64_bytes, name="data.csv", mime_type="text/csv"))
+        component = _make_mock_component(enable_inline_vision=True)
+
+        with patch(
+            "solace_agent_mesh.agent.utils.artifact_helpers.save_artifact_with_metadata",
+            new_callable=AsyncMock,
+            return_value={"status": "success", "data_version": 0},
+        ), patch(
+            "solace_agent_mesh.agent.utils.artifact_helpers.load_artifact_content_or_metadata",
+            new_callable=AsyncMock,
+            return_value={"status": "success", "metadata": {"filename": "data.csv"}},
+        ):
+            result = await _prepare_a2a_filepart_for_adk(
+                part, component, "user1", "session1"
+            )
+
+        assert result is not None
+        assert result.text is not None  # Should be text metadata
+        assert result.inline_data is None
+
+    @pytest.mark.asyncio
+    async def test_image_returns_text_when_vision_disabled(self):
+        """Images should return text metadata when enable_inline_vision=False."""
+        from solace_agent_mesh.common.a2a.translation import _prepare_a2a_filepart_for_adk
+        from a2a.types import FilePart, FileWithBytes
+
+        png_bytes = _make_png_bytes(200)
+        b64_bytes = base64.b64encode(png_bytes).decode("utf-8")
+        part = FilePart(file=FileWithBytes(bytes=b64_bytes, name="test.png", mime_type="image/png"))
+        component = _make_mock_component(enable_inline_vision=False)
+
+        with patch(
+            "solace_agent_mesh.agent.utils.artifact_helpers.save_artifact_with_metadata",
+            new_callable=AsyncMock,
+            return_value={"status": "success", "data_version": 0},
+        ), patch(
+            "solace_agent_mesh.agent.utils.artifact_helpers.load_artifact_content_or_metadata",
+            new_callable=AsyncMock,
+            return_value={"status": "success", "metadata": {"filename": "test.png"}},
+        ):
+            result = await _prepare_a2a_filepart_for_adk(
+                part, component, "user1", "session1"
+            )
+
+        assert result is not None
+        assert result.text is not None  # Should be text metadata
+        assert result.inline_data is None
+
+
+class TestInlineVisionLimits:
+    """Tests for max_inline_vision_images and max_inline_vision_bytes limits."""
+
+    @pytest.mark.asyncio
+    async def test_max_images_limit_enforced(self):
+        """After max_inline_vision_images, additional images fall back to text."""
+        from solace_agent_mesh.common.a2a.translation import _prepare_a2a_filepart_for_adk
+        from a2a.types import FilePart, FileWithBytes
+
+        component = _make_mock_component(
+            enable_inline_vision=True,
+            max_inline_vision_images=2,
+        )
+
+        tracker = {"images_inlined": 0, "bytes_inlined": 0}
+        results = []
+
+        for i in range(3):
+            png_bytes = _make_png_bytes(100)
+            b64_bytes = base64.b64encode(png_bytes).decode("utf-8")
+            part = FilePart(file=FileWithBytes(
+                bytes=b64_bytes, name=f"img{i}.png", mime_type="image/png"
+            ))
+
+            with patch(
+                "solace_agent_mesh.agent.utils.artifact_helpers.save_artifact_with_metadata",
+                new_callable=AsyncMock,
+                return_value={"status": "success", "data_version": 0},
+            ), patch(
+                "solace_agent_mesh.agent.utils.artifact_helpers.load_artifact_content_or_metadata",
+                new_callable=AsyncMock,
+                return_value={"status": "success", "metadata": {"filename": f"img{i}.png"}},
+            ):
+                result = await _prepare_a2a_filepart_for_adk(
+                    part, component, "user1", "session1",
+                    inline_vision_tracker=tracker,
+                )
+                results.append(result)
+
+        # First 2 should be inline_data
+        assert results[0].inline_data is not None
+        assert results[1].inline_data is not None
+        # Third should fall back to text
+        assert results[2].text is not None
+        assert results[2].inline_data is None
+        # Tracker should show 2 images inlined
+        assert tracker["images_inlined"] == 2
+
+    @pytest.mark.asyncio
+    async def test_max_bytes_limit_enforced(self):
+        """After max_inline_vision_bytes, additional images fall back to text."""
+        from solace_agent_mesh.common.a2a.translation import _prepare_a2a_filepart_for_adk
+        from a2a.types import FilePart, FileWithBytes
+
+        component = _make_mock_component(
+            enable_inline_vision=True,
+            max_inline_vision_bytes=50,  # Very small limit — less than one image
+        )
+
+        tracker = {"images_inlined": 0, "bytes_inlined": 0}
+        results = []
+
+        for i in range(2):
+            png_bytes = _make_png_bytes(100)
+            b64_bytes = base64.b64encode(png_bytes).decode("utf-8")
+            part = FilePart(file=FileWithBytes(
+                bytes=b64_bytes, name=f"img{i}.png", mime_type="image/png"
+            ))
+
+            with patch(
+                "solace_agent_mesh.agent.utils.artifact_helpers.save_artifact_with_metadata",
+                new_callable=AsyncMock,
+                return_value={"status": "success", "data_version": 0},
+            ), patch(
+                "solace_agent_mesh.agent.utils.artifact_helpers.load_artifact_content_or_metadata",
+                new_callable=AsyncMock,
+                return_value={"status": "success", "metadata": {"filename": f"img{i}.png"}},
+            ):
+                result = await _prepare_a2a_filepart_for_adk(
+                    part, component, "user1", "session1",
+                    inline_vision_tracker=tracker,
+                )
+                results.append(result)
+
+        # First should be inline_data (0 bytes < 50 limit, so it proceeds)
+        assert results[0].inline_data is not None
+        # Second should fall back to text (100 bytes >= 50 limit, exceeded)
+        assert results[1].text is not None
+        assert results[1].inline_data is None
+
+
+# ─── Layer 2 Tests: LiteLLM multipart tool messages ───────────────────────
+
+class TestLiteLLMVisionToolMessages:
+    """Tests for _content_to_message_param handling of _vision_image_data_url."""
+
+    def test_tool_response_with_vision_data_url_creates_tool_plus_user_messages(self):
+        """Tool response with _vision_image_data_url should create tool msg + user msg with image."""
+        from solace_agent_mesh.agent.adk.models.lite_llm import _content_to_message_param
+
+        data_url = "data:image/png;base64,iVBORw0KGgo="
+        response_data = {
+            "status": "success",
+            "message": "Image loaded",
+            "filename": "test.png",
+            "_vision_image_data_url": data_url,
+        }
+
+        content = adk_types.Content(
+            role="tool",
+            parts=[
+                adk_types.Part(
+                    function_response=adk_types.FunctionResponse(
+                        id="call_123",
+                        name="load_artifact",
+                        response=response_data,
+                    )
+                )
+            ],
+        )
+
+        result = _content_to_message_param(content)
+        # Should be a list of 2 messages: tool + user
+        assert isinstance(result, list)
+        assert len(result) == 2
+
+        # First: tool message with text-only content
+        tool_msg = result[0]
+        assert tool_msg["role"] == "tool"
+        assert tool_msg["tool_call_id"] == "call_123"
+        assert isinstance(tool_msg["content"], str)
+        text_data = json.loads(tool_msg["content"])
+        assert text_data["status"] == "success"
+        assert "_vision_image_data_url" not in text_data
+
+        # Second: user message with image
+        user_msg = result[1]
+        assert user_msg["role"] == "user"
+        assert isinstance(user_msg["content"], list)
+        assert len(user_msg["content"]) == 2
+        assert user_msg["content"][0]["type"] == "text"
+        assert user_msg["content"][1]["type"] == "image_url"
+        assert user_msg["content"][1]["image_url"] == {"url": data_url}
+
+    def test_tool_response_without_vision_data_url_is_text_only(self):
+        """Normal tool response without _vision_image_data_url should be text-only."""
+        from solace_agent_mesh.agent.adk.models.lite_llm import _content_to_message_param
+
+        response_data = {
+            "status": "success",
+            "message": "Loaded text file",
+            "content": "Hello world",
+        }
+
+        content = adk_types.Content(
+            role="tool",
+            parts=[
+                adk_types.Part(
+                    function_response=adk_types.FunctionResponse(
+                        id="call_456",
+                        name="load_artifact",
+                        response=response_data,
+                    )
+                )
+            ],
+        )
+
+        result = _content_to_message_param(content)
+        assert isinstance(result, dict)
+        assert result["role"] == "tool"
+        # Content should be a string (not a list)
+        assert isinstance(result["content"], str)
+        parsed = json.loads(result["content"])
+        assert parsed["status"] == "success"
+
+
+# ─── Bytes sanitization tests ─────────────────────────────────────────────
+
+def _sanitize_bytes_in_dict(obj):
+    """Local copy of the helper for testing (callbacks.py has heavy deps)."""
+    if isinstance(obj, dict):
+        for key, value in obj.items():
+            if isinstance(value, (bytes, bytearray)):
+                obj[key] = f"<binary data: {len(value)} bytes>"
+            elif isinstance(value, (dict, list)):
+                _sanitize_bytes_in_dict(value)
+    elif isinstance(obj, list):
+        for i, item in enumerate(obj):
+            if isinstance(item, (bytes, bytearray)):
+                obj[i] = f"<binary data: {len(item)} bytes>"
+            elif isinstance(item, (dict, list)):
+                _sanitize_bytes_in_dict(item)
+
+
+class TestSanitizeBytesInDict:
+    """Tests for _sanitize_bytes_in_dict helper."""
+
+    def test_sanitizes_bytes_in_flat_dict(self):
+        data = {"text": "hello", "image": b"\x89PNG\r\n\x1a\n" + b"\x00" * 92}
+        _sanitize_bytes_in_dict(data)
+        assert data["text"] == "hello"
+        assert isinstance(data["image"], str)
+        assert "100 bytes" in data["image"]
+
+    def test_sanitizes_bytes_in_nested_dict(self):
+        data = {"outer": {"inner": b"\x00" * 50}}
+        _sanitize_bytes_in_dict(data)
+        assert isinstance(data["outer"]["inner"], str)
+        assert "50 bytes" in data["outer"]["inner"]
+
+    def test_sanitizes_bytes_in_list(self):
+        data = [b"\x00" * 10, "text", {"key": b"\x00" * 20}]
+        _sanitize_bytes_in_dict(data)
+        assert isinstance(data[0], str)
+        assert "10 bytes" in data[0]
+        assert data[1] == "text"
+        assert isinstance(data[2]["key"], str)
+        assert "20 bytes" in data[2]["key"]
+
+    def test_no_change_for_dict_without_bytes(self):
+        data = {"text": "hello", "number": 42, "nested": {"key": "value"}}
+        original = json.dumps(data)
+        _sanitize_bytes_in_dict(data)
+        assert json.dumps(data) == original
+
+
+# ─── Image artifact detection tests ───────────────────────────────────────
+
+class TestIsImageArtifact:
+    """Tests for is_image_artifact helper used in inline vision."""
+
+    def test_png_detected(self):
+        from solace_agent_mesh.common.utils.mime_helpers import is_image_artifact
+        assert is_image_artifact("photo.png", "image/png") is True
+
+    def test_jpg_detected(self):
+        from solace_agent_mesh.common.utils.mime_helpers import is_image_artifact
+        assert is_image_artifact("photo.jpg", "image/jpeg") is True
+
+    def test_webp_detected(self):
+        from solace_agent_mesh.common.utils.mime_helpers import is_image_artifact
+        assert is_image_artifact("photo.webp", "image/webp") is True
+
+    def test_svg_excluded(self):
+        from solace_agent_mesh.common.utils.mime_helpers import is_image_artifact
+        assert is_image_artifact("diagram.svg", "image/svg+xml") is False
+
+    def test_csv_not_image(self):
+        from solace_agent_mesh.common.utils.mime_helpers import is_image_artifact
+        assert is_image_artifact("data.csv", "text/csv") is False
+
+    def test_filename_fallback_when_no_mime(self):
+        from solace_agent_mesh.common.utils.mime_helpers import is_image_artifact
+        assert is_image_artifact("photo.png", None) is True
+
+    def test_non_image_filename_when_no_mime(self):
+        from solace_agent_mesh.common.utils.mime_helpers import is_image_artifact
+        assert is_image_artifact("data.csv", None) is False

--- a/tests/unit/common/utils/test_mime_helpers.py
+++ b/tests/unit/common/utils/test_mime_helpers.py
@@ -5,6 +5,7 @@ Unit tests for common/utils/mime_helpers.py
 from solace_agent_mesh.common.utils.mime_helpers import (
     resolve_mime_type,
     get_extension_for_mime_type,
+    is_image_artifact,
     _EXTENSION_TO_MIME,
 )
 
@@ -132,3 +133,63 @@ class TestExtensionToMimeAliases:
 
     def test_bin_not_in_reverse_map(self):
         assert ".bin" not in _EXTENSION_TO_MIME
+
+
+# --- is_image_artifact ---
+
+
+class TestIsImageArtifact:
+    """Tests for is_image_artifact()."""
+
+    def test_image_mime_type_returns_true(self):
+        assert is_image_artifact("photo.png", "image/png") is True
+
+    def test_image_jpeg_returns_true(self):
+        assert is_image_artifact("photo.jpg", "image/jpeg") is True
+
+    def test_image_webp_returns_true(self):
+        assert is_image_artifact("anim.webp", "image/webp") is True
+
+    def test_svg_mime_type_excluded(self):
+        assert is_image_artifact("icon.svg", "image/svg+xml") is False
+
+    def test_non_image_mime_type_returns_false(self):
+        assert is_image_artifact("doc.pdf", "application/pdf") is False
+
+    def test_non_image_mime_with_image_extension_returns_false(self):
+        """A .png file with text/plain mime should not be treated as image."""
+        assert is_image_artifact("report.png", "text/plain") is False
+
+    def test_octet_stream_falls_back_to_extension(self):
+        assert is_image_artifact("photo.png", "application/octet-stream") is True
+
+    def test_octet_stream_non_image_extension(self):
+        assert is_image_artifact("data.bin", "application/octet-stream") is False
+
+    def test_none_mime_falls_back_to_extension(self):
+        assert is_image_artifact("photo.jpg", None) is True
+
+    def test_none_mime_non_image_extension(self):
+        assert is_image_artifact("readme.md", None) is False
+
+    def test_no_filename_no_mime_returns_false(self):
+        assert is_image_artifact(None, None) is False
+
+    def test_no_filename_with_image_mime_returns_true(self):
+        assert is_image_artifact(None, "image/png") is True
+
+    def test_extensionless_file_with_image_mime_returns_true(self):
+        assert is_image_artifact("photo", "image/gif") is True
+
+    def test_extensionless_file_no_mime_returns_false(self):
+        assert is_image_artifact("photo", None) is False
+
+    def test_mime_type_case_insensitive(self):
+        assert is_image_artifact("x.png", "Image/PNG") is True
+
+    def test_mime_type_with_parameters(self):
+        assert is_image_artifact("x.png", "image/png; charset=binary") is True
+
+    def test_svg_extension_no_mime_returns_false(self):
+        """SVG extension is not in _INLINE_VISION_EXTENSIONS."""
+        assert is_image_artifact("icon.svg", None) is False


### PR DESCRIPTION
This pull request introduces support for "inline vision" in the agent mesh, allowing image artifacts to be passed directly as binary data to vision-capable LLMs (e.g., Claude Sonnet 4, GPT-4o), instead of converting them to text metadata summaries. It also adds robust handling and sanitization of binary data for LLM requests, and includes new utility functions and tests to support these features.

**Inline Vision Support for Image Artifacts:**

* Added the `enable_inline_vision` config option to `SamAgentAppConfig` and `SamAgentComponent`, enabling image artifacts to be sent as binary data (`inline_data`) to the LLM when set to `True`. This is logged at startup and used throughout artifact handling. [[1]](diffhunk://#diff-d92ff5851cee10ce0a98473ca2f1270359723a069de0a38fffe5fdb74de56014R410-R416) [[2]](diffhunk://#diff-33a5eba6ed9bdef92d933e883ea9f9a9ed76f5fadeaa17c0f022e52f899b7609R130) [[3]](diffhunk://#diff-33a5eba6ed9bdef92d933e883ea9f9a9ed76f5fadeaa17c0f022e52f899b7609R229-R236)
* Updated `_prepare_a2a_filepart_for_adk` to pass image artifacts as binary data to the LLM when inline vision is enabled, using the new `_try_inline_vision_part` helper. Otherwise, artifacts are summarized as text as before. [[1]](diffhunk://#diff-8c7970dea9f8f4d462ab125cce278a5e697bb7b9bbec9d7f86f1c40e8c2509b4R42-R122) [[2]](diffhunk://#diff-8c7970dea9f8f4d462ab125cce278a5e697bb7b9bbec9d7f86f1c40e8c2509b4R133) [[3]](diffhunk://#diff-8c7970dea9f8f4d462ab125cce278a5e697bb7b9bbec9d7f86f1c40e8c2509b4R146) [[4]](diffhunk://#diff-8c7970dea9f8f4d462ab125cce278a5e697bb7b9bbec9d7f86f1c40e8c2509b4L119-R189) [[5]](diffhunk://#diff-8c7970dea9f8f4d462ab125cce278a5e697bb7b9bbec9d7f86f1c40e8c2509b4L128-R216)
* Modified `_prepare_adk_content_with_artifacts` to exclude image artifacts from metadata summaries when inline vision is enabled, logging the number of skipped images and ensuring only non-image artifacts are summarized. [[1]](diffhunk://#diff-1c0f9ec68c95bc0ace6ac67196206f9ce0a9cb9d24b400016734f4a0861ee70bR956-R991) [[2]](diffhunk://#diff-1c0f9ec68c95bc0ace6ac67196206f9ce0a9cb9d24b400016734f4a0861ee70bR1010-R1016)

**Binary Data Handling and Sanitization:**

* Added `_sanitize_bytes_in_dict_inplace`, a utility that recursively replaces bytes in dicts/lists with a placeholder string, ensuring LLM request dumps are JSON-serializable and safe to publish. This is now used in `solace_llm_invocation_callback` before sending requests. [[1]](diffhunk://#diff-7fa66b346c9d81f771a975b026b36f4314d1114ae28cbb856918803c6b0adc63R2312-R2334) [[2]](diffhunk://#diff-7fa66b346c9d81f771a975b026b36f4314d1114ae28cbb856918803c6b0adc63L2356-R2383)

**Artifact Type Detection:**

* Introduced `is_image_artifact` in `mime_helpers.py` to reliably detect image artifacts (excluding SVG) using mime type or file extension, supporting the inline vision logic.
* Updated imports and usages to utilize `is_image_artifact` where appropriate. [[1]](diffhunk://#diff-1c0f9ec68c95bc0ace6ac67196206f9ce0a9cb9d24b400016734f4a0861ee70bR37) [[2]](diffhunk://#diff-8c7970dea9f8f4d462ab125cce278a5e697bb7b9bbec9d7f86f1c40e8c2509b4L28-R28)

**Testing:**

* Added comprehensive unit tests for `_sanitize_bytes_in_dict_inplace` and `is_image_artifact`, covering various edge cases and ensuring correct behavior. [[1]](diffhunk://#diff-d8ff6db0852ddb2c81a52865d4ca14da53fc4d5d87e7970e7b66b906443951c2L5-R8) [[2]](diffhunk://#diff-d8ff6db0852ddb2c81a52865d4ca14da53fc4d5d87e7970e7b66b906443951c2R49-R98) [[3]](diffhunk://#diff-d16a380aa3d85ca132d13518368fdd98e75db82cac6a631e3f229f9ed32466baR8) [[4]](diffhunk://#diff-d16a380aa3d85ca132d13518368fdd98e75db82cac6a631e3f229f9ed32466baR136-R195)

These changes together enable native vision support for LLMs, improve robustness when handling binary data, and ensure correct and testable artifact processing.