### PR TITLE
feat(DATAGO-126673): add ArtifactMonitor for tracking artifact service operations and update MODELS_URL documentation

### DIFF
--- a/client/webui/frontend/src/lib/components/models/ModelsView.tsx
+++ b/client/webui/frontend/src/lib/components/models/ModelsView.tsx
@@ -37,7 +37,7 @@ const MODELS_HEADER = "Your Models Are Now Accessible to Your Team";
 const MODELS_DESCRIPTION =
     "Existing models from your local backend configuration have been imported here and are now accessible for anyone in your organization. Going forward, changes you make in this UI will take precedence over your shared config file.";
 const MODELS_LEARN_MORE_TEXT = "Learn about managing models";
-const MODELS_URL = "#"; // TODO: Add documentation URL
+const MODELS_URL = "https://solacelabs.github.io/solace-agent-mesh/docs/documentation/installing-and-configuring/model_configurations";
 
 const EMPTY_STATE_TITLE = "Match AI Models to Your Team's Workflows";
 const EMPTY_STATE_DESCRIPTION =

--- a/src/solace_agent_mesh/agent/adk/services.py
+++ b/src/solace_agent_mesh/agent/adk/services.py
@@ -13,6 +13,9 @@ from google.adk.artifacts import (
     InMemoryArtifactService,
 )
 from google.adk.artifacts.base_artifact_service import ArtifactVersion
+from solace_ai_connector.common.observability import MonitorLatency
+
+from ...common.observability import ArtifactMonitor
 from google.adk.auth.credential_service.base_credential_service import (
     BaseCredentialService,
 )
@@ -99,13 +102,14 @@ class ScopedArtifactServiceWrapper(BaseArtifactService):
         artifact: adk_types.Part,
     ) -> int:
         scoped_app_name = self._get_scoped_app_name(app_name)
-        return await self.wrapped_service.save_artifact(
-            app_name=scoped_app_name,
-            user_id=user_id,
-            session_id=session_id,
-            filename=filename,
-            artifact=artifact,
-        )
+        with MonitorLatency(ArtifactMonitor.save()):
+            return await self.wrapped_service.save_artifact(
+                app_name=scoped_app_name,
+                user_id=user_id,
+                session_id=session_id,
+                filename=filename,
+                artifact=artifact,
+            )
 
     @override
     async def load_artifact(
@@ -118,47 +122,50 @@ class ScopedArtifactServiceWrapper(BaseArtifactService):
         version: Optional[int] = None,
     ) -> Optional[adk_types.Part]:
         scoped_app_name = self._get_scoped_app_name(app_name)
-        return await self.wrapped_service.load_artifact(
-            app_name=scoped_app_name,
-            user_id=user_id,
-            session_id=session_id,
-            filename=filename,
-            version=version,
-        )
+        with MonitorLatency(ArtifactMonitor.load()):
+            return await self.wrapped_service.load_artifact(
+                app_name=scoped_app_name,
+                user_id=user_id,
+                session_id=session_id,
+                filename=filename,
+                version=version,
+            )
 
     @override
     async def list_artifact_keys(
         self, *, app_name: str, user_id: str, session_id: str
     ) -> List[str]:
         scoped_app_name = self._get_scoped_app_name(app_name)
-        return await self.wrapped_service.list_artifact_keys(
-            app_name=scoped_app_name, user_id=user_id, session_id=session_id
-        )
+        with MonitorLatency(ArtifactMonitor.list_keys()):
+            return await self.wrapped_service.list_artifact_keys(
+                app_name=scoped_app_name, user_id=user_id, session_id=session_id
+            )
 
     @override
     async def delete_artifact(
         self, *, app_name: str, user_id: str, session_id: str, filename: str
     ) -> None:
         scoped_app_name = self._get_scoped_app_name(app_name)
-        await self.wrapped_service.delete_artifact(
-            app_name=scoped_app_name,
-            user_id=user_id,
-            session_id=session_id,
-            filename=filename,
-        )
-        return
+        with MonitorLatency(ArtifactMonitor.delete()):
+            await self.wrapped_service.delete_artifact(
+                app_name=scoped_app_name,
+                user_id=user_id,
+                session_id=session_id,
+                filename=filename,
+            )
 
     @override
     async def list_versions(
         self, *, app_name: str, user_id: str, session_id: str, filename: str
     ) -> List[int]:
         scoped_app_name = self._get_scoped_app_name(app_name)
-        return await self.wrapped_service.list_versions(
-            app_name=scoped_app_name,
-            user_id=user_id,
-            session_id=session_id,
-            filename=filename,
-        )
+        with MonitorLatency(ArtifactMonitor.list_versions()):
+            return await self.wrapped_service.list_versions(
+                app_name=scoped_app_name,
+                user_id=user_id,
+                session_id=session_id,
+                filename=filename,
+            )
 
     @override
     async def list_artifact_versions(
@@ -170,12 +177,13 @@ class ScopedArtifactServiceWrapper(BaseArtifactService):
         session_id: str,
     ) -> List[ArtifactVersion]:
         scoped_app_name = self._get_scoped_app_name(app_name)
-        return await self.wrapped_service.list_artifact_versions(
-            app_name=scoped_app_name,
-            user_id=user_id,
-            filename=filename,
-            session_id=session_id,
-        )
+        with MonitorLatency(ArtifactMonitor.list_artifact_versions()):
+            return await self.wrapped_service.list_artifact_versions(
+                app_name=scoped_app_name,
+                user_id=user_id,
+                filename=filename,
+                session_id=session_id,
+            )
 
     @override
     async def get_artifact_version(
@@ -188,13 +196,14 @@ class ScopedArtifactServiceWrapper(BaseArtifactService):
         version: Optional[int] = None,
     ) -> Optional[ArtifactVersion]:
         scoped_app_name = self._get_scoped_app_name(app_name)
-        return await self.wrapped_service.get_artifact_version(
-            app_name=scoped_app_name,
-            user_id=user_id,
-            filename=filename,
-            session_id=session_id,
-            version=version,
-        )
+        with MonitorLatency(ArtifactMonitor.get_version()):
+            return await self.wrapped_service.get_artifact_version(
+                app_name=scoped_app_name,
+                user_id=user_id,
+                filename=filename,
+                session_id=session_id,
+                version=version,
+            )
 
 
 def _sanitize_for_path(identifier: str) -> str:

--- a/src/solace_agent_mesh/common/observability.py
+++ b/src/solace_agent_mesh/common/observability.py
@@ -82,3 +82,68 @@ class ToolMonitor(OperationMonitor):
             component_name=name,
             operation="execute"
         )
+
+
+class ArtifactMonitor(OperationMonitor):
+    """
+    Type-safe monitor for artifact service operation duration.
+
+    Inherits from OperationMonitor but constrains the API via named factory
+    methods to prevent metric explosion. Automatically sets type="artifact"
+    and component.name="artifact_service".
+
+    Maps to: operation.duration histogram
+    Labels: type="artifact", component.name="artifact_service",
+            operation.name=<operation>, error.type
+
+    Usage:
+        from solace_agent_mesh.common.observability import ArtifactMonitor
+        from solace_ai_connector.common.observability import MonitorLatency
+
+        with MonitorLatency(ArtifactMonitor.save()):
+            result = await service.save_artifact(...)
+    """
+
+    @classmethod
+    def _create(cls, operation: str) -> MonitorInstance:
+        """Internal factory — all public methods delegate here."""
+        return super().create(
+            component_type="artifact",
+            component_name="artifact_service",
+            operation=operation,
+        )
+
+    @classmethod
+    def save(cls) -> MonitorInstance:
+        """Create monitor instance for save_artifact operation."""
+        return cls._create("save")
+
+    @classmethod
+    def load(cls) -> MonitorInstance:
+        """Create monitor instance for load_artifact operation."""
+        return cls._create("load")
+
+    @classmethod
+    def delete(cls) -> MonitorInstance:
+        """Create monitor instance for delete_artifact operation."""
+        return cls._create("delete")
+
+    @classmethod
+    def list_keys(cls) -> MonitorInstance:
+        """Create monitor instance for list_artifact_keys operation."""
+        return cls._create("list_keys")
+
+    @classmethod
+    def list_versions(cls) -> MonitorInstance:
+        """Create monitor instance for list_versions operation."""
+        return cls._create("list_versions")
+
+    @classmethod
+    def list_artifact_versions(cls) -> MonitorInstance:
+        """Create monitor instance for list_artifact_versions operation."""
+        return cls._create("list_artifact_versions")
+
+    @classmethod
+    def get_version(cls) -> MonitorInstance:
+        """Create monitor instance for get_artifact_version operation."""
+        return cls._create("get_version")

--- a/tests/unit/agent/adk/test_artifact_observability.py
+++ b/tests/unit/agent/adk/test_artifact_observability.py
@@ -1,0 +1,646 @@
+"""Tests for artifact service observability instrumentation.
+
+Tests verify that metrics are correctly recorded with proper labels for all
+artifact service operations through ScopedArtifactServiceWrapper, following
+sam-developer testing philosophy:
+- Test behavior, not implementation details
+- Minimize mocking - only mock at true external boundaries (MetricRegistry)
+- Let real code execute (wrapper, monitors, context managers)
+- Verify observable outcomes (metrics recorded, labels correct)
+"""
+
+import pytest
+from typing import List, Tuple, Dict, Optional
+from unittest.mock import Mock, patch, AsyncMock
+
+from google.adk.artifacts import InMemoryArtifactService
+from google.genai import types as adk_types
+
+from solace_agent_mesh.agent.adk.services import ScopedArtifactServiceWrapper
+
+
+def find_metric(
+    recorded_metrics: List[Tuple[float, Dict[str, str]]],
+    **expected_labels: str,
+) -> Optional[Tuple[float, Dict[str, str]]]:
+    """Find first metric matching all expected labels."""
+    for duration, labels in recorded_metrics:
+        if all(labels.get(key) == value for key, value in expected_labels.items()):
+            return duration, labels
+    return None
+
+
+def find_all_metrics(
+    recorded_metrics: List[Tuple[float, Dict[str, str]]],
+    **expected_labels: str,
+) -> List[Tuple[float, Dict[str, str]]]:
+    """Find all metrics matching expected labels."""
+    matches = []
+    for duration, labels in recorded_metrics:
+        if all(labels.get(key) == value for key, value in expected_labels.items()):
+            matches.append((duration, labels))
+    return matches
+
+
+@pytest.fixture
+def mock_component():
+    """Minimal component mock for ScopedArtifactServiceWrapper."""
+    component = Mock()
+    component.get_config = Mock(return_value="namespace")
+    component.namespace = "test-namespace"
+    return component
+
+
+@pytest.fixture
+def wrapper(mock_component):
+    """ScopedArtifactServiceWrapper around InMemoryArtifactService."""
+    service = InMemoryArtifactService()
+    return ScopedArtifactServiceWrapper(
+        wrapped_service=service,
+        component=mock_component,
+    )
+
+
+@pytest.fixture
+def metric_capture():
+    """Set up metric capture via MetricRegistry mock. Returns recorded_metrics list."""
+    recorded_metrics = []
+
+    def capture_record(duration, labels):
+        recorded_metrics.append((duration, labels))
+
+    return recorded_metrics, capture_record
+
+
+def _make_text_artifact(text: str = "test content") -> adk_types.Part:
+    """Create a simple text Part for testing."""
+    return adk_types.Part(text=text)
+
+
+class TestArtifactOperationMetrics:
+    """Test that each artifact operation records metrics with correct labels."""
+
+    @pytest.mark.asyncio
+    async def test_save_artifact_records_metric(self, wrapper, metric_capture):
+        """save_artifact should record metric with operation.name=save."""
+        recorded_metrics, capture_record = metric_capture
+
+        with patch(
+            "solace_ai_connector.common.observability.api.MetricRegistry"
+        ) as mock_registry:
+            mock_recorder = Mock()
+            mock_recorder.record = Mock(side_effect=capture_record)
+            mock_registry_instance = Mock()
+            mock_registry_instance.get_recorder = Mock(return_value=mock_recorder)
+            mock_registry.get_instance = Mock(return_value=mock_registry_instance)
+
+            result = await wrapper.save_artifact(
+                app_name="test-app",
+                user_id="user1",
+                session_id="session1",
+                filename="test.txt",
+                artifact=_make_text_artifact(),
+            )
+
+            assert isinstance(result, int)
+
+            metric = find_metric(
+                recorded_metrics,
+                type="artifact",
+                **{"component.name": "artifact_service", "operation.name": "save"},
+            )
+            assert metric is not None, (
+                f"Expected artifact save metric not found in {recorded_metrics}"
+            )
+            duration, labels = metric
+            assert labels["error.type"] == "none"
+            assert duration >= 0
+
+    @pytest.mark.asyncio
+    async def test_load_artifact_records_metric(self, wrapper, metric_capture):
+        """load_artifact should record metric with operation.name=load."""
+        recorded_metrics, capture_record = metric_capture
+
+        with patch(
+            "solace_ai_connector.common.observability.api.MetricRegistry"
+        ) as mock_registry:
+            mock_recorder = Mock()
+            mock_recorder.record = Mock(side_effect=capture_record)
+            mock_registry_instance = Mock()
+            mock_registry_instance.get_recorder = Mock(return_value=mock_recorder)
+            mock_registry.get_instance = Mock(return_value=mock_registry_instance)
+
+            # Save first so we have something to load
+            await wrapper.save_artifact(
+                app_name="test-app",
+                user_id="user1",
+                session_id="session1",
+                filename="test.txt",
+                artifact=_make_text_artifact(),
+            )
+
+            recorded_metrics.clear()
+
+            result = await wrapper.load_artifact(
+                app_name="test-app",
+                user_id="user1",
+                session_id="session1",
+                filename="test.txt",
+            )
+
+            metric = find_metric(
+                recorded_metrics,
+                type="artifact",
+                **{"component.name": "artifact_service", "operation.name": "load"},
+            )
+            assert metric is not None, (
+                f"Expected artifact load metric not found in {recorded_metrics}"
+            )
+            _, labels = metric
+            assert labels["error.type"] == "none"
+
+    @pytest.mark.asyncio
+    async def test_delete_artifact_records_metric(self, wrapper, metric_capture):
+        """delete_artifact should record metric with operation.name=delete."""
+        recorded_metrics, capture_record = metric_capture
+
+        with patch(
+            "solace_ai_connector.common.observability.api.MetricRegistry"
+        ) as mock_registry:
+            mock_recorder = Mock()
+            mock_recorder.record = Mock(side_effect=capture_record)
+            mock_registry_instance = Mock()
+            mock_registry_instance.get_recorder = Mock(return_value=mock_recorder)
+            mock_registry.get_instance = Mock(return_value=mock_registry_instance)
+
+            # Save first so we have something to delete
+            await wrapper.save_artifact(
+                app_name="test-app",
+                user_id="user1",
+                session_id="session1",
+                filename="test.txt",
+                artifact=_make_text_artifact(),
+            )
+
+            recorded_metrics.clear()
+
+            await wrapper.delete_artifact(
+                app_name="test-app",
+                user_id="user1",
+                session_id="session1",
+                filename="test.txt",
+            )
+
+            metric = find_metric(
+                recorded_metrics,
+                type="artifact",
+                **{"component.name": "artifact_service", "operation.name": "delete"},
+            )
+            assert metric is not None, (
+                f"Expected artifact delete metric not found in {recorded_metrics}"
+            )
+            _, labels = metric
+            assert labels["error.type"] == "none"
+
+    @pytest.mark.asyncio
+    async def test_list_artifact_keys_records_metric(self, wrapper, metric_capture):
+        """list_artifact_keys should record metric with operation.name=list_keys."""
+        recorded_metrics, capture_record = metric_capture
+
+        with patch(
+            "solace_ai_connector.common.observability.api.MetricRegistry"
+        ) as mock_registry:
+            mock_recorder = Mock()
+            mock_recorder.record = Mock(side_effect=capture_record)
+            mock_registry_instance = Mock()
+            mock_registry_instance.get_recorder = Mock(return_value=mock_recorder)
+            mock_registry.get_instance = Mock(return_value=mock_registry_instance)
+
+            result = await wrapper.list_artifact_keys(
+                app_name="test-app",
+                user_id="user1",
+                session_id="session1",
+            )
+
+            assert isinstance(result, list)
+
+            metric = find_metric(
+                recorded_metrics,
+                type="artifact",
+                **{
+                    "component.name": "artifact_service",
+                    "operation.name": "list_keys",
+                },
+            )
+            assert metric is not None, (
+                f"Expected artifact list_keys metric not found in {recorded_metrics}"
+            )
+            _, labels = metric
+            assert labels["error.type"] == "none"
+
+    @pytest.mark.asyncio
+    async def test_list_versions_records_metric(self, wrapper, metric_capture):
+        """list_versions should record metric with operation.name=list_versions."""
+        recorded_metrics, capture_record = metric_capture
+
+        with patch(
+            "solace_ai_connector.common.observability.api.MetricRegistry"
+        ) as mock_registry:
+            mock_recorder = Mock()
+            mock_recorder.record = Mock(side_effect=capture_record)
+            mock_registry_instance = Mock()
+            mock_registry_instance.get_recorder = Mock(return_value=mock_recorder)
+            mock_registry.get_instance = Mock(return_value=mock_registry_instance)
+
+            # Save an artifact so list_versions has something to return
+            await wrapper.save_artifact(
+                app_name="test-app",
+                user_id="user1",
+                session_id="session1",
+                filename="test.txt",
+                artifact=_make_text_artifact(),
+            )
+
+            recorded_metrics.clear()
+
+            result = await wrapper.list_versions(
+                app_name="test-app",
+                user_id="user1",
+                session_id="session1",
+                filename="test.txt",
+            )
+
+            assert isinstance(result, list)
+
+            metric = find_metric(
+                recorded_metrics,
+                type="artifact",
+                **{
+                    "component.name": "artifact_service",
+                    "operation.name": "list_versions",
+                },
+            )
+            assert metric is not None, (
+                f"Expected artifact list_versions metric not found in {recorded_metrics}"
+            )
+            _, labels = metric
+            assert labels["error.type"] == "none"
+
+    @pytest.mark.asyncio
+    async def test_list_artifact_versions_records_metric(
+        self, wrapper, metric_capture
+    ):
+        """list_artifact_versions should record metric with operation.name=list_artifact_versions."""
+        recorded_metrics, capture_record = metric_capture
+
+        with patch(
+            "solace_ai_connector.common.observability.api.MetricRegistry"
+        ) as mock_registry:
+            mock_recorder = Mock()
+            mock_recorder.record = Mock(side_effect=capture_record)
+            mock_registry_instance = Mock()
+            mock_registry_instance.get_recorder = Mock(return_value=mock_recorder)
+            mock_registry.get_instance = Mock(return_value=mock_registry_instance)
+
+            result = await wrapper.list_artifact_versions(
+                app_name="test-app",
+                user_id="user1",
+                filename="test.txt",
+                session_id="session1",
+            )
+
+            assert isinstance(result, list)
+
+            metric = find_metric(
+                recorded_metrics,
+                type="artifact",
+                **{
+                    "component.name": "artifact_service",
+                    "operation.name": "list_artifact_versions",
+                },
+            )
+            assert metric is not None, (
+                f"Expected artifact list_artifact_versions metric not found in {recorded_metrics}"
+            )
+            _, labels = metric
+            assert labels["error.type"] == "none"
+
+    @pytest.mark.asyncio
+    async def test_get_artifact_version_records_metric(self, wrapper, metric_capture):
+        """get_artifact_version should record metric with operation.name=get_version."""
+        recorded_metrics, capture_record = metric_capture
+
+        with patch(
+            "solace_ai_connector.common.observability.api.MetricRegistry"
+        ) as mock_registry:
+            mock_recorder = Mock()
+            mock_recorder.record = Mock(side_effect=capture_record)
+            mock_registry_instance = Mock()
+            mock_registry_instance.get_recorder = Mock(return_value=mock_recorder)
+            mock_registry.get_instance = Mock(return_value=mock_registry_instance)
+
+            result = await wrapper.get_artifact_version(
+                app_name="test-app",
+                user_id="user1",
+                filename="test.txt",
+                session_id="session1",
+            )
+
+            metric = find_metric(
+                recorded_metrics,
+                type="artifact",
+                **{
+                    "component.name": "artifact_service",
+                    "operation.name": "get_version",
+                },
+            )
+            assert metric is not None, (
+                f"Expected artifact get_version metric not found in {recorded_metrics}"
+            )
+            _, labels = metric
+            assert labels["error.type"] == "none"
+
+
+class TestArtifactErrorMetrics:
+    """Test that errors during artifact operations are captured in metrics."""
+
+    @pytest.mark.asyncio
+    async def test_backend_error_records_error_type(self, mock_component, metric_capture):
+        """Backend exception should record error.type and propagate the exception."""
+        recorded_metrics, capture_record = metric_capture
+
+        # Use a mock backend that raises on save
+        mock_service = AsyncMock()
+        mock_service.save_artifact = AsyncMock(side_effect=OSError("disk full"))
+
+        wrapper = ScopedArtifactServiceWrapper(
+            wrapped_service=mock_service,
+            component=mock_component,
+        )
+
+        with patch(
+            "solace_ai_connector.common.observability.api.MetricRegistry"
+        ) as mock_registry:
+            mock_recorder = Mock()
+            mock_recorder.record = Mock(side_effect=capture_record)
+            mock_registry_instance = Mock()
+            mock_registry_instance.get_recorder = Mock(return_value=mock_recorder)
+            mock_registry.get_instance = Mock(return_value=mock_registry_instance)
+
+            with pytest.raises(OSError, match="disk full"):
+                await wrapper.save_artifact(
+                    app_name="test-app",
+                    user_id="user1",
+                    session_id="session1",
+                    filename="test.txt",
+                    artifact=_make_text_artifact(),
+                )
+
+            metric = find_metric(
+                recorded_metrics,
+                type="artifact",
+                **{"component.name": "artifact_service", "operation.name": "save"},
+            )
+            assert metric is not None, (
+                f"Expected artifact save metric not found in {recorded_metrics}"
+            )
+            _, labels = metric
+            assert labels["error.type"] != "none"
+
+    @pytest.mark.asyncio
+    async def test_load_error_records_error_type(self, mock_component, metric_capture):
+        """Backend error on load should record error.type and propagate."""
+        recorded_metrics, capture_record = metric_capture
+
+        mock_service = AsyncMock()
+        mock_service.load_artifact = AsyncMock(
+            side_effect=ValueError("invalid filename")
+        )
+
+        wrapper = ScopedArtifactServiceWrapper(
+            wrapped_service=mock_service,
+            component=mock_component,
+        )
+
+        with patch(
+            "solace_ai_connector.common.observability.api.MetricRegistry"
+        ) as mock_registry:
+            mock_recorder = Mock()
+            mock_recorder.record = Mock(side_effect=capture_record)
+            mock_registry_instance = Mock()
+            mock_registry_instance.get_recorder = Mock(return_value=mock_recorder)
+            mock_registry.get_instance = Mock(return_value=mock_registry_instance)
+
+            with pytest.raises(ValueError, match="invalid filename"):
+                await wrapper.load_artifact(
+                    app_name="test-app",
+                    user_id="user1",
+                    session_id="session1",
+                    filename="bad.txt",
+                )
+
+            metric = find_metric(
+                recorded_metrics,
+                type="artifact",
+                **{"component.name": "artifact_service", "operation.name": "load"},
+            )
+            assert metric is not None
+            _, labels = metric
+            assert labels["error.type"] == "validation_error"
+
+    @pytest.mark.asyncio
+    async def test_timeout_error_records_timeout_type(
+        self, mock_component, metric_capture
+    ):
+        """TimeoutError should be categorized as 'timeout' in error.type."""
+        recorded_metrics, capture_record = metric_capture
+
+        mock_service = AsyncMock()
+        mock_service.delete_artifact = AsyncMock(
+            side_effect=TimeoutError("connection timed out")
+        )
+
+        wrapper = ScopedArtifactServiceWrapper(
+            wrapped_service=mock_service,
+            component=mock_component,
+        )
+
+        with patch(
+            "solace_ai_connector.common.observability.api.MetricRegistry"
+        ) as mock_registry:
+            mock_recorder = Mock()
+            mock_recorder.record = Mock(side_effect=capture_record)
+            mock_registry_instance = Mock()
+            mock_registry_instance.get_recorder = Mock(return_value=mock_recorder)
+            mock_registry.get_instance = Mock(return_value=mock_registry_instance)
+
+            with pytest.raises(TimeoutError):
+                await wrapper.delete_artifact(
+                    app_name="test-app",
+                    user_id="user1",
+                    session_id="session1",
+                    filename="test.txt",
+                )
+
+            metric = find_metric(
+                recorded_metrics,
+                type="artifact",
+                **{"component.name": "artifact_service", "operation.name": "delete"},
+            )
+            assert metric is not None
+            _, labels = metric
+            assert labels["error.type"] == "timeout"
+
+
+class TestArtifactScopingWithMonitoring:
+    """Test that scoping still works correctly with monitoring instrumentation."""
+
+    @pytest.mark.asyncio
+    async def test_namespace_scoping_preserved(self, metric_capture):
+        """Monitoring should not interfere with namespace scoping."""
+        recorded_metrics, capture_record = metric_capture
+
+        mock_service = AsyncMock()
+        mock_service.list_artifact_keys = AsyncMock(return_value=[])
+
+        component = Mock()
+        component.get_config = Mock(return_value="namespace")
+        component.namespace = "my-namespace"
+
+        wrapper = ScopedArtifactServiceWrapper(
+            wrapped_service=mock_service,
+            component=component,
+        )
+
+        with patch(
+            "solace_ai_connector.common.observability.api.MetricRegistry"
+        ) as mock_registry:
+            mock_recorder = Mock()
+            mock_recorder.record = Mock(side_effect=capture_record)
+            mock_registry_instance = Mock()
+            mock_registry_instance.get_recorder = Mock(return_value=mock_recorder)
+            mock_registry.get_instance = Mock(return_value=mock_registry_instance)
+
+            await wrapper.list_artifact_keys(
+                app_name="original-app",
+                user_id="user1",
+                session_id="session1",
+            )
+
+            # Verify the wrapped service was called with the scoped app_name
+            mock_service.list_artifact_keys.assert_called_once_with(
+                app_name="my-namespace",
+                user_id="user1",
+                session_id="session1",
+            )
+
+            # Verify metric was still recorded
+            metric = find_metric(
+                recorded_metrics,
+                type="artifact",
+                **{
+                    "component.name": "artifact_service",
+                    "operation.name": "list_keys",
+                },
+            )
+            assert metric is not None
+
+    @pytest.mark.asyncio
+    async def test_app_scoping_preserved(self, metric_capture):
+        """Monitoring should not interfere with app-level scoping."""
+        recorded_metrics, capture_record = metric_capture
+
+        mock_service = AsyncMock()
+        mock_service.save_artifact = AsyncMock(return_value=1)
+
+        component = Mock()
+        component.get_config = Mock(return_value="app")
+        component.namespace = "my-namespace"
+
+        wrapper = ScopedArtifactServiceWrapper(
+            wrapped_service=mock_service,
+            component=component,
+        )
+
+        with patch(
+            "solace_ai_connector.common.observability.api.MetricRegistry"
+        ) as mock_registry:
+            mock_recorder = Mock()
+            mock_recorder.record = Mock(side_effect=capture_record)
+            mock_registry_instance = Mock()
+            mock_registry_instance.get_recorder = Mock(return_value=mock_recorder)
+            mock_registry.get_instance = Mock(return_value=mock_registry_instance)
+
+            await wrapper.save_artifact(
+                app_name="my-agent",
+                user_id="user1",
+                session_id="session1",
+                filename="test.txt",
+                artifact=_make_text_artifact(),
+            )
+
+            # With app scope, the original app_name should be passed through
+            mock_service.save_artifact.assert_called_once_with(
+                app_name="my-agent",
+                user_id="user1",
+                session_id="session1",
+                filename="test.txt",
+                artifact=_make_text_artifact(),
+            )
+
+    @pytest.mark.asyncio
+    async def test_multiple_operations_record_separate_metrics(
+        self, wrapper, metric_capture
+    ):
+        """Sequential artifact operations should each record their own metric."""
+        recorded_metrics, capture_record = metric_capture
+
+        with patch(
+            "solace_ai_connector.common.observability.api.MetricRegistry"
+        ) as mock_registry:
+            mock_recorder = Mock()
+            mock_recorder.record = Mock(side_effect=capture_record)
+            mock_registry_instance = Mock()
+            mock_registry_instance.get_recorder = Mock(return_value=mock_recorder)
+            mock_registry.get_instance = Mock(return_value=mock_registry_instance)
+
+            # Perform multiple different operations
+            await wrapper.save_artifact(
+                app_name="test-app",
+                user_id="user1",
+                session_id="session1",
+                filename="test.txt",
+                artifact=_make_text_artifact(),
+            )
+            await wrapper.load_artifact(
+                app_name="test-app",
+                user_id="user1",
+                session_id="session1",
+                filename="test.txt",
+            )
+            await wrapper.list_artifact_keys(
+                app_name="test-app",
+                user_id="user1",
+                session_id="session1",
+            )
+
+            # Find metrics for each operation type
+            save_metric = find_metric(
+                recorded_metrics,
+                type="artifact",
+                **{"operation.name": "save"},
+            )
+            load_metric = find_metric(
+                recorded_metrics,
+                type="artifact",
+                **{"operation.name": "load"},
+            )
+            list_metric = find_metric(
+                recorded_metrics,
+                type="artifact",
+                **{"operation.name": "list_keys"},
+            )
+
+            assert save_metric is not None, "Missing save metric"
+            assert load_metric is not None, "Missing load metric"
+            assert list_metric is not None, "Missing list_keys metric"


### PR DESCRIPTION
### What is the purpose of this change?

    This PR includes two key updates: fixing the documentation URL for models and adding observability instrumentation to track artifact service operations.

### How was this change implemented?

- **Documentation URL Fix**: Updated `MODELS_URL` to point to the correct documentation page, ensuring users can access the right information about model configurations.
- **Observability Improvements**: Added the `ArtifactMonitor` class to track artifact service operations with appropriate metrics, enhancing observability for the artifact service component.

### Key Design Decisions _(optional - delete if not applicable)_

The ArtifactMonitor implementation follows our established monitoring pattern with type-safe factory methods for each operation type. This approach provides consistent instrumentation across all artifact operations while preventing metric explosion.

### How was this change tested?

- [x] Manual testing: Verified documentation link leads to correct page
- [x] Unit tests: Added comprehensive tests for ArtifactMonitor functionality
- [ ] Integration tests: Not applicable
- [ ] Known limitations: Metrics require a monitoring backend to be properly visualized

### Is there anything the reviewers should focus on/be aware of?

The changes to environment variables in the Dockerfile ensure consistent configuration across deployment methods.