### PR TITLE
fix(DATAGO-132190): exclude test-utils from tsconfig.lib.json

### DIFF
--- a/client/webui/frontend/tsconfig.lib.json
+++ b/client/webui/frontend/tsconfig.lib.json
@@ -25,5 +25,5 @@
         }
     },
     "include": ["src/lib/**/*"],
-    "exclude": ["node_modules", "**/*.test.ts", "**/*.test.tsx", "**/*.spec.ts", "**/*.spec.tsx", "**/*.stories.ts", "**/*.stories.tsx"]
+    "exclude": ["node_modules", "src/lib/test-utils/**", "**/*.test.ts", "**/*.test.tsx", "**/*.spec.ts", "**/*.spec.tsx", "**/*.stories.ts", "**/*.stories.tsx"]
 }


### PR DESCRIPTION
## Summary

Fixes the published `@SolaceLabs/solace-agent-mesh-ui` 2.6.4 package, which emits types to `dist/lib/index.d.ts` instead of `dist/index.d.ts`. Consumers relying on the `"types": "./dist/index.d.ts"` field in `package.json` (such as `solace-agent-mesh-enterprise`) get "Could not find a declaration file for module '@SolaceLabs/solace-agent-mesh-ui'" when running `tsc`.

## Root Cause

`src/lib/test-utils/renderWithProviders.tsx` (added in #1414) imports from `@/stories/mocks/StoryProvider`, which lives outside `src/lib/`. When `tsc --emitDeclarationOnly` runs against `tsconfig.lib.json`, this external import pulls files outside the lib tree into compilation, which shifts tsc's implicit `rootDir` up from `src/lib/` to `src/`. All emitted declaration files then land under `dist/lib/...` instead of `dist/...`.

## Fix

Exclude `src/lib/test-utils/**` from the library build. The test utility is only used by Vitest/Storybook and is never consumed by downstream packages, so it has no business in the published library anyway.

## Verification

Local build with the fix:

```
$ rm -rf dist && npm run build-package
...
$ ls dist/index.d.ts
dist/index.d.ts       # ✅ at correct path
$ ls dist/lib 2>/dev/null
# (empty — no stray lib/ directory)
```

## Test plan

- [x] Local `npm run build-package` emits `dist/index.d.ts` at the root
- [x] No `dist/lib/` directory is produced
- [x] `dist/index.d.ts` still re-exports `./api`, `./components`, `./contexts`, etc.
- [ ] After merge + CI version bump + publish, enterprise `tsc -b` passes against the new tarball

🤖 Generated with [Claude Code](https://claude.com/claude-code)