### PR TITLE
fix(ui): make NavItemConfig.icon optional for submenu children

### DIFF
--- a/client/webui/frontend/src/lib/components/navigation/CollapsibleNavigationSidebar.tsx
+++ b/client/webui/frontend/src/lib/components/navigation/CollapsibleNavigationSidebar.tsx
@@ -333,7 +333,7 @@ export const CollapsibleNavigationSidebar = ({
                         <ConditionalTooltip key={item.id} show={isCollapsed} label={item.label}>
                             <button onClick={() => handleBottomItemClick(item)} className={navButtonStyles()} disabled={item.disabled}>
                                 <div className={iconWrapperStyles({ active: isActive, withMargin: true })}>
-                                    <item.icon className={iconStyles({ active: isActive })} />
+                                    {item.icon && <item.icon className={iconStyles({ active: isActive })} />}
                                 </div>
                                 <span className={cn(navTextStyles(), textAnimBase, textAnimClass)}>{item.label}</span>
                             </button>

--- a/client/webui/frontend/src/lib/components/navigation/NavItemButton.tsx
+++ b/client/webui/frontend/src/lib/components/navigation/NavItemButton.tsx
@@ -30,7 +30,7 @@ export const NavItemButton: React.FC<NavItemButtonProps> = ({ item, isActive, on
             ) : (
                 <>
                     <div className={iconWrapperStyles({ active: isHighlighted, withMargin: true })}>
-                        <item.icon className={iconStyles({ active: isHighlighted })} />
+                        {item.icon && <item.icon className={iconStyles({ active: isHighlighted })} />}
                     </div>
                     <span className={cn(navTextStyles({ active: isActive }), "overflow-hidden whitespace-nowrap transition-[opacity,max-width] duration-200", isCollapsed ? "max-w-0 opacity-0" : "max-w-[180px] opacity-100")}>{item.label}</span>
                 </>

--- a/client/webui/frontend/src/lib/types/fe.ts
+++ b/client/webui/frontend/src/lib/types/fe.ts
@@ -262,8 +262,8 @@ export interface NavItemConfig {
     /** Display text shown next to the icon in expanded mode */
     label: string;
 
-    /** Lucide icon component or any React component that accepts className prop */
-    icon: React.ElementType;
+    /** Lucide icon component or any React component that accepts className prop. Optional for submenu children. */
+    icon?: React.ElementType;
 
     /**
      * Route path to navigate to when clicked (e.g., "/agents").


### PR DESCRIPTION
## Summary

- Makes `icon` optional on `NavItemConfig` since submenu children (e.g. evaluations sub-pages) render as text-only labels without icons
- Adds null guards in `CollapsibleNavigationSidebar` and `NavItemButton` for the non-indent rendering paths
- Fixes strict type checking when `NavItemConfig` resolves to source rather than the published `.d.ts` (e.g. in the Go repo where `@SolaceLabs/solace-agent-mesh-ui` maps to community source)

## Context

The enterprise evaluations feature (`f171279b4`) added nav children without `icon`. This compiles against the npm package because `skipLibCheck: true` relaxes `.d.ts` structural checking, but fails in the Go repo where the import resolves to actual TypeScript source.

## Test plan

- [x] `npm run build` passes
- [x] `npm run lint` passes (0 errors, 28 pre-existing warnings)
- [x] Submenu children (Assets, Evaluations) continue to render as text-only labels
- [x] Top-level items with icons render unchanged