### PR TITLE
feat(DATAGO-131939): remove model status change callback and simplify agent card publishing logic

### DIFF
--- a/src/solace_agent_mesh/agent/sac/component.py
+++ b/src/solace_agent_mesh/agent/sac/component.py
@@ -4130,29 +4130,6 @@ class SamAgentComponent(SamComponentBase):
             )
             raise e
 
-    def _on_model_status_change(self, old_status: str, new_status: str):
-        """Callback invoked by LiteLlm on any status transition.
-
-        Handles starting/stopping agent card publishing based on model readiness.
-        """
-        if not self._lazy_model_mode:
-            return  # No action needed if not in lazy model mode
-        
-        log.info(
-            "%s Model status changed: %s -> %s",
-            self.log_identifier,
-            old_status,
-            new_status,
-        )
-        if new_status == "ready":
-            self._publish_agent_card()
-        elif new_status == "none" and old_status == "ready":
-            self.cancel_timer(self._card_publish_timer_id)
-            log.info(
-                "%s Agent card publishing stopped (model unconfigured).",
-                self.log_identifier,
-            )
-
     async def _async_setup_and_run(self) -> None:
         """
         Main async logic for the agent component.
@@ -4165,8 +4142,7 @@ class SamAgentComponent(SamComponentBase):
             # Perform agent-specific async initialization
             await self._perform_async_init()
 
-            if not self._lazy_model_mode:
-                self._publish_agent_card()
+            self._publish_agent_card()
 
         except Exception as e:
             log.exception(

--- a/tests/unit/agent/sac/test_agent_component_lazy_model.py
+++ b/tests/unit/agent/sac/test_agent_component_lazy_model.py
@@ -6,67 +6,6 @@ from unittest.mock import MagicMock, patch, call
 from src.solace_agent_mesh.agent.sac.component import SamAgentComponent
 
 
-class TestAgentComponentOnModelStatusChange:
-    """Test SamAgentComponent._on_model_status_change callback."""
-
-    def _create_component(self, lazy_model_mode=True):
-        """Create a mock SamAgentComponent with the real _on_model_status_change bound."""
-        component = MagicMock(spec=SamAgentComponent)
-        component.log_identifier = "[TestAgent]"
-        component._lazy_model_mode = lazy_model_mode
-        component._card_publish_timer_id = "timer-123"
-        component._publish_agent_card = MagicMock()
-        component.cancel_timer = MagicMock()
-
-        # Bind the real method
-        component._on_model_status_change = (
-            SamAgentComponent._on_model_status_change.__get__(
-                component, SamAgentComponent
-            )
-        )
-        return component
-
-    def test_publishes_card_when_ready(self):
-        """When status transitions to 'ready', agent card should be published."""
-        component = self._create_component(lazy_model_mode=True)
-        component._on_model_status_change("initializing", "ready")
-        component._publish_agent_card.assert_called_once()
-
-    def test_cancels_timer_when_unconfigured(self):
-        """When status transitions from 'ready' to 'none', card publishing stops."""
-        component = self._create_component(lazy_model_mode=True)
-        component._on_model_status_change("ready", "none")
-        component.cancel_timer.assert_called_once_with("timer-123")
-        component._publish_agent_card.assert_not_called()
-
-    def test_no_action_when_not_lazy_mode(self):
-        """When not in lazy model mode, callback does nothing."""
-        component = self._create_component(lazy_model_mode=False)
-        component._on_model_status_change("initializing", "ready")
-        component._publish_agent_card.assert_not_called()
-        component.cancel_timer.assert_not_called()
-
-    def test_no_cancel_on_non_ready_to_none(self):
-        """Transitioning from 'initializing' to 'none' should not cancel timer."""
-        component = self._create_component(lazy_model_mode=True)
-        component._on_model_status_change("initializing", "none")
-        component.cancel_timer.assert_not_called()
-        component._publish_agent_card.assert_not_called()
-
-    def test_reconfigure_publishes_card_again(self):
-        """Unconfigure then reconfigure should publish card again."""
-        component = self._create_component(lazy_model_mode=True)
-
-        component._on_model_status_change("initializing", "ready")
-        assert component._publish_agent_card.call_count == 1
-
-        component._on_model_status_change("ready", "none")
-        component.cancel_timer.assert_called_once()
-
-        component._on_model_status_change("none", "ready")
-        assert component._publish_agent_card.call_count == 2
-
-
 class TestAgentComponentAsyncSetupLazyMode:
     """Test that _async_setup_and_run respects lazy model mode for card publishing."""
 


### PR DESCRIPTION
### What is the purpose of this change?

This change improves the handling of dynamic tools in the agent system, particularly fixing an issue where DynamicTool subclasses weren't displaying their real names and descriptions in agent cards and tool manifests.

### How was this change implemented?

- Added special handling for DynamicTool subclasses by checking for tool_name/tool_description properties
- Refactored tool manifest building in SamAgentComponent for improved clarity and error handling
- Simplified agent card publishing logic by removing the model status change callback
- Fixed testing components to properly bind real async/sync methods

### Key Design Decisions

The code now handles both traditional tools (with name/description attributes) and DynamicTool subclasses (which may have tool_name/tool_description properties). This improves compatibility with different tool types while maintaining backward compatibility.

### How was this change tested?

- [x] Manual testing: Verified agent cards show correct tool names and descriptions
- [x] Unit tests: Added new tests for tool_name property resolution in both setup.py and component.py
- [x] Integration tests: Verified agent initialization with mixed tool types
- [ ] Known limitations: Full integration testing with all tool types would be beneficial

### Is there anything the reviewers should focus on/be aware of?

The changes to the tool manifest building logic are significant - please review the implementation in SamAgentComponent's _build_tool_manifest and related methods.