### PR TITLE
fix(DATAGO-132511): investigate intermittent hanging integration tests

### DIFF
--- a/tests/integration/test_support/a2a_agent/executor.py
+++ b/tests/integration/test_support/a2a_agent/executor.py
@@ -61,8 +61,10 @@ class DeclarativeAgentExecutor(AgentExecutor):
 
                 await event_queue.enqueue_event(event_obj)
 
-                # If the event is a terminal task, stop processing more responses for this request.
-                # Non-terminal states like 'submitted' or 'working' should not stop the processing.
+                # Check if this is a terminal event (ends the stream):
+                # 1. Task with terminal state (completed/failed/canceled/rejected)
+                # 2. TaskStatusUpdateEvent with final=True
+                # These match the SDK's EventConsumer definition of is_final_event
                 if isinstance(event_obj, Task) and event_obj.status and event_obj.status.state in [
                     TaskState.completed,
                     TaskState.failed,
@@ -71,18 +73,24 @@ class DeclarativeAgentExecutor(AgentExecutor):
                 ]:
                     terminal_event_sent = True
                     break
+                elif isinstance(event_obj, TaskStatusUpdateEvent) and event_obj.final:
+                    terminal_event_sent = True
+                    break
             except Exception as e:
                 log.error(f"{log_id} Failed to validate or enqueue primed response: {e}")
                 # Stop processing on error to avoid cascading failures
                 break
 
-        # If no terminal event was sent, just close the queue
-        # For cancellation tests, we only need to verify the cancel request arrives at the server
-        # We don't need to fully process the cancellation through the A2A framework
+        # Close the queue appropriately based on whether terminal event was sent
         if not terminal_event_sent:
-            log.info(f"{log_id} No terminal event in primed responses. Closing queue.")
-
-        await event_queue.close()
+            # No terminal event: use immediate close to avoid race condition where
+            # EventConsumer hangs in timeout loop. immediate=True returns immediately,
+            # allowing consumer's next iteration (within 0.5s) to detect closed state.
+            log.info(f"{log_id} No terminal event in primed responses. Closing queue immediately.")
+            await event_queue.close(immediate=True)
+        else:
+            # Terminal event sent: use graceful close to let consumer process all events
+            await event_queue.close()
 
     async def cancel(self, context: RequestContext, event_queue: EventQueue):
         """Handles a cancellation request by updating the task state."""
@@ -92,4 +100,8 @@ class DeclarativeAgentExecutor(AgentExecutor):
             task = context.current_task
             task.status = TaskStatus(state=TaskState.canceled)
             await event_queue.enqueue_event(task)
-        await event_queue.close()
+            # Graceful close - canceled task is terminal, let consumer process it
+            await event_queue.close()
+        else:
+            # No task to cancel, close immediately
+            await event_queue.close(immediate=True)


### PR DESCRIPTION
### What is the purpose of this change?

```
Integration tests simulating crashed downstream agents were hanging intermittently for hours instead of completing in ~13 minutes. Tests like test_proxy_remote_crash_no_response would sometimes pass, sometimes    
  hang forever, depending on timing.


  Root Cause                                                                                                                                                                                                           
   
  When simulating an agent crash (agent sends status but no final response), a race condition occurred between:                                                                                                        
                                
  1. Executor closing the event queue to signal "agent stopped"                                                                                                                                                        
  2. SSE Consumer detecting the closure while in a 0.5-second timeout loop
                                                                                                                                                                                                                       
  The Race: Between checking "is queue closed?" and waiting for the next event, timing determined the outcome:                                                                                                         
  - Fast timing: Consumer detects closure and exits cleanly                                                                                                                                                            
  - Slow timing: Consumer starts waiting, timeout fires, infinite loop begins 


This was intermittent because it depended on asyncio scheduler timing, CPU load, and OS scheduling.
  ```

### How was this change implemented?
```
  Two changes to DeclarativeAgentExecutor:                                                                                                                                                                             
   
  1. Detect All Terminal Event Types                                                                                                                                                                                   
                                
  Previously only detected Task objects with terminal states. A2A protocol also supports TaskStatusUpdateEvent.final=true to end streams. Now we detect both terminal event patterns, matching the SDK's own           
  definition.                   
                                                                                                                                                                                                                       
  2. Conditional Queue Closing  

  Instead of always using graceful close (which blocks and creates the race):
  - Terminal event sent: Use graceful close() to let consumer process all events
  - No terminal event (crash): Use close(immediate=True) which returns immediately, allowing consumer's next iteration (within 0.5s) to detect closed state and exit     
```

### Key Design Decisions _(optional - delete if not applicable)_

    Why did you choose this approach over alternatives?

### How was this change tested?

- [ ] Manual testing: [describe scenarios]
- [ ] Unit tests: [new/modified tests]
- [ ] Integration tests: [if applicable]
- [ ] Known limitations: [what wasn't tested]

### Is there anything the reviewers should focus on/be aware of?

    Special attention areas, potential risks, or open questions
