### PR TITLE
fix(DATAGO-132161): LLM environment variables not seeded 

### DIFF
--- a/src/solace_agent_mesh/services/platform/services/model_configuration_seeder.py
+++ b/src/solace_agent_mesh/services/platform/services/model_configuration_seeder.py
@@ -189,32 +189,34 @@ def seed_model_configurations(
 
     existing_count = db.query(func.count(ModelConfiguration.id)).scalar()
 
+    seeded_aliases = set()
+
     if existing_count == 0:
         # Try seeding from models_config if provided
-        count = 0
         if models_config:
             log.info("[Model Seed] Seeding from config with %d entries", len(models_config))
-            count = _seed_from_models_config(db, models_config)
+            seeded_aliases = _seed_from_models_config(db, models_config)
 
         # If no models_config provided or empty, seed from environment variables
-        if count == 0:
+        if not seeded_aliases:
             log.info("[Model Seed] No models_config provided, seeding from environment variables")
-            count = _seed_from_env_vars(db)
+            seeded_aliases = _seed_from_env_vars(db)
 
-        if count > 0:
-            log.info("[Model Seed] Successfully seeded %d model configurations", count)
+        if seeded_aliases:
+            log.info("[Model Seed] Successfully seeded %d model configurations", len(seeded_aliases))
         else:
             log.warning("[Model Seed] No model configurations seeded from config or env vars")
     else:
         log.info("[Model Seed] Table has %d existing configurations, skipping bulk seed", existing_count)
 
     # Always ensure general and planning placeholder records exist
-    _ensure_default_aliases(db)
+    defaults_created = _ensure_default_aliases(db, seeded_aliases)
+    seeded_aliases.update(defaults_created)
 
-    return db.query(func.count(ModelConfiguration.id)).scalar()
+    return existing_count + len(seeded_aliases)
 
 
-def _ensure_default_aliases(db: Session) -> None:
+def _ensure_default_aliases(db: Session, seeded_aliases: set = None) -> set:
     """
     Ensure 'general' and 'planning' model aliases exist in the DB.
 
@@ -222,12 +224,30 @@ def _ensure_default_aliases(db: Session) -> None:
     always has these entries to display. Placeholders use PLACEHOLDER_VALUE
     for provider and model_name, which the service layer strips to None
     before returning to clients.
+
+    Args:
+        db: SQLAlchemy database session
+        seeded_aliases: Set of alias names already seeded in this session
+            (used to avoid querying uncommitted records when autoflush is off)
+
+    Returns:
+        Set of alias names that were created as placeholders.
     """
     from solace_agent_mesh.services.platform.models import ModelConfiguration
     from solace_agent_mesh.shared.utils.timestamp_utils import now_epoch_ms
     from solace_agent_mesh.services.platform.constants import PLACEHOLDER_VALUE, DEFAULT_MODEL_ALIASES
 
+    if seeded_aliases is None:
+        seeded_aliases = set()
+
+    created = set()
+
     for alias in DEFAULT_MODEL_ALIASES:
+        # Skip if already seeded in this session (avoids uncommitted query issue)
+        if alias in seeded_aliases:
+            log.debug("[Model Seed] Default alias '%s' already seeded this session, skipping", alias)
+            continue
+
         existing = db.query(ModelConfiguration).filter(
             ModelConfiguration.alias == alias
         ).first()
@@ -252,16 +272,23 @@ def _ensure_default_aliases(db: Session) -> None:
             updated_time=now_epoch_ms(),
         )
         db.add(model_config)
+        created.add(alias)
         log.info("[Model Seed] Created placeholder for default alias '%s'", alias)
 
+    return created
 
-def _seed_from_models_config(db: Session, models_config: dict) -> int:
-    """Seed model aliases from models_config dict."""
-    count = 0
+
+def _seed_from_models_config(db: Session, models_config: dict) -> set:
+    """Seed model aliases from models_config dict.
+
+    Returns:
+        Set of alias names that were successfully seeded.
+    """
+    seeded = set()
 
     if not models_config:
         log.info("[Model Seed] No models_config provided")
-        return 0
+        return seeded
 
     from solace_agent_mesh.shared.utils.timestamp_utils import now_epoch_ms
     from solace_agent_mesh.services.platform.models import ModelConfiguration
@@ -318,19 +345,23 @@ def _seed_from_models_config(db: Session, models_config: dict) -> int:
                 updated_time=now_epoch_ms(),
             )
             db.add(model_config)
-            count += 1
+            seeded.add(alias)
             log.debug("[Model Seed] Seeded model configuration: %s", alias)
 
         except Exception as e:
             log.error("[Model Seed] Failed to seed model '%s': %s", alias, e, exc_info=True)
             # Continue with next model instead of failing the entire seeding process
 
-    return count
+    return seeded
 
 
-def _seed_from_env_vars(db: Session) -> int:
-    """Seed model aliases from environment variables."""
-    count = 0
+def _seed_from_env_vars(db: Session) -> set:
+    """Seed model aliases from environment variables.
+
+    Returns:
+        Set of alias names that were successfully seeded.
+    """
+    seeded = set()
 
     from solace_agent_mesh.shared.utils.timestamp_utils import now_epoch_ms
     from solace_agent_mesh.services.platform.models import ModelConfiguration
@@ -345,15 +376,6 @@ def _seed_from_env_vars(db: Session) -> int:
 
     for alias, model_env, endpoint_env, key_env in env_mappings:
         try:
-            # Check if already exists before processing
-            existing = db.query(ModelConfiguration).filter(
-                ModelConfiguration.alias == alias
-            ).first()
-
-            if existing:
-                log.debug("[Model Seed] Model configuration '%s' already exists, skipping", alias)
-                continue
-
             model_name = os.getenv(model_env, "").strip()
             if not model_name:
                 log.debug("[Model Seed] Skipping '%s': %s not set", alias, model_env)
@@ -390,11 +412,11 @@ def _seed_from_env_vars(db: Session) -> int:
                 updated_time=now_epoch_ms(),
             )
             db.add(model_config)
-            count += 1
+            seeded.add(alias)
             log.info("[Model Seed] Seeded model configuration from env vars: %s", alias)
 
         except Exception as e:
             log.error("[Model Seed] Failed to seed model '%s' from env vars: %s", alias, e, exc_info=True)
             # Continue with next model instead of failing the entire seeding process
 
-    return count
+    return seeded

--- a/tests/unit/services/platform/test_model_configuration_seeder.py
+++ b/tests/unit/services/platform/test_model_configuration_seeder.py
@@ -1,4 +1,4 @@
-"""Unit tests for model configuration seeder.
+"""Unit and integration tests for model configuration seeder.
 
 Tests the provider inference logic to ensure:
 - Known provider detection (OpenAI, Anthropic, Azure, Bedrock, Vertex, Google AI Studio)
@@ -6,15 +6,25 @@ Tests the provider inference logic to ensure:
 - Fallback to custom provider
 
 Also tests seeding from YAML config and environment variables.
+
+Integration tests use a real in-memory SQLite database with autoflush=False
+(matching production config) to catch issues like uncommitted records not being
+visible to subsequent queries within the same transaction.
 """
 
 import os
+import pytest
 from unittest.mock import Mock
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
 from solace_agent_mesh.services.platform.services.model_configuration_seeder import (
     _infer_provider,
     _seed_from_models_config,
     _seed_from_env_vars,
+    seed_model_configurations,
 )
+from solace_agent_mesh.services.platform.models import ModelConfiguration
+from solace_agent_mesh.shared.database.base import Base
 
 
 class TestInferProvider:
@@ -149,12 +159,10 @@ class TestSeedFromModelsConfig:
             },
         }
 
-        count = _seed_from_models_config(mock_db, models_config)
+        seeded = _seed_from_models_config(mock_db, models_config)
 
-        assert count == 3
+        assert seeded == {"gpt-4", "local-llm", "my-api"}
         assert mock_db.add.call_count == 3
-        # Note: Transaction ownership is with the caller (component startup)
-        # The seeding function only adds models, caller is responsible for commit
 
         # Verify each model type was seeded correctly
         added_models = [call[0][0] for call in mock_db.add.call_args_list]
@@ -191,12 +199,10 @@ class TestSeedFromModelsConfig:
             },
         }
 
-        count = _seed_from_models_config(mock_db, models_config)
+        seeded = _seed_from_models_config(mock_db, models_config)
 
-        assert count == 3
+        assert seeded == {"multimodal", "gemini_pro", "gpt4"}
         assert mock_db.add.call_count == 3
-        # Note: Transaction ownership is with the caller (component startup)
-        # The seeding function only adds models, caller is responsible for commit
 
         added_models = [call[0][0] for call in mock_db.add.call_args_list]
 
@@ -244,13 +250,11 @@ class TestSeedFromEnvVars:
         os.environ["LLM_REPORT_MODEL_NAME"] = "gpt-4-turbo"
 
         try:
-            count = _seed_from_env_vars(mock_db)
+            seeded = _seed_from_env_vars(mock_db)
 
             # Should seed 4 models (planning, general, image_gen, report_gen)
-            assert count == 4
+            assert seeded == {"planning", "general", "image_gen", "report_gen"}
             assert mock_db.add.call_count == 4
-            # Note: Transaction ownership is with the caller (component startup)
-        # The seeding function only adds models, caller is responsible for commit
 
             added_models = [call[0][0] for call in mock_db.add.call_args_list]
 
@@ -279,6 +283,200 @@ class TestSeedFromEnvVars:
                 "LLM_SERVICE_ENDPOINT",
                 "LLM_SERVICE_API_KEY",
                 "LLM_SERVICE_GENERAL_MODEL_NAME",
+                "IMAGE_MODEL_NAME",
+                "IMAGE_SERVICE_ENDPOINT",
+                "IMAGE_SERVICE_API_KEY",
+                "LLM_REPORT_MODEL_NAME",
+            ]:
+                os.environ.pop(key, None)
+
+
+@pytest.fixture
+def db_session():
+    """Create an in-memory SQLite session with autoflush=False (matching production)."""
+    engine = create_engine("sqlite:///:memory:")
+    Base.metadata.create_all(engine)
+    Session = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+    session = Session()
+    yield session
+    session.close()
+
+
+class TestSeedIntegration:
+    """Integration tests using a real DB session with autoflush=False.
+
+    These tests verify that seed_model_configurations works correctly
+    end-to-end, including the interaction between seeding functions and
+    _ensure_default_aliases within a single uncommitted transaction.
+    """
+
+    def test_env_vars_seed_general_and_planning_no_duplicates(self, db_session):
+        """Env var seeding of general/planning must not conflict with _ensure_default_aliases.
+
+        Regression test: with autoflush=False, _ensure_default_aliases could not see
+        records added by _seed_from_env_vars in the same transaction, causing duplicate
+        alias inserts and IntegrityError on commit.
+        """
+        os.environ["LLM_SERVICE_GENERAL_MODEL_NAME"] = "gpt-4"
+        os.environ["LLM_SERVICE_PLANNING_MODEL_NAME"] = "gpt-4"
+        os.environ["LLM_SERVICE_ENDPOINT"] = "https://api.openai.com/v1"
+        os.environ["LLM_SERVICE_API_KEY"] = "sk-test"
+
+        try:
+            count = seed_model_configurations(db_session, models_config=None)
+            db_session.commit()
+
+            # general and planning seeded from env vars (not duplicated by _ensure_default_aliases)
+            assert count == 2
+
+            models = db_session.query(ModelConfiguration).all()
+            aliases = [m.alias for m in models]
+            assert aliases.count("general") == 1
+            assert aliases.count("planning") == 1
+
+            # Verify they have real data, not placeholder values
+            general = db_session.query(ModelConfiguration).filter(
+                ModelConfiguration.alias == "general"
+            ).first()
+            assert general.model_name == "gpt-4"
+            assert general.provider == "openai"
+        finally:
+            for key in [
+                "LLM_SERVICE_GENERAL_MODEL_NAME",
+                "LLM_SERVICE_PLANNING_MODEL_NAME",
+                "LLM_SERVICE_ENDPOINT",
+                "LLM_SERVICE_API_KEY",
+            ]:
+                os.environ.pop(key, None)
+
+    def test_env_vars_partial_seed_creates_placeholder_for_missing(self, db_session):
+        """When only general is set via env vars, planning gets a placeholder."""
+        os.environ["LLM_SERVICE_GENERAL_MODEL_NAME"] = "gpt-4"
+        os.environ["LLM_SERVICE_ENDPOINT"] = "https://api.openai.com/v1"
+        os.environ["LLM_SERVICE_API_KEY"] = "sk-test"
+
+        try:
+            count = seed_model_configurations(db_session, models_config=None)
+            db_session.commit()
+
+            # general from env + planning placeholder
+            assert count == 2
+
+            general = db_session.query(ModelConfiguration).filter(
+                ModelConfiguration.alias == "general"
+            ).first()
+            assert general.model_name == "gpt-4"
+
+            planning = db_session.query(ModelConfiguration).filter(
+                ModelConfiguration.alias == "planning"
+            ).first()
+            assert planning.model_name == "undefined"  # PLACEHOLDER_VALUE
+        finally:
+            for key in [
+                "LLM_SERVICE_GENERAL_MODEL_NAME",
+                "LLM_SERVICE_ENDPOINT",
+                "LLM_SERVICE_API_KEY",
+            ]:
+                os.environ.pop(key, None)
+
+    def test_no_env_vars_creates_placeholders(self, db_session):
+        """With no env vars and no config, both general and planning get placeholders."""
+        count = seed_model_configurations(db_session, models_config=None)
+        db_session.commit()
+
+        assert count == 2
+
+        for alias in ["general", "planning"]:
+            model = db_session.query(ModelConfiguration).filter(
+                ModelConfiguration.alias == alias
+            ).first()
+            assert model is not None
+            assert model.model_name == "undefined"
+
+    def test_models_config_seeds_general_and_planning(self, db_session):
+        """YAML config seeding of general/planning must not conflict with _ensure_default_aliases."""
+        models_config = {
+            "general": {
+                "model": "gpt-4",
+                "api_base": "https://api.openai.com/v1",
+                "api_key": "sk-test",
+            },
+            "planning": {
+                "model": "gpt-4-turbo",
+                "api_base": "https://api.openai.com/v1",
+                "api_key": "sk-test",
+            },
+        }
+
+        count = seed_model_configurations(db_session, models_config=models_config)
+        db_session.commit()
+
+        assert count == 2
+
+        models = db_session.query(ModelConfiguration).all()
+        aliases = [m.alias for m in models]
+        assert aliases.count("general") == 1
+        assert aliases.count("planning") == 1
+
+    def test_existing_data_skips_seeding_but_ensures_defaults(self, db_session):
+        """When table already has data, skip bulk seed but still ensure defaults exist."""
+        from solace_agent_mesh.shared.database.id_generators import generate_uuidv7
+        from solace_agent_mesh.shared.utils.timestamp_utils import now_epoch_ms
+
+        # Pre-populate with a non-default model
+        existing = ModelConfiguration(
+            id=generate_uuidv7(),
+            alias="custom_model",
+            provider="openai",
+            model_name="gpt-4",
+            model_auth_type="none",
+            model_auth_config={"type": "none"},
+            model_params={},
+            created_by="system",
+            updated_by="system",
+            created_time=now_epoch_ms(),
+            updated_time=now_epoch_ms(),
+        )
+        db_session.add(existing)
+        db_session.commit()
+
+        count = seed_model_configurations(db_session, models_config=None)
+        db_session.commit()
+
+        # custom_model + general placeholder + planning placeholder
+        assert count == 3
+
+        for alias in ["general", "planning"]:
+            model = db_session.query(ModelConfiguration).filter(
+                ModelConfiguration.alias == alias
+            ).first()
+            assert model is not None
+
+    def test_all_four_env_vars_seeded(self, db_session):
+        """All four env var mappings seed correctly without conflicts."""
+        os.environ["LLM_SERVICE_GENERAL_MODEL_NAME"] = "gpt-4"
+        os.environ["LLM_SERVICE_PLANNING_MODEL_NAME"] = "gpt-4-turbo"
+        os.environ["LLM_SERVICE_ENDPOINT"] = "https://api.openai.com/v1"
+        os.environ["LLM_SERVICE_API_KEY"] = "sk-test"
+        os.environ["IMAGE_MODEL_NAME"] = "dall-e-3"
+        os.environ["IMAGE_SERVICE_ENDPOINT"] = "https://api.openai.com/v1"
+        os.environ["IMAGE_SERVICE_API_KEY"] = "sk-image"
+        os.environ["LLM_REPORT_MODEL_NAME"] = "gpt-4"
+
+        try:
+            count = seed_model_configurations(db_session, models_config=None)
+            db_session.commit()
+
+            assert count == 4
+
+            aliases = {m.alias for m in db_session.query(ModelConfiguration).all()}
+            assert aliases == {"general", "planning", "image_gen", "report_gen"}
+        finally:
+            for key in [
+                "LLM_SERVICE_GENERAL_MODEL_NAME",
+                "LLM_SERVICE_PLANNING_MODEL_NAME",
+                "LLM_SERVICE_ENDPOINT",
+                "LLM_SERVICE_API_KEY",
                 "IMAGE_MODEL_NAME",
                 "IMAGE_SERVICE_ENDPOINT",
                 "IMAGE_SERVICE_API_KEY",


### PR DESCRIPTION
### What is the purpose of this change?

Fix a bug where _ensure_default_aliases attempted to insert duplicate "general" and "planning" records after _seed_from_env_vars had already added them, causing an IntegrityError on commit

invisible to subsequent db.query() calls within the same transaction
Solution: track seeded aliases in-memory (as a set) and pass them to _ensure_default_aliases to skip without querying the DB


### How was this change implemented?

_seed_from_env_vars and _seed_from_models_config now return a set of seeded alias names instead of an int count
_ensure_default_aliases accepts a seeded_aliases parameter and skips any alias already in that set (avoiding the uncommitted query problem)
_ensure_default_aliases returns its own set of created placeholders
Final count computed from existing_count + len(seeded_aliases) instead of a DB query (also affected by autoflush=False)

### How was this change tested?

- [x] Manual testing: [describe scenarios]
- [x] Unit tests: [new/modified tests]
- [ ] Integration tests: [if applicable]
- [ ] Known limitations: [what wasn't tested]

### Is there anything the reviewers should focus on/be aware of?

    Special attention areas, potential risks, or open questions
