### PR TITLE
fix(DATAGO-132190): add min-w-0 to main to prevent nav sidebar collapse

### DIFF
--- a/client/webui/frontend/src/AppLayout.tsx
+++ b/client/webui/frontend/src/AppLayout.tsx
@@ -138,7 +138,7 @@ function AppLayoutContent() {
             ) : (
                 <NavigationSidebar items={topNavItems} bottomItems={bottomNavigationItems} activeItem={getActiveItem()} onItemChange={handleNavItemChange} onHeaderClick={handleHeaderClick} />
             )}
-            <main className="flex h-full w-full flex-1 flex-col">
+            <main className="flex h-full w-full min-w-0 flex-1 flex-col">
                 <ModelWarningBanner />
                 <Outlet />
             </main>


### PR DESCRIPTION
### What is the purpose of this change?

The `NavigationSidebar` disappears when the viewport gets narrow enough that a page's content would exceed `viewport - sidebar` width.

### How was this change implemented?

Added `min-w-0` to the `<main>` element in `AppLayout.tsx`. Without it, `<main>`'s default `min-width: auto` resolves to its intrinsic min-content width; when a page's content exceeds `viewport - sidebar`, the flex row shrinks the sibling `NavigationSidebar` (which has no `flex-shrink-0`) instead of `<main>`, making the sidebar appear to collapse.

### Key Design Decisions

Fixed at the `AppLayout` layer so every page benefits rather than adding per-page `overflow-x-auto` / `min-w-0` workarounds. Pages that legitimately need horizontal scroll already opt in via their own `overflow-x-auto`.

### How was this change tested?

- [x] Manual testing: verified the sidebar stays visible at narrow viewports on pages that previously triggered the bug.
- [x] Type check: `tsc --noEmit` passes.
- [ ] No new unit tests — small layout fix covered by existing tests.

### Is there anything the reviewers should focus on/be aware of?

- `min-w-0` on `<main>` is a subtle flexbox change; please sanity-check that no page relied on the previous intrinsic min-content behavior.
- Companion fix lands in the enterprise repo (solace-agent-mesh-enterprise PR #1055).