### PR TITLE
refactor(DATAGO-132190): PageLayout + self-controlling ModelWarningBanner

### DIFF
--- a/client/webui/frontend/src/AppLayout.tsx
+++ b/client/webui/frontend/src/AppLayout.tsx
@@ -27,7 +27,6 @@ function AppLayoutContent() {
     const [modelSetupDismissed, setModelSetupDismissed] = useLocalStorage("model-setup-dialog-dismissed", false);
 
     const { data: modelConfigStatus } = useModelConfigStatus();
-    const showModelWarning = modelConfigUiEnabled && modelConfigStatus && !modelConfigStatus.configured;
 
     useEffect(() => {
         if (modelConfigUiEnabled && modelConfigStatus && !modelConfigStatus.configured && !modelSetupDismissed) {
@@ -139,8 +138,8 @@ function AppLayoutContent() {
             ) : (
                 <NavigationSidebar items={topNavItems} bottomItems={bottomNavigationItems} activeItem={getActiveItem()} onItemChange={handleNavItemChange} onHeaderClick={handleHeaderClick} />
             )}
-            <main className="h-full w-full flex-1 overflow-auto">
-                <ModelWarningBanner showWarning={!!showModelWarning} hasModelConfigWrite={hasModelConfigWrite} />
+            <main className="flex h-full w-full flex-1 flex-col">
+                <ModelWarningBanner />
                 <Outlet />
             </main>
             <ToastContainer />

--- a/client/webui/frontend/src/lib/components/index.ts
+++ b/client/webui/frontend/src/lib/components/index.ts
@@ -8,6 +8,7 @@ export * from "./chat";
 export * from "./settings";
 
 export * from "./common";
+export * from "./layout";
 
 export * from "./header";
 export * from "./pages";

--- a/client/webui/frontend/src/lib/components/layout/PageLayout.tsx
+++ b/client/webui/frontend/src/lib/components/layout/PageLayout.tsx
@@ -1,0 +1,12 @@
+import type { ReactNode } from "react";
+
+import { cn } from "@/lib/utils";
+
+interface PageLayoutProps {
+    children: ReactNode;
+    className?: string;
+}
+
+export function PageLayout({ children, className }: PageLayoutProps) {
+    return <div className={cn("flex min-h-0 w-full flex-1 flex-col overflow-hidden", className)}>{children}</div>;
+}

--- a/client/webui/frontend/src/lib/components/layout/index.ts
+++ b/client/webui/frontend/src/lib/components/layout/index.ts
@@ -1,0 +1,1 @@
+export * from "./PageLayout";

--- a/client/webui/frontend/src/lib/components/models/ModelDetailsPage.tsx
+++ b/client/webui/frontend/src/lib/components/models/ModelDetailsPage.tsx
@@ -4,6 +4,7 @@ import { Pencil, Trash2, Ellipsis } from "lucide-react";
 
 import { Button, Menu, Popover, PopoverContent, PopoverTrigger, type MenuAction } from "@/lib/components/ui";
 import { EmptyState, Footer, PageContentWrapper, PageSection, PageLabelWithValue, PageLabel, PageValue, Metadata } from "@/lib/components/common";
+import { PageLayout } from "@/lib/components/layout";
 import { Header } from "@/lib/components/header";
 
 import { useModelConfigs, useDeleteModel } from "@/lib/api/models";
@@ -68,7 +69,7 @@ export const ModelDetailsPage = () => {
     const title = modelToView ? modelToView.alias : "N/A";
 
     return (
-        <div className="flex h-full w-full min-w-4xl flex-col overflow-hidden">
+        <PageLayout className="min-w-4xl">
             <Header title={title} breadcrumbs={[{ label: "Models", onClick: () => navigate("/agents?tab=models") }, { label: title }]} buttons={headerButtons} />
 
             {modelConfigsLoading ? (
@@ -159,6 +160,6 @@ export const ModelDetailsPage = () => {
                     Close
                 </Button>
             </Footer>
-        </div>
+        </PageLayout>
     );
 };

--- a/client/webui/frontend/src/lib/components/models/ModelEdit.tsx
+++ b/client/webui/frontend/src/lib/components/models/ModelEdit.tsx
@@ -344,13 +344,7 @@ export const ModelEdit = ({ isNew, modelToEdit, onSave, onDirtyStateChange, mode
         // Password fields use the dedicated PasswordInput component
         if (field.type === "password") {
             return (
-                <FormFieldLayoutItem
-                    key={field.name}
-                    helpText={!isNew ? "Your API key is securely stored. Leave blank to keep the existing key, or enter a new value to replace it." : field.helpText}
-                    label={field.label}
-                    required={field.required}
-                    error={errors[field.name] as { message?: string }}
-                >
+                <FormFieldLayoutItem key={field.name} helpText={field.helpText} label={field.label} required={field.required} error={errors[field.name] as { message?: string }}>
                     <PasswordInput name={field.name} control={control} hasStoredValue={storedCredentialFields.has(field.name)} placeholder={field.placeholder} rules={{ required: isRequiredField ? `${field.label} is required` : false }} />
                 </FormFieldLayoutItem>
             );

--- a/client/webui/frontend/src/lib/components/models/ModelEditPage.tsx
+++ b/client/webui/frontend/src/lib/components/models/ModelEditPage.tsx
@@ -5,6 +5,7 @@ import { Button } from "@/lib/components/ui";
 import { Header } from "@/lib/components/header";
 
 import { Footer, PageContentWrapper, EmptyState, MessageBanner, ConfirmationDialog } from "@/lib/components/common";
+import { PageLayout } from "@/lib/components/layout";
 import { ModelEdit } from "./ModelEdit";
 import { ALL_PROVIDERS, buildModelPayload, buildTestPayload } from "./modelProviderUtils";
 import { useModelById, useCreateModel, useUpdateModel, useTestModelConnection, useSupportedModels } from "@/lib/api/models";
@@ -111,7 +112,7 @@ export const ModelEditPage = () => {
     }
 
     return (
-        <div className="flex h-full w-full min-w-4xl flex-col overflow-hidden">
+        <PageLayout className="min-w-4xl">
             <Header title={title} breadcrumbs={[{ label: "Agent Mesh", onClick: () => navigate("/agents?tab=models") }, { label: title }]} />
 
             <PageContentWrapper>
@@ -142,6 +143,6 @@ export const ModelEditPage = () => {
                     {isSaving ? "Saving..." : isNew ? "Add" : "Save"}
                 </Button>
             </Footer>
-        </div>
+        </PageLayout>
     );
 };

--- a/client/webui/frontend/src/lib/components/models/ModelWarningBanner.tsx
+++ b/client/webui/frontend/src/lib/components/models/ModelWarningBanner.tsx
@@ -1,15 +1,18 @@
 import { useNavigate } from "react-router-dom";
+import { useBooleanFlagDetails } from "@openfeature/react-sdk";
 
+import { useModelConfigStatus } from "@/lib/api/models";
 import { MessageBanner } from "@/lib/components/common/MessageBanner";
 import { Button } from "@/lib/components/ui";
+import { useChatContext } from "@/lib/hooks";
 
-interface ModelWarningBannerProps {
-    showWarning: boolean;
-    hasModelConfigWrite: boolean;
-}
-
-export function ModelWarningBanner({ showWarning, hasModelConfigWrite }: ModelWarningBannerProps) {
+export function ModelWarningBanner() {
     const navigate = useNavigate();
+    const { value: modelConfigUiEnabled } = useBooleanFlagDetails("model_config_ui", false);
+    const { data: modelConfigStatus } = useModelConfigStatus();
+    const { hasModelConfigWrite } = useChatContext();
+
+    const showWarning = modelConfigUiEnabled && modelConfigStatus && !modelConfigStatus.configured;
 
     if (!showWarning) return null;
 
@@ -20,7 +23,7 @@ export function ModelWarningBanner({ showWarning, hasModelConfigWrite }: ModelWa
             message={
                 <div className="flex w-full items-center justify-between gap-3">
                     <span>
-                        No model has been set up. Some features may not work as intended without a configured model.
+                        Default models have not been configured. Chat, agent creation, and other AI features require a General and Planning model to function.
                         {hasModelConfigWrite ? " Go to Agent Mesh to configure your models." : " Ask your administrator to configure models in Agent Mesh."}
                     </span>
                     {hasModelConfigWrite && (

--- a/client/webui/frontend/src/lib/components/pages/AgentMeshPage.tsx
+++ b/client/webui/frontend/src/lib/components/pages/AgentMeshPage.tsx
@@ -2,7 +2,7 @@ import { useMemo } from "react";
 import { useSearchParams, useNavigate } from "react-router-dom";
 import { useBooleanFlagDetails } from "@openfeature/react-sdk";
 
-import { Button, EmptyState, Header } from "@/lib/components";
+import { Button, EmptyState, Header, PageLayout } from "@/lib/components";
 import { AgentMeshCards } from "@/lib/components/agents";
 import { WorkflowList } from "@/lib/components/workflows";
 import { ModelsView } from "@/lib/components/models";
@@ -64,7 +64,7 @@ export function AgentMeshPage() {
     ];
 
     return (
-        <div className="flex h-full w-full flex-col">
+        <PageLayout>
             <Header
                 title="Agent Mesh"
                 tabs={tabs}
@@ -95,6 +95,6 @@ export function AgentMeshPage() {
                     {activeTab === "models" && <ModelsView />}
                 </div>
             )}
-        </div>
+        </PageLayout>
     );
 }

--- a/client/webui/frontend/src/lib/components/pages/ArtifactsPage.tsx
+++ b/client/webui/frontend/src/lib/components/pages/ArtifactsPage.tsx
@@ -39,6 +39,7 @@ import { ConfigContext } from "@/lib/contexts/ConfigContext";
 import { ContentRenderer } from "@/lib/components/chat/preview/ContentRenderer";
 import { canPreviewArtifact, getFileContent, getRenderType } from "@/lib/components/chat/preview/previewUtils";
 import { Header } from "@/lib/components/header/Header";
+import { PageLayout } from "@/lib/components/layout";
 import { LifecycleBadge } from "@/lib/components/ui";
 import type { FileAttachment } from "@/lib/types";
 import type { ArtifactWithSession } from "@/lib/api/artifacts";
@@ -1088,7 +1089,7 @@ export function ArtifactsPage() {
     );
 
     return (
-        <div className="flex h-full flex-col">
+        <PageLayout>
             {/* Page Header - using shared Header component for consistent styling */}
             <Header
                 title={
@@ -1268,6 +1269,6 @@ export function ArtifactsPage() {
                     </DialogFooter>
                 </DialogContent>
             </Dialog>
-        </div>
+        </PageLayout>
     );
 }

--- a/client/webui/frontend/src/lib/components/pages/ChatPage.tsx
+++ b/client/webui/frontend/src/lib/components/pages/ChatPage.tsx
@@ -13,6 +13,7 @@ import type { TextPart } from "@/lib/types";
 import type { CollaborativeUser } from "@/lib/types/collaboration";
 import { ChatInputArea, ChatMessage, ChatSessionDialog, ChatSessionDeleteDialog, ChatSidePanel, LoadingMessageRow, ProjectBadge, SessionSidePanel, UserPresenceAvatars, ShareNotificationMessage } from "@/lib/components/chat";
 import { Button, ChatMessageList, CHAT_STYLES, ResizablePanelGroup, ResizablePanel, ResizableHandle, Spinner, Tooltip, TooltipContent, TooltipTrigger } from "@/lib/components/ui";
+import { PageLayout } from "@/lib/components/layout";
 import type { ChatMessageListRef } from "@/lib/components/ui/chat/chat-message-list";
 import { useShareLink, useShareUsers } from "@/lib/api/share";
 import { api } from "@/lib/api";
@@ -521,7 +522,7 @@ export function ChatPage() {
     }, [isTaskMonitorConnected, isTaskMonitorConnecting, taskMonitorSseError, connectTaskMonitorStream]);
 
     return (
-        <div className="relative flex h-screen w-full flex-col overflow-hidden">
+        <PageLayout className="relative">
             {!useNewNav && (
                 <div className={`absolute top-0 left-0 z-20 h-screen transition-transform duration-300 ${isSessionSidePanelCollapsed ? "-translate-x-full" : "translate-x-0"}`}>
                     <SessionSidePanel onToggle={handleSessionSidePanelToggle} />
@@ -694,6 +695,6 @@ export function ChatPage() {
             </div>
             <ChatSessionDeleteDialog open={!!sessionToDelete} onCancel={closeSessionDeleteModal} onConfirm={confirmSessionDelete} sessionName={sessionToDelete?.name || ""} />
             {sessionId && <ShareDialog sessionId={sessionId} sessionTitle={sessionName || "New Chat"} open={isShareDialogOpen} onOpenChange={setIsShareDialogOpen} />}
-        </div>
+        </PageLayout>
     );
 }

--- a/client/webui/frontend/src/lib/components/pages/PromptsPage.tsx
+++ b/client/webui/frontend/src/lib/components/pages/PromptsPage.tsx
@@ -4,7 +4,7 @@ import { RefreshCcw, Upload } from "lucide-react";
 
 import type { PromptGroup, Prompt } from "@/lib/types/prompts";
 import type { PromptImportData } from "@/lib/schemas";
-import { Button, EmptyState, Header, VariableDialog, LifecycleBadge } from "@/lib/components";
+import { Button, EmptyState, Header, PageLayout, VariableDialog, LifecycleBadge } from "@/lib/components";
 import { GeneratePromptDialog, PromptCards, PromptDeleteDialog, PromptTemplateBuilder, VersionHistoryPage, PromptImportDialog } from "@/lib/components/prompts";
 import { detectVariables, downloadBlob, getErrorMessage } from "@/lib/utils";
 import { api } from "@/lib/api";
@@ -338,7 +338,7 @@ export const PromptsPage: React.FC = () => {
 
     // Main prompts view
     return (
-        <div className="flex h-full w-full flex-col">
+        <PageLayout>
             <Header
                 title={
                     <>
@@ -392,6 +392,6 @@ export const PromptsPage: React.FC = () => {
             )}
 
             <PromptImportDialog open={showImportDialog} onOpenChange={setShowImportDialog} onImport={handleImport} existingPrompts={promptGroups} />
-        </div>
+        </PageLayout>
     );
 };

--- a/client/webui/frontend/src/lib/components/pages/RecentChatsPage.tsx
+++ b/client/webui/frontend/src/lib/components/pages/RecentChatsPage.tsx
@@ -12,6 +12,7 @@ import { ProjectBadge, SessionSearch, SessionActionMenu, ChatSessionDeleteDialog
 import { ShareDialog } from "@/lib/components/share/ShareDialog";
 import { Header } from "@/lib/components/header";
 import { EmptyState } from "@/lib/components/common/EmptyState";
+import { PageLayout } from "@/lib/components/layout";
 import { Button, Select, SelectContent, SelectItem, SelectTrigger, SelectValue, Spinner, Tabs, TabsList, TabsTrigger, Tooltip, TooltipContent, TooltipTrigger } from "@/lib/components/ui";
 
 const PAGE_SIZE = 20;
@@ -278,7 +279,7 @@ export const RecentChatsPage: React.FC = () => {
     }
 
     return (
-        <div className="flex h-full flex-col">
+        <PageLayout>
             <Header
                 title="Recent Chats"
                 buttons={[
@@ -462,6 +463,6 @@ export const RecentChatsPage: React.FC = () => {
                     }}
                 />
             )}
-        </div>
+        </PageLayout>
     );
 };

--- a/client/webui/frontend/src/lib/components/pages/ScheduledTasksPage.tsx
+++ b/client/webui/frontend/src/lib/components/pages/ScheduledTasksPage.tsx
@@ -12,7 +12,7 @@ import { TaskExecutionHistoryPage } from "./TaskExecutionHistoryPage";
 import { TaskTemplateBuilder } from "@/lib/components/scheduled-tasks/TaskTemplateBuilder";
 import { GenerateTaskDialog } from "@/lib/components/scheduled-tasks/GenerateTaskDialog";
 import { TaskCards } from "@/lib/components/scheduled-tasks/TaskCards";
-import { Header, EmptyState, ConfirmationDialog } from "@/lib/components";
+import { Header, EmptyState, ConfirmationDialog, PageLayout } from "@/lib/components";
 import { LifecycleBadge } from "@/lib/components/ui";
 
 export function ScheduledTasksPage() {
@@ -131,7 +131,7 @@ export function ScheduledTasksPage() {
     }
 
     return (
-        <div className="flex h-full w-full flex-col">
+        <PageLayout>
             <Header
                 title={
                     <>
@@ -187,6 +187,6 @@ export function ScheduledTasksPage() {
                 onConfirm={handleConfirmDelete}
                 actionLabels={{ confirm: "Delete", cancel: "Cancel" }}
             />
-        </div>
+        </PageLayout>
     );
 }

--- a/client/webui/frontend/src/lib/components/pages/SharedChatViewPage.tsx
+++ b/client/webui/frontend/src/lib/components/pages/SharedChatViewPage.tsx
@@ -14,6 +14,7 @@ import { AlertCircle, Info, Loader2, MessageSquare, PanelLeftIcon, UserLock } fr
 import { useLocation, useNavigate } from "react-router-dom";
 import { Button, Spinner, ResizablePanelGroup, ResizablePanel, ResizableHandle, Tooltip, TooltipContent, TooltipTrigger, CHAT_STYLES } from "@/lib/components/ui";
 import { Header } from "@/lib/components/header";
+import { PageLayout } from "@/lib/components/layout";
 import { ChatMessage, SessionSidePanel } from "@/lib/components/chat";
 import { SharedChatProvider } from "@/lib/providers/SharedChatProvider";
 import { SharedSidePanel } from "@/lib/components/share/SharedSidePanel";
@@ -36,39 +37,39 @@ export function SharedChatViewPage() {
     // Loading state
     if (shared.loading) {
         return (
-            <div className="flex h-screen items-center justify-center">
+            <PageLayout className="items-center justify-center">
                 <Spinner size="large" variant="primary">
                     <p className="mt-4 text-sm text-(--secondary-text-wMain)">Loading shared chat...</p>
                 </Spinner>
-            </div>
+            </PageLayout>
         );
     }
 
     // Error state
     if (shared.error) {
         return (
-            <div className="flex h-screen flex-col items-center justify-center gap-4 p-8">
+            <PageLayout className="items-center justify-center gap-4 p-8">
                 <AlertCircle className="h-16 w-16 text-(--error-wMain)" />
                 <h1 className="text-2xl font-semibold">Unable to View Shared Chat</h1>
                 <p className="max-w-md text-center text-(--secondary-text-wMain)">{shared.error}</p>
                 <Button variant="outline" onClick={() => shared.navigate("/chat")}>
                     Go to Chat
                 </Button>
-            </div>
+            </PageLayout>
         );
     }
 
     // Not found state
     if (!shared.session) {
         return (
-            <div className="flex h-screen flex-col items-center justify-center gap-4 p-8">
+            <PageLayout className="items-center justify-center gap-4 p-8">
                 <AlertCircle className="h-16 w-16 text-(--secondary-text-wMain)" />
                 <h1 className="text-2xl font-semibold">Shared Chat Not Found</h1>
                 <p className="text-(--secondary-text-wMain)">This shared chat may have been deleted or the link is invalid.</p>
                 <Button variant="outline" onClick={() => shared.navigate("/chat")}>
                     Go to Chat
                 </Button>
-            </div>
+            </PageLayout>
         );
     }
 
@@ -114,7 +115,7 @@ export function SharedChatViewPage() {
             onSwitchSession={sid => navigate("/chat", { state: { openSessionsPanel: true, switchToSession: sid } })}
             onNewSession={() => navigate("/chat", { state: { openSessionsPanel: true, newChat: true } })}
         >
-            <div className="relative flex h-screen w-full flex-col overflow-hidden">
+            <PageLayout className="relative">
                 <div className={`absolute top-0 left-0 z-20 h-screen transition-transform duration-300 ${isSessionSidePanelCollapsed ? "-translate-x-full" : "translate-x-0"}`}>
                     <SessionSidePanel onToggle={() => setIsSessionSidePanelCollapsed(!isSessionSidePanelCollapsed)} />
                 </div>
@@ -196,7 +197,7 @@ export function SharedChatViewPage() {
                         </ResizablePanelGroup>
                     </div>
                 </div>
-            </div>
+            </PageLayout>
         </SharedChatProvider>
     );
 }

--- a/client/webui/frontend/src/lib/components/projects/ProjectsPage.tsx
+++ b/client/webui/frontend/src/lib/components/projects/ProjectsPage.tsx
@@ -10,7 +10,7 @@ import { ProjectDetailView } from "./ProjectDetailView";
 import { ShareProjectDialog } from "./ShareProjectDialog";
 import { useProjectContext } from "@/lib/providers";
 import type { Project } from "@/lib/types/projects";
-import { Button, Header } from "@/lib/components";
+import { Button, Header, PageLayout } from "@/lib/components";
 import { downloadBlob, getErrorMessage } from "@/lib/utils";
 import { useChatContext, useIsProjectSharingEnabled, useStartIndexing } from "@/lib/hooks";
 import { useExportProject, useImportProject, useFetchProjectsOnMount, useTogglePinProject } from "@/lib/api/projects/hooks";
@@ -183,7 +183,7 @@ export const ProjectsPage: React.FC = () => {
     const showDetailView = selectedProject !== null;
 
     return (
-        <div className="flex h-full w-full flex-col">
+        <PageLayout>
             {!showDetailView && (
                 <Header
                     title="Projects"
@@ -241,6 +241,6 @@ export const ProjectsPage: React.FC = () => {
 
             {/* Share Project Dialog */}
             {projectToShare && <ShareProjectDialog isOpen={isShareDialogOpen} onClose={handleShareDialogClose} project={projectToShare} />}
-        </div>
+        </PageLayout>
     );
 };

--- a/client/webui/frontend/src/lib/components/workflowVisualization/WorkflowVisualizationPage.tsx
+++ b/client/webui/frontend/src/lib/components/workflowVisualization/WorkflowVisualizationPage.tsx
@@ -3,6 +3,7 @@ import { useParams, useNavigate, useSearchParams } from "react-router-dom";
 import { Workflow } from "lucide-react";
 
 import { Button, EmptyState } from "@/lib/components";
+import { PageLayout } from "@/lib/components/layout";
 import { Header, type BreadcrumbItem } from "@/lib/components/header";
 import { useChatContext } from "@/lib/hooks";
 import { isWorkflowAgent, getWorkflowConfig } from "@/lib/utils/agentUtils";
@@ -243,7 +244,7 @@ export function WorkflowVisualizationPage() {
     // Loading state
     if (agentsLoading) {
         return (
-            <div className="flex h-full w-full flex-col">
+            <PageLayout>
                 <Header
                     title={
                         <div className="flex items-center gap-2">
@@ -254,14 +255,14 @@ export function WorkflowVisualizationPage() {
                     breadcrumbs={breadcrumbs}
                 />
                 <EmptyState title="Loading..." variant="loading" />
-            </div>
+            </PageLayout>
         );
     }
 
     // Error state
     if (agentsError) {
         return (
-            <div className="flex h-full w-full flex-col">
+            <PageLayout>
                 <Header
                     title={
                         <div className="flex items-center gap-2">
@@ -272,14 +273,14 @@ export function WorkflowVisualizationPage() {
                     breadcrumbs={breadcrumbs}
                 />
                 <EmptyState variant="error" title="Error loading data" subtitle={agentsError} />
-            </div>
+            </PageLayout>
         );
     }
 
     // Workflow not found
     if (!workflow || !config) {
         return (
-            <div className="flex h-full w-full flex-col">
+            <PageLayout>
                 <Header
                     title={
                         <div className="flex items-center gap-2">
@@ -290,12 +291,12 @@ export function WorkflowVisualizationPage() {
                     breadcrumbs={breadcrumbs}
                 />
                 <EmptyState variant="error" title="Workflow not found" subtitle={`Could not find a workflow named "${workflowName}"`} />
-            </div>
+            </PageLayout>
         );
     }
 
     return (
-        <div className="flex h-full w-full flex-col">
+        <PageLayout>
             <Header
                 title={
                     <div className="flex items-center gap-2">
@@ -350,7 +351,7 @@ export function WorkflowVisualizationPage() {
                     </div>
                 )}
             </div>
-        </div>
+        </PageLayout>
     );
 }
 

--- a/client/webui/frontend/src/lib/test-utils/index.ts
+++ b/client/webui/frontend/src/lib/test-utils/index.ts
@@ -1,0 +1,1 @@
+export { renderWithProviders } from "./renderWithProviders";

--- a/client/webui/frontend/src/lib/test-utils/renderWithProviders.tsx
+++ b/client/webui/frontend/src/lib/test-utils/renderWithProviders.tsx
@@ -1,0 +1,68 @@
+import { render, type RenderOptions, type RenderResult } from "@testing-library/react";
+import { OpenFeature, OpenFeatureProvider } from "@openfeature/react-sdk";
+import { InMemoryProvider, type FlagValue } from "@openfeature/web-sdk";
+import { MemoryRouter } from "react-router-dom";
+import type { ReactElement } from "react";
+
+import { StoryProvider } from "@/stories/mocks/StoryProvider";
+import type { AuthContextValue, ChatContextValue, ConfigContextValue, ProjectContextValue, TaskContextValue } from "@/lib";
+
+type FeatureFlagMap = Record<string, FlagValue>;
+
+interface RenderWithProvidersOptions extends Omit<RenderOptions, "wrapper"> {
+    featureFlags?: FeatureFlagMap;
+    chatContextValues?: Partial<ChatContextValue>;
+    authContextValues?: Partial<AuthContextValue>;
+    configContextValues?: Partial<ConfigContextValue>;
+    projectContextValues?: Partial<ProjectContextValue>;
+    taskContextValues?: Partial<TaskContextValue>;
+    initialPath?: string;
+}
+
+const VARIANT_KEY = "default";
+
+function buildInMemoryProvider(flags: FeatureFlagMap): InMemoryProvider {
+    const flagConfig = Object.fromEntries(
+        Object.entries(flags).map(([flagKey, value]) => [
+            flagKey,
+            {
+                variants: { [VARIANT_KEY]: value },
+                defaultVariant: VARIANT_KEY,
+                disabled: false,
+            },
+        ])
+    );
+    return new InMemoryProvider(flagConfig);
+}
+
+/**
+ * Async render helper for tests that depend on OpenFeature flag resolution.
+ *
+ * Pre-sets the OpenFeature provider via `setProviderAndWait` before rendering
+ * so the provider is READY on first render — `useBooleanFlagDetails` resolves
+ * synchronously in `useState`'s initializer, no timing hacks needed.
+ */
+export async function renderWithProviders(
+    ui: ReactElement,
+    { featureFlags = {}, chatContextValues, authContextValues, configContextValues, projectContextValues, taskContextValues, initialPath = "/", ...rtlOptions }: RenderWithProvidersOptions = {}
+): Promise<RenderResult> {
+    await OpenFeature.setProviderAndWait(buildInMemoryProvider(featureFlags));
+
+    return render(
+        <MemoryRouter initialEntries={[initialPath]}>
+            <OpenFeatureProvider>
+                <StoryProvider
+                    chatContextValues={chatContextValues}
+                    authContextValues={authContextValues}
+                    configContextValues={configContextValues}
+                    projectContextValues={projectContextValues}
+                    taskContextValues={taskContextValues}
+                    skipFeatureFlagProvider
+                >
+                    {ui}
+                </StoryProvider>
+            </OpenFeatureProvider>
+        </MemoryRouter>,
+        rtlOptions
+    );
+}

--- a/client/webui/frontend/src/stories/layout/AppLayout.test.tsx
+++ b/client/webui/frontend/src/stories/layout/AppLayout.test.tsx
@@ -1,5 +1,5 @@
 /// <reference types="@testing-library/jest-dom" />
-import { render, screen } from "@testing-library/react";
+import { render, screen, waitFor } from "@testing-library/react";
 import { describe, test, expect, vi, beforeEach } from "vitest";
 import * as matchers from "@testing-library/jest-dom/matchers";
 import { MemoryRouter } from "react-router-dom";
@@ -46,44 +46,49 @@ describe("AppLayout model warning banner", () => {
             mockModelConfigStatus.mockReturnValue({ data: { configured: false } });
         });
 
-        test("does not show warning", () => {
+        test("does not show warning", async () => {
             renderLayout();
-            expect(screen.queryByText(/No model has been set up/)).not.toBeInTheDocument();
+            await new Promise(r => setTimeout(r, 0));
+            expect(screen.queryByText(/Default models have not been configured/)).not.toBeInTheDocument();
         });
     });
 
     describe("when model_config_ui flag is enabled", () => {
-        test("does not show warning when models are configured", () => {
+        test("does not show warning when models are configured", async () => {
             mockModelConfigStatus.mockReturnValue({ data: { configured: true } });
             renderLayout({}, { model_config_ui: true });
-            expect(screen.queryByText(/No model has been set up/)).not.toBeInTheDocument();
+            await new Promise(r => setTimeout(r, 0));
+            expect(screen.queryByText(/Default models have not been configured/)).not.toBeInTheDocument();
         });
 
-        test("does not show warning when status is still loading", () => {
+        test("does not show warning when status is still loading", async () => {
             mockModelConfigStatus.mockReturnValue({ data: undefined });
             renderLayout({}, { model_config_ui: true });
-            expect(screen.queryByText(/No model has been set up/)).not.toBeInTheDocument();
+            await new Promise(r => setTimeout(r, 0));
+            expect(screen.queryByText(/Default models have not been configured/)).not.toBeInTheDocument();
         });
 
-        test("shows warning when models not configured", () => {
+        test("shows warning when models not configured", async () => {
             mockModelConfigStatus.mockReturnValue({ data: { configured: false } });
             renderLayout({}, { model_config_ui: true });
-            expect(screen.getByText(/No model has been set up/)).toBeInTheDocument();
+            expect(await screen.findByText(/Default models have not been configured/)).toBeInTheDocument();
         });
 
-        test("shows Go to Models button when user has write permission", () => {
+        test("shows Go to Models button when user has write permission", async () => {
             mockModelConfigStatus.mockReturnValue({ data: { configured: false } });
             renderLayout({ hasModelConfigWrite: true }, { model_config_ui: true });
             // Banner and dialog may both show a "Go to Models" button
-            const buttons = screen.getAllByRole("button", { name: /Go to Models/i });
-            expect(buttons.length).toBeGreaterThanOrEqual(1);
+            await waitFor(() => {
+                const buttons = screen.getAllByRole("button", { name: /Go to Models/i });
+                expect(buttons.length).toBeGreaterThanOrEqual(1);
+            });
             expect(screen.queryByText(/Ask your administrator/)).not.toBeInTheDocument();
         });
 
-        test("shows contact admin text when user lacks write permission", () => {
+        test("shows contact admin text when user lacks write permission", async () => {
             mockModelConfigStatus.mockReturnValue({ data: { configured: false } });
             renderLayout({ hasModelConfigWrite: false }, { model_config_ui: true });
-            expect(screen.getByText(/Ask your administrator/)).toBeInTheDocument();
+            expect(await screen.findByText(/Ask your administrator/)).toBeInTheDocument();
             expect(screen.queryByRole("button", { name: /Go to Models/i })).not.toBeInTheDocument();
         });
     });

--- a/client/webui/frontend/src/stories/layout/AppLayout.test.tsx
+++ b/client/webui/frontend/src/stories/layout/AppLayout.test.tsx
@@ -1,25 +1,18 @@
 /// <reference types="@testing-library/jest-dom" />
-import { render, screen, waitFor } from "@testing-library/react";
+import { screen, waitFor } from "@testing-library/react";
 import { describe, test, expect, vi, beforeEach } from "vitest";
 import * as matchers from "@testing-library/jest-dom/matchers";
-import { MemoryRouter } from "react-router-dom";
 import React from "react";
 
-import { StoryProvider } from "../mocks/StoryProvider";
+import { renderWithProviders } from "@/lib/test-utils";
+import * as modelsApi from "@/lib/api/models";
+import AppLayout from "@/AppLayout";
 
 expect.extend(matchers);
-
-// ---- Mocks must be declared before the dynamic import ----
 
 // Mock ChatProvider to pass-through so StoryProvider's MockChatProvider values reach AppLayoutContent.
 vi.mock("@/lib/providers", () => ({
     ChatProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
-}));
-
-// Mock useModelConfigStatus hook
-const mockModelConfigStatus = vi.fn<() => { data: { configured: boolean } | undefined }>();
-vi.mock("@/lib/api/models", () => ({
-    useModelConfigStatus: () => mockModelConfigStatus(),
 }));
 
 // Mock useLocalStorage to avoid side-effects
@@ -27,18 +20,11 @@ vi.mock("@/lib/hooks/useLocalStorage", () => ({
     useLocalStorage: (_key: string, initial: unknown) => [initial, vi.fn()],
 }));
 
-// Lazy import so all mocks are in place
-const { default: AppLayout } = await import("@/AppLayout");
+const mockModelConfigStatus = vi.fn<() => { data: { configured: boolean } | undefined }>();
 
-function renderLayout(chatContextValues = {}, featureFlags: Record<string, boolean> = {}) {
-    return render(
-        <MemoryRouter>
-            <StoryProvider chatContextValues={chatContextValues} configContextValues={{ configFeatureEnablement: featureFlags }}>
-                <AppLayout />
-            </StoryProvider>
-        </MemoryRouter>
-    );
-}
+beforeEach(() => {
+    vi.spyOn(modelsApi, "useModelConfigStatus").mockImplementation((() => mockModelConfigStatus()) as unknown as typeof modelsApi.useModelConfigStatus);
+});
 
 describe("AppLayout model warning banner", () => {
     describe("when model_config_ui flag is disabled", () => {
@@ -47,8 +33,7 @@ describe("AppLayout model warning banner", () => {
         });
 
         test("does not show warning", async () => {
-            renderLayout();
-            await new Promise(r => setTimeout(r, 0));
+            await renderWithProviders(<AppLayout />);
             expect(screen.queryByText(/Default models have not been configured/)).not.toBeInTheDocument();
         });
     });
@@ -56,27 +41,28 @@ describe("AppLayout model warning banner", () => {
     describe("when model_config_ui flag is enabled", () => {
         test("does not show warning when models are configured", async () => {
             mockModelConfigStatus.mockReturnValue({ data: { configured: true } });
-            renderLayout({}, { model_config_ui: true });
-            await new Promise(r => setTimeout(r, 0));
+            await renderWithProviders(<AppLayout />, { featureFlags: { model_config_ui: true } });
             expect(screen.queryByText(/Default models have not been configured/)).not.toBeInTheDocument();
         });
 
         test("does not show warning when status is still loading", async () => {
             mockModelConfigStatus.mockReturnValue({ data: undefined });
-            renderLayout({}, { model_config_ui: true });
-            await new Promise(r => setTimeout(r, 0));
+            await renderWithProviders(<AppLayout />, { featureFlags: { model_config_ui: true } });
             expect(screen.queryByText(/Default models have not been configured/)).not.toBeInTheDocument();
         });
 
         test("shows warning when models not configured", async () => {
             mockModelConfigStatus.mockReturnValue({ data: { configured: false } });
-            renderLayout({}, { model_config_ui: true });
-            expect(await screen.findByText(/Default models have not been configured/)).toBeInTheDocument();
+            await renderWithProviders(<AppLayout />, { featureFlags: { model_config_ui: true } });
+            expect(screen.getByText(/Default models have not been configured/)).toBeInTheDocument();
         });
 
         test("shows Go to Models button when user has write permission", async () => {
             mockModelConfigStatus.mockReturnValue({ data: { configured: false } });
-            renderLayout({ hasModelConfigWrite: true }, { model_config_ui: true });
+            await renderWithProviders(<AppLayout />, {
+                featureFlags: { model_config_ui: true },
+                chatContextValues: { hasModelConfigWrite: true },
+            });
             // Banner and dialog may both show a "Go to Models" button
             await waitFor(() => {
                 const buttons = screen.getAllByRole("button", { name: /Go to Models/i });
@@ -87,8 +73,11 @@ describe("AppLayout model warning banner", () => {
 
         test("shows contact admin text when user lacks write permission", async () => {
             mockModelConfigStatus.mockReturnValue({ data: { configured: false } });
-            renderLayout({ hasModelConfigWrite: false }, { model_config_ui: true });
-            expect(await screen.findByText(/Ask your administrator/)).toBeInTheDocument();
+            await renderWithProviders(<AppLayout />, {
+                featureFlags: { model_config_ui: true },
+                chatContextValues: { hasModelConfigWrite: false },
+            });
+            expect(screen.getByText(/Ask your administrator/)).toBeInTheDocument();
             expect(screen.queryByRole("button", { name: /Go to Models/i })).not.toBeInTheDocument();
         });
     });

--- a/client/webui/frontend/src/stories/mocks/StoryProvider.tsx
+++ b/client/webui/frontend/src/stories/mocks/StoryProvider.tsx
@@ -27,6 +27,14 @@ interface StoryProviderProps {
     taskContextValues?: Partial<TaskContextValue>;
     configContextValues?: Partial<ConfigContextValue>;
     routerValues?: RouterValues;
+    /**
+     * When true, skip the internal OpenFeatureTestProvider — the caller is
+     * responsible for configuring the global OpenFeature provider (e.g. via
+     * `renderWithProviders`, which calls `setProviderAndWait` before render).
+     * Prevents a double-mount race where the test provider overrides a
+     * pre-warmed global provider.
+     */
+    skipFeatureFlagProvider?: boolean;
 }
 
 /**
@@ -57,30 +65,29 @@ export const StoryProvider: React.FC<StoryProviderProps> = ({
     projectContextValues = {},
     taskContextValues = {},
     configContextValues = {},
+    skipFeatureFlagProvider = false,
 }) => {
     const featureFlags = configContextValues.configFeatureEnablement ?? {};
 
-    return (
-        <QueryProvider>
-            <OpenFeatureTestProvider flagValueMap={featureFlags}>
-                <ThemeProvider>
-                    <MockConfigProvider mockValues={configContextValues}>
-                        <MockAuthProvider mockValues={authContextValues}>
-                            <SSEProvider>
-                                <MockAudioSettingsProvider mockValues={audioSettingsContextValues}>
-                                    <MockProjectProvider mockValues={projectContextValues}>
-                                        <MockTextSelectionProvider mockValues={textSelectionContextValues}>
-                                            <MockTaskProvider mockValues={taskContextValues}>
-                                                <MockChatProvider mockValues={chatContextValues}>{children}</MockChatProvider>
-                                            </MockTaskProvider>
-                                        </MockTextSelectionProvider>
-                                    </MockProjectProvider>
-                                </MockAudioSettingsProvider>
-                            </SSEProvider>
-                        </MockAuthProvider>
-                    </MockConfigProvider>
-                </ThemeProvider>
-            </OpenFeatureTestProvider>
-        </QueryProvider>
+    const innerTree = (
+        <ThemeProvider>
+            <MockConfigProvider mockValues={configContextValues}>
+                <MockAuthProvider mockValues={authContextValues}>
+                    <SSEProvider>
+                        <MockAudioSettingsProvider mockValues={audioSettingsContextValues}>
+                            <MockProjectProvider mockValues={projectContextValues}>
+                                <MockTextSelectionProvider mockValues={textSelectionContextValues}>
+                                    <MockTaskProvider mockValues={taskContextValues}>
+                                        <MockChatProvider mockValues={chatContextValues}>{children}</MockChatProvider>
+                                    </MockTaskProvider>
+                                </MockTextSelectionProvider>
+                            </MockProjectProvider>
+                        </MockAudioSettingsProvider>
+                    </SSEProvider>
+                </MockAuthProvider>
+            </MockConfigProvider>
+        </ThemeProvider>
     );
+
+    return <QueryProvider>{skipFeatureFlagProvider ? innerTree : <OpenFeatureTestProvider flagValueMap={featureFlags}>{innerTree}</OpenFeatureTestProvider>}</QueryProvider>;
 };

--- a/client/webui/frontend/src/stories/models/ModelSetupDialog.stories.tsx
+++ b/client/webui/frontend/src/stories/models/ModelSetupDialog.stories.tsx
@@ -8,7 +8,7 @@ import { createOpenFeatureDecorator } from "../mocks/OpenFeatureDecorator";
 
 const warningBannerHandlers = [
     http.get("*/api/v1/platform/models/status", () => {
-        return HttpResponse.json({ configured: false });
+        return HttpResponse.json({ data: { configured: false } });
     }),
 ];
 

--- a/client/webui/frontend/src/stories/models/ModelSetupDialog.stories.tsx
+++ b/client/webui/frontend/src/stories/models/ModelSetupDialog.stories.tsx
@@ -1,8 +1,20 @@
 import type { Meta, StoryObj } from "@storybook/react-vite";
+import { http, HttpResponse } from "msw";
 import { within, expect } from "storybook/test";
 
 import { ModelSetupDialog } from "@/lib/components/models/ModelSetupDialog";
 import { ModelWarningBanner } from "@/lib/components/models/ModelWarningBanner";
+import { createOpenFeatureDecorator } from "../mocks/OpenFeatureDecorator";
+
+const warningBannerHandlers = [
+    http.get("*/api/v1/platform/models/status", () => {
+        return HttpResponse.json({ configured: false });
+    }),
+];
+
+const OpenFeatureModelConfigEnabled = createOpenFeatureDecorator({
+    flags: { model_config_ui: true },
+});
 
 const meta = {
     title: "Pages/Models/ModelSetupDialog",
@@ -59,16 +71,19 @@ export const NonAdminVariant: Story = {
 export const WarningBannerAdmin: StoryObj = {
     parameters: {
         layout: "fullscreen",
+        msw: { handlers: warningBannerHandlers },
+        chatContext: { hasModelConfigWrite: true },
     },
+    decorators: [OpenFeatureModelConfigEnabled],
     render: () => (
         <div style={{ padding: "1rem", width: "100vw" }}>
-            <ModelWarningBanner showWarning={true} hasModelConfigWrite={true} />
+            <ModelWarningBanner />
         </div>
     ),
     play: async ({ canvasElement }) => {
         const canvas = within(canvasElement);
 
-        expect(canvas.getByText(/No model has been set up/)).toBeInTheDocument();
+        expect(await canvas.findByText(/Default models have not been configured/)).toBeInTheDocument();
         expect(canvas.getByRole("button", { name: /Go to Models/i })).toBeInTheDocument();
         expect(canvas.queryByText(/Ask your administrator/)).not.toBeInTheDocument();
     },
@@ -77,16 +92,19 @@ export const WarningBannerAdmin: StoryObj = {
 export const WarningBannerNonAdmin: StoryObj = {
     parameters: {
         layout: "fullscreen",
+        msw: { handlers: warningBannerHandlers },
+        chatContext: { hasModelConfigWrite: false },
     },
+    decorators: [OpenFeatureModelConfigEnabled],
     render: () => (
         <div style={{ padding: "1rem", width: "100vw" }}>
-            <ModelWarningBanner showWarning={true} hasModelConfigWrite={false} />
+            <ModelWarningBanner />
         </div>
     ),
     play: async ({ canvasElement }) => {
         const canvas = within(canvasElement);
 
-        expect(canvas.getByText(/No model has been set up/)).toBeInTheDocument();
+        expect(await canvas.findByText(/Default models have not been configured/)).toBeInTheDocument();
         expect(canvas.getByText(/Ask your administrator/)).toBeInTheDocument();
         expect(canvas.queryByRole("button", { name: /Go to Models/i })).not.toBeInTheDocument();
     },

--- a/client/webui/frontend/src/stories/models/ModelWarningBanner.test.tsx
+++ b/client/webui/frontend/src/stories/models/ModelWarningBanner.test.tsx
@@ -1,37 +1,58 @@
 /// <reference types="@testing-library/jest-dom" />
 import { render, screen } from "@testing-library/react";
-import { describe, test, expect } from "vitest";
+import { describe, test, expect, vi } from "vitest";
 import * as matchers from "@testing-library/jest-dom/matchers";
 import { MemoryRouter } from "react-router-dom";
 
-import { ModelWarningBanner } from "@/lib/components/models/ModelWarningBanner";
+import { StoryProvider } from "../mocks/StoryProvider";
 
 expect.extend(matchers);
 
-function renderBanner(props: { showWarning: boolean; hasModelConfigWrite: boolean }) {
+const mockModelConfigStatus = vi.fn<() => { data: { configured: boolean } | undefined }>();
+vi.mock("@/lib/api/models", () => ({
+    useModelConfigStatus: () => mockModelConfigStatus(),
+}));
+
+const { ModelWarningBanner } = await import("@/lib/components/models/ModelWarningBanner");
+
+function renderBanner({ configured, modelConfigUiEnabled, hasModelConfigWrite }: { configured: boolean | undefined; modelConfigUiEnabled: boolean; hasModelConfigWrite: boolean }) {
+    mockModelConfigStatus.mockReturnValue({ data: configured === undefined ? undefined : { configured } });
     return render(
         <MemoryRouter>
-            <ModelWarningBanner {...props} />
+            <StoryProvider chatContextValues={{ hasModelConfigWrite }} configContextValues={{ configFeatureEnablement: { model_config_ui: modelConfigUiEnabled } }}>
+                <ModelWarningBanner />
+            </StoryProvider>
         </MemoryRouter>
     );
 }
+
 describe("ModelWarningBanner", () => {
-    test("renders nothing when showWarning is false", () => {
-        const { container } = renderBanner({ showWarning: false, hasModelConfigWrite: true });
-        expect(container.innerHTML).toBe("");
+    test("renders nothing when model_config_ui flag is disabled", async () => {
+        renderBanner({ configured: false, modelConfigUiEnabled: false, hasModelConfigWrite: true });
+        await new Promise(r => setTimeout(r, 0));
+        expect(screen.queryByText(/Default models have not been configured/)).not.toBeInTheDocument();
     });
-    test("renders warning text when showWarning is true", () => {
-        renderBanner({ showWarning: true, hasModelConfigWrite: false });
-        expect(screen.getByText(/No model has been set up/)).toBeInTheDocument();
+
+    test("renders nothing when models are already configured", async () => {
+        renderBanner({ configured: true, modelConfigUiEnabled: true, hasModelConfigWrite: true });
+        await new Promise(r => setTimeout(r, 0));
+        expect(screen.queryByText(/Default models have not been configured/)).not.toBeInTheDocument();
     });
-    test("shows Go to Models button when hasModelConfigWrite is true", () => {
-        renderBanner({ showWarning: true, hasModelConfigWrite: true });
-        expect(screen.getByRole("button", { name: /Go to Models/i })).toBeInTheDocument();
+
+    test("renders warning text when models not configured and flag enabled", async () => {
+        renderBanner({ configured: false, modelConfigUiEnabled: true, hasModelConfigWrite: false });
+        expect(await screen.findByText(/Default models have not been configured/)).toBeInTheDocument();
+    });
+
+    test("shows Go to Models button when hasModelConfigWrite is true", async () => {
+        renderBanner({ configured: false, modelConfigUiEnabled: true, hasModelConfigWrite: true });
+        expect(await screen.findByRole("button", { name: /Go to Models/i })).toBeInTheDocument();
         expect(screen.queryByText(/Ask your administrator/)).not.toBeInTheDocument();
     });
-    test("shows admin contact text when hasModelConfigWrite is false", () => {
-        renderBanner({ showWarning: true, hasModelConfigWrite: false });
-        expect(screen.getByText(/Ask your administrator/)).toBeInTheDocument();
+
+    test("shows admin contact text when hasModelConfigWrite is false", async () => {
+        renderBanner({ configured: false, modelConfigUiEnabled: true, hasModelConfigWrite: false });
+        expect(await screen.findByText(/Ask your administrator/)).toBeInTheDocument();
         expect(screen.queryByRole("button", { name: /Go to Models/i })).not.toBeInTheDocument();
     });
 });

--- a/client/webui/frontend/src/stories/models/ModelWarningBanner.test.tsx
+++ b/client/webui/frontend/src/stories/models/ModelWarningBanner.test.tsx
@@ -1,58 +1,65 @@
 /// <reference types="@testing-library/jest-dom" />
-import { render, screen } from "@testing-library/react";
-import { describe, test, expect, vi } from "vitest";
+import { screen } from "@testing-library/react";
+import { describe, test, expect, vi, beforeEach } from "vitest";
 import * as matchers from "@testing-library/jest-dom/matchers";
-import { MemoryRouter } from "react-router-dom";
 
-import { StoryProvider } from "../mocks/StoryProvider";
+import { renderWithProviders } from "@/lib/test-utils";
+import * as modelsApi from "@/lib/api/models";
+import { ModelWarningBanner } from "@/lib/components/models/ModelWarningBanner";
 
 expect.extend(matchers);
 
 const mockModelConfigStatus = vi.fn<() => { data: { configured: boolean } | undefined }>();
-vi.mock("@/lib/api/models", () => ({
-    useModelConfigStatus: () => mockModelConfigStatus(),
-}));
 
-const { ModelWarningBanner } = await import("@/lib/components/models/ModelWarningBanner");
-
-function renderBanner({ configured, modelConfigUiEnabled, hasModelConfigWrite }: { configured: boolean | undefined; modelConfigUiEnabled: boolean; hasModelConfigWrite: boolean }) {
-    mockModelConfigStatus.mockReturnValue({ data: configured === undefined ? undefined : { configured } });
-    return render(
-        <MemoryRouter>
-            <StoryProvider chatContextValues={{ hasModelConfigWrite }} configContextValues={{ configFeatureEnablement: { model_config_ui: modelConfigUiEnabled } }}>
-                <ModelWarningBanner />
-            </StoryProvider>
-        </MemoryRouter>
-    );
-}
+beforeEach(() => {
+    vi.spyOn(modelsApi, "useModelConfigStatus").mockImplementation((() => mockModelConfigStatus()) as unknown as typeof modelsApi.useModelConfigStatus);
+});
 
 describe("ModelWarningBanner", () => {
     test("renders nothing when model_config_ui flag is disabled", async () => {
-        renderBanner({ configured: false, modelConfigUiEnabled: false, hasModelConfigWrite: true });
-        await new Promise(r => setTimeout(r, 0));
+        mockModelConfigStatus.mockReturnValue({ data: { configured: false } });
+        await renderWithProviders(<ModelWarningBanner />, {
+            featureFlags: { model_config_ui: false },
+            chatContextValues: { hasModelConfigWrite: true },
+        });
         expect(screen.queryByText(/Default models have not been configured/)).not.toBeInTheDocument();
     });
 
     test("renders nothing when models are already configured", async () => {
-        renderBanner({ configured: true, modelConfigUiEnabled: true, hasModelConfigWrite: true });
-        await new Promise(r => setTimeout(r, 0));
+        mockModelConfigStatus.mockReturnValue({ data: { configured: true } });
+        await renderWithProviders(<ModelWarningBanner />, {
+            featureFlags: { model_config_ui: true },
+            chatContextValues: { hasModelConfigWrite: true },
+        });
         expect(screen.queryByText(/Default models have not been configured/)).not.toBeInTheDocument();
     });
 
     test("renders warning text when models not configured and flag enabled", async () => {
-        renderBanner({ configured: false, modelConfigUiEnabled: true, hasModelConfigWrite: false });
-        expect(await screen.findByText(/Default models have not been configured/)).toBeInTheDocument();
+        mockModelConfigStatus.mockReturnValue({ data: { configured: false } });
+        await renderWithProviders(<ModelWarningBanner />, {
+            featureFlags: { model_config_ui: true },
+            chatContextValues: { hasModelConfigWrite: false },
+        });
+        expect(screen.getByText(/Default models have not been configured/)).toBeInTheDocument();
     });
 
     test("shows Go to Models button when hasModelConfigWrite is true", async () => {
-        renderBanner({ configured: false, modelConfigUiEnabled: true, hasModelConfigWrite: true });
-        expect(await screen.findByRole("button", { name: /Go to Models/i })).toBeInTheDocument();
+        mockModelConfigStatus.mockReturnValue({ data: { configured: false } });
+        await renderWithProviders(<ModelWarningBanner />, {
+            featureFlags: { model_config_ui: true },
+            chatContextValues: { hasModelConfigWrite: true },
+        });
+        expect(screen.getByRole("button", { name: /Go to Models/i })).toBeInTheDocument();
         expect(screen.queryByText(/Ask your administrator/)).not.toBeInTheDocument();
     });
 
     test("shows admin contact text when hasModelConfigWrite is false", async () => {
-        renderBanner({ configured: false, modelConfigUiEnabled: true, hasModelConfigWrite: false });
-        expect(await screen.findByText(/Ask your administrator/)).toBeInTheDocument();
+        mockModelConfigStatus.mockReturnValue({ data: { configured: false } });
+        await renderWithProviders(<ModelWarningBanner />, {
+            featureFlags: { model_config_ui: true },
+            chatContextValues: { hasModelConfigWrite: false },
+        });
+        expect(screen.getByText(/Ask your administrator/)).toBeInTheDocument();
         expect(screen.queryByRole("button", { name: /Go to Models/i })).not.toBeInTheDocument();
     });
 });


### PR DESCRIPTION
### What is the purpose of this change?

Fix a layout bug where `ModelWarningBanner` pushed the routed `<Outlet />` below the viewport, causing every in-`AppLayout` page to show an unwanted page-level scrollbar. Also tightens the banner's API so `AppLayout` does not need to know whether it will render.

### How was this change implemented?

- Added `PageLayout` (`src/lib/components/layout/PageLayout.tsx`) — a flex-column wrapper using `flex-1 min-h-0 overflow-hidden` that each page now uses as its root element, consuming whatever vertical space `AppLayout`'s main leaves.
- Changed `AppLayout` `<main>` from `h-full overflow-auto` to `flex h-full flex-col` so the banner + `<Outlet />` stack naturally.
- Moved all visibility logic into `ModelWarningBanner` itself: it now reads `useBooleanFlagDetails("model_config_ui")`, `useModelConfigStatus()`, and `useChatContext().hasModelConfigWrite` and returns `null` when not applicable. The component takes no props.
- Migrated every page rendered inside `AppLayout` to `<PageLayout>`: `ChatPage`, `SharedChatViewPage`, `PromptsPage`, `AgentMeshPage`, `RecentChatsPage`, `ScheduledTasksPage`, `ArtifactsPage`, `ProjectsPage`, `WorkflowVisualizationPage`, `ModelDetailsPage`, `ModelEditPage`.
- Updated `AppLayout.test.tsx`, `ModelWarningBanner.test.tsx`, and `ModelSetupDialog.stories.tsx` to the new banner API — using `StoryProvider` / `OpenFeatureTestProvider` + MSW for `/api/v1/platform/models/status`, plus async `findByText` for OpenFeature's async flag resolution.

### Key Design Decisions _(optional - delete if not applicable)_

- **Why a shared `PageLayout` instead of fixing sizes per page?** Pages had inconsistent roots (`h-full` vs `h-screen`) which is exactly what caused the overflow when the banner stole ~44px. A single wrapper puts the container contract in one place and lets future siblings of the `<Outlet />` coexist without breaking pages.
- **Why make the banner self-controlling?** `AppLayout` was fetching model config status and threading `showWarning` / `hasModelConfigWrite` as props just to decide whether to render the banner. Keeping that logic inside the banner removes leaky state from `AppLayout` and means callers only need to render `<ModelWarningBanner />`.

### How was this change tested?

- [x] Unit tests: `AppLayout.test.tsx` and `ModelWarningBanner.test.tsx` updated and passing (full suite: 821 tests across 79 files, all green).
- [x] Type check: `tsc --noEmit` clean.
- [ ] Manual testing: did not start dev server for this PR — verified via unit tests and type check only.
- [ ] Known limitations: storybook visual regression for the banner stories not re-run locally; the stories were updated for the new API but should be eyeballed in Chromatic/Storybook CI.

### Is there anything the reviewers should focus on/be aware of?

- Review the `PageLayout` migration of each page — confirm none of them relied on `h-full` vs `h-screen` semantics for internal scrolling. The pattern throughout is inner scroll containers, which are unaffected.
- `ModelSetupDialog.stories.tsx` now uses MSW + `OpenFeatureTestProvider`; confirm this matches the convention used in `ChatPage.stories.tsx` and other banner-using stories.