### PR TITLE
fix(DATAGO-131970): azure-gpt-5 model connection fails test connection when it should pass

### DIFF
--- a/src/solace_agent_mesh/agent/adk/models/lite_llm.py
+++ b/src/solace_agent_mesh/agent/adk/models/lite_llm.py
@@ -872,8 +872,8 @@ def _get_completion_inputs(
                 mapped_key = param_mapping.get(key, key)
                 generation_params[mapped_key] = config_dict[key]
 
-            if not generation_params:
-                generation_params = None
+        if not generation_params:
+            generation_params = None
 
     return messages, tools, response_format, generation_params
 

--- a/src/solace_agent_mesh/services/platform/services/model_config_service.py
+++ b/src/solace_agent_mesh/services/platform/services/model_config_service.py
@@ -651,11 +651,12 @@ class ModelConfigService:
             # sends: system instruction, tools with schemas, and a user message.
             # This catches models that pass a bare "Say OK" test but fail under
             # real orchestrator usage (e.g. can't handle tools or system prompts).
-            # Temperature must be in GenerateContentConfig (not just model_config)
-            # because _get_completion_inputs requires it to be present.
-            # Use the user's value from model_params if set, otherwise default.
+            # Only include temperature if the user explicitly set one.
+            # Many models have restrictions on temperature values (e.g. GPT-5
+            # only supports temperature=1), so we let the provider use its own
+            # default rather than imposing 0.1.
             model_params = request.model_params or {}
-            temperature = model_params.get("temperature", 0.1)
+            temperature = model_params.get("temperature")
 
             llm_request = LlmRequest(
                 contents=[
@@ -694,8 +695,8 @@ class ModelConfigService:
                             ]
                         )
                     ],
-                    temperature=temperature,
-                    max_output_tokens=50,
+                    **({"temperature": temperature} if temperature is not None else {}),
+                    max_output_tokens=256,
                 ),
             )
 

--- a/tests/unit/agent/adk/models/test_lite_llm_caching.py
+++ b/tests/unit/agent/adk/models/test_lite_llm_caching.py
@@ -306,3 +306,27 @@ class TestGetCompletionInputsIntegration:
         assert generation_params["temperature"] == 0.7
         assert generation_params["max_completion_tokens"] == 1000
         assert generation_params["top_p"] == 0.9
+
+    def test_generation_params_without_temperature(self):
+        """Test that generation params work when temperature is not set.
+
+        Regression test: an indentation bug caused generation_params to be
+        set to None inside the extraction loop when the first key
+        (temperature) was absent, crashing on subsequent keys like
+        max_output_tokens.
+        """
+        content = Content(role="user", parts=[Part(text="Hello")])
+        config = GenerateContentConfig(
+            system_instruction="You are a helpful assistant.",
+            max_output_tokens=256,
+        )
+        request = LlmRequest(contents=[content], config=config)
+
+        _, _, _, generation_params = _get_completion_inputs(
+            request,
+            cache_strategy="5m"
+        )
+
+        assert generation_params is not None
+        assert "temperature" not in generation_params
+        assert generation_params["max_completion_tokens"] == 256

--- a/tests/unit/services/platform/test_model_config_service.py
+++ b/tests/unit/services/platform/test_model_config_service.py
@@ -411,6 +411,31 @@ class TestTestConnection:
             # Check that sensitive key doesn't appear
             assert "sk-very-secret-key" not in message
 
+    @pytest.mark.asyncio
+    async def test_test_connection_succeeds_without_temperature(self):
+        """Test connection succeeds when no temperature is provided in model_params."""
+        from solace_agent_mesh.services.platform.api.routers.dto.requests import ModelConfigurationTestRequest
+
+        service = ModelConfigService()
+        service.repository = Mock()
+        mock_db = Mock()
+
+        request = ModelConfigurationTestRequest(
+            provider="openai",
+            model_name="gpt-5",
+            auth_config={"type": "apikey", "api_key": "sk-test-key"},
+            # No model_params / no temperature — should not crash
+        )
+
+        with patch("solace_agent_mesh.services.platform.services.model_config_service.LiteLlm") as MockLiteLlm:
+            mock_instance = MockLiteLlm.return_value
+            mock_instance.generate_content_async = _mock_llm_success_response()
+
+            success, message = await service.test_connection(mock_db, request)
+
+            assert success is True
+            assert "successful" in message.lower()
+
 
 class TestGetModelsFromProviderById:
     """Tests for get_models_from_provider_by_id with override logic."""


### PR DESCRIPTION
### What is the purpose of this change?

Stop forcing temperature=0.1 during test connection — many reasoning models (e.g. GPT-5) reject non-default temperature values. Temperature is now only sent if the user explicitly configured one.

Increase test connection max_output_tokens from 50 to 256 — reasoning models consume tokens internally for chain-of-thought before producing visible output, causing "No response from LLM" with the previous budget.

Fix indentation bug in _get_completion_inputs where the generation_params = None fallback was inside the parameter extraction loop, causing a NoneType crash when temperature was the first (absent) key.

### How was this change implemented?

Removed default temperature in test connection (model_config_service.py):

Increased max_output_tokens from 50 to 256 (model_config_service.py):

Fixed indentation bug in _get_completion_inputs (lite_llm.py):

### How was this change tested?

- [x] Manual testing: [describe scenarios]
- [x] Unit tests: [new/modified tests]
- [ ] Integration tests: [if applicable]
- [ ] Known limitations: [what wasn't tested]

### Is there anything the reviewers should focus on/be aware of?

    Special attention areas, potential risks, or open questions
