### PR TITLE
chore(DATAGO-132651): adding inert to side panel when closed so it does interfere with accessibility

### DIFF
--- a/client/webui/frontend/src/lib/components/pages/ChatPage.tsx
+++ b/client/webui/frontend/src/lib/components/pages/ChatPage.tsx
@@ -529,7 +529,7 @@ export function ChatPage() {
     return (
         <PageLayout className="relative">
             {!useNewNav && (
-                <div className={`absolute top-0 left-0 z-20 h-screen transition-transform duration-300 ${isSessionSidePanelCollapsed ? "-translate-x-full" : "translate-x-0"}`}>
+                <div inert={isSessionSidePanelCollapsed} className={`absolute top-0 left-0 z-20 h-screen transition-transform duration-300 ${isSessionSidePanelCollapsed ? "-translate-x-full" : "translate-x-0"}`}>
                     <SessionSidePanel onToggle={handleSessionSidePanelToggle} />
                 </div>
             )}


### PR DESCRIPTION
### What is the purpose of this change?

Cypress tests were failing due to a change to the loading of the session side panel. Two chat buttons were found, even when the side panel was closed.

<img width="1274" height="633" alt="image" src="https://github.com/user-attachments/assets/b238de91-84d1-4f83-a57d-dd605a8d5b8b" />

### How was this change implemented?

This pull request introduces a small accessibility improvement to the `ChatPage` component. The change adds the `inert` attribute to the session side panel when it is collapsed, ensuring it is not focusable or interactive for assistive technologies.

- Accessibility enhancement:
  * [`client/webui/frontend/src/lib/components/pages/ChatPage.tsx`](diffhunk://#diff-dae858a65b85f43bd1e62e2e8649daeffce5fc9ef79434cd62dab2b028b1ee1bL532-R532): Added the `inert` attribute to the session side panel `<div>` when it is collapsed, improving accessibility by making the panel non-interactive when hidden.

### How was this change tested?

- [ ] Manual testing: [describe scenarios]
- [ ] Unit tests: [new/modified tests]
- [ ] Integration tests: [if applicable]
- [ ] Known limitations: [what wasn't tested]

