### PR TITLE
fix(DATAGO-132718): hide old chat list UI in shared chat when new nav enabled

### DIFF
--- a/client/webui/frontend/src/lib/components/pages/SharedChatViewPage.tsx
+++ b/client/webui/frontend/src/lib/components/pages/SharedChatViewPage.tsx
@@ -19,20 +19,24 @@ import { ChatMessage, SessionSidePanel } from "@/lib/components/chat";
 import { SharedChatProvider } from "@/lib/providers/SharedChatProvider";
 import { SharedSidePanel } from "@/lib/components/share/SharedSidePanel";
 import { useSharedSession, formatDateYMD } from "@/lib/hooks/useSharedSession";
+import { useConfigContext } from "@/lib/hooks";
 export function SharedChatViewPage() {
     const shared = useSharedSession();
     const location = useLocation();
     const navigate = useNavigate();
+    const { configFeatureEnablement } = useConfigContext();
+    const useNewNav = configFeatureEnablement?.newNavigation ?? false;
     const [isSessionSidePanelCollapsed, setIsSessionSidePanelCollapsed] = useState(true);
 
     // Open sessions panel if navigated with state
     useEffect(() => {
+        if (useNewNav) return;
         const state = location.state as { openSessionsPanel?: boolean } | null;
         if (state?.openSessionsPanel) {
             setIsSessionSidePanelCollapsed(false);
             navigate(location.pathname, { replace: true, state: {} });
         }
-    }, [location.state, location.pathname, navigate]);
+    }, [location.state, location.pathname, navigate, useNewNav]);
 
     // Loading state
     if (shared.loading) {
@@ -116,16 +120,18 @@ export function SharedChatViewPage() {
             onNewSession={() => navigate("/chat", { state: { openSessionsPanel: true, newChat: true } })}
         >
             <PageLayout className="relative">
-                <div className={`absolute top-0 left-0 z-20 h-screen transition-transform duration-300 ${isSessionSidePanelCollapsed ? "-translate-x-full" : "translate-x-0"}`}>
-                    <SessionSidePanel onToggle={() => setIsSessionSidePanelCollapsed(!isSessionSidePanelCollapsed)} />
-                </div>
-                <div className={`transition-all duration-300 ${isSessionSidePanelCollapsed ? "ml-0" : "ml-100"}`}>
+                {!useNewNav && (
+                    <div className={`absolute top-0 left-0 z-20 h-screen transition-transform duration-300 ${isSessionSidePanelCollapsed ? "-translate-x-full" : "translate-x-0"}`}>
+                        <SessionSidePanel onToggle={() => setIsSessionSidePanelCollapsed(!isSessionSidePanelCollapsed)} />
+                    </div>
+                )}
+                <div className={`transition-all duration-300 ${!useNewNav && !isSessionSidePanelCollapsed ? "ml-100" : "ml-0"}`}>
                     <Header
                         title={session.title}
                         buttons={headerButtons}
                         leadingAction={
-                            isSessionSidePanelCollapsed ? (
-                                <Button variant="ghost" onClick={() => setIsSessionSidePanelCollapsed(false)} className="h-10 w-10 p-0" tooltip="Show Chat Sessions">
+                            !useNewNav && isSessionSidePanelCollapsed ? (
+                                <Button data-testid="showSessionsPanel" variant="ghost" onClick={() => setIsSessionSidePanelCollapsed(false)} className="h-10 w-10 p-0" tooltip="Show Chat Sessions">
                                     <PanelLeftIcon className="size-5" />
                                 </Button>
                             ) : null
@@ -133,7 +139,7 @@ export function SharedChatViewPage() {
                     />
                 </div>
 
-                <div className={`flex min-h-0 flex-1 transition-all duration-300 ${isSessionSidePanelCollapsed ? "ml-0" : "ml-100"}`}>
+                <div className={`flex min-h-0 flex-1 transition-all duration-300 ${!useNewNav && !isSessionSidePanelCollapsed ? "ml-100" : "ml-0"}`}>
                     <div className="min-h-0 flex-1 overflow-x-auto">
                         <ResizablePanelGroup direction="horizontal" autoSaveId="shared-chat-view-side-panel" className="h-full">
                             {/* Messages panel */}

--- a/client/webui/frontend/src/stories/chat/SharedChatViewPage.test.tsx
+++ b/client/webui/frontend/src/stories/chat/SharedChatViewPage.test.tsx
@@ -9,6 +9,42 @@ import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 expect.extend(matchers);
 
 const mockUseSharedSession = vi.fn();
+const mockUseConfigContext = vi.fn();
+
+function makeValidSession(overrides: Record<string, unknown> = {}) {
+    return {
+        shareId: "share-1",
+        navigate: vi.fn(),
+        session: {
+            title: "Test Shared Chat",
+            tasks: [{ userId: "alice@example.com" }],
+            createdTime: 0,
+            snapshotTime: null,
+            isOwner: false,
+            sessionId: null,
+        },
+        loading: false,
+        error: null,
+        isForking: false,
+        isSidePanelCollapsed: true,
+        activeSidePanelTab: "files",
+        setActiveSidePanelTab: vi.fn(),
+        selectedTaskId: null,
+        setSelectedTaskId: vi.fn(),
+        toggleSidePanel: vi.fn(),
+        openSidePanelTab: vi.fn(),
+        convertedArtifacts: [],
+        ragData: [],
+        hasRagSources: false,
+        messages: [],
+        lastMessageIndexByTaskId: new Map(),
+        sessionIdForProvider: "session-1",
+        handleSharedArtifactDownload: vi.fn(),
+        handleForkChat: vi.fn(),
+        handleProviderTabOpen: vi.fn(),
+        ...overrides,
+    };
+}
 
 describe("SharedChatViewPage", () => {
     let SharedChatViewPage: React.ComponentType;
@@ -16,15 +52,26 @@ describe("SharedChatViewPage", () => {
     beforeEach(async () => {
         vi.resetModules();
         mockUseSharedSession.mockReset();
+        mockUseConfigContext.mockReset();
+        mockUseConfigContext.mockReturnValue({});
 
         vi.doMock("@/lib/hooks/useSharedSession", () => ({
             useSharedSession: mockUseSharedSession,
             formatDateYMD: (epochMs: number) => new Date(epochMs).toISOString().slice(0, 10),
         }));
 
-        // Mock ChatMessage to avoid pulling in the full chat component tree
+        vi.doMock("@/lib/hooks", async () => {
+            const actual = await vi.importActual<typeof import("@/lib/hooks")>("@/lib/hooks");
+            return {
+                ...actual,
+                useConfigContext: mockUseConfigContext,
+            };
+        });
+
+        // Mock chat components — include SessionSidePanel so the flag-gate tests can assert its presence
         vi.doMock("@/lib/components/chat", () => ({
             ChatMessage: () => React.createElement("div", { "data-testid": "chat-message" }),
+            SessionSidePanel: ({ onToggle }: { onToggle: () => void }) => React.createElement("div", { "data-testid": "session-side-panel", onClick: onToggle }),
         }));
 
         // Mock SharedSidePanel
@@ -37,10 +84,23 @@ describe("SharedChatViewPage", () => {
             SharedChatProvider: ({ children }: { children: React.ReactNode }) => React.createElement("div", null, children),
         }));
 
-        // Mock Header component
+        // Mock Header — render leadingAction so the toggle button is findable in tests
         vi.doMock("@/lib/components/header", () => ({
-            Header: ({ title }: { title: string }) => React.createElement("header", { "data-testid": "header" }, title),
+            Header: ({ title, leadingAction }: { title: string; leadingAction?: React.ReactNode }) => React.createElement("header", { "data-testid": "header" }, leadingAction, title),
         }));
+
+        // Neutralize ResizablePanel* — their real impl needs DOM measurements that jsdom can't provide
+        vi.doMock("@/lib/components/ui", async () => {
+            const actual = await vi.importActual<Record<string, unknown>>("@/lib/components/ui");
+            return {
+                ...actual,
+                ResizablePanelGroup: ({ children }: { children: React.ReactNode }) => React.createElement("div", { "data-testid": "resizable-panel-group" }, children),
+                ResizablePanel: React.forwardRef<unknown, { children: React.ReactNode }>(function ResizablePanel({ children }) {
+                    return React.createElement("div", { "data-testid": "resizable-panel" }, children);
+                }),
+                ResizableHandle: () => React.createElement("div", { "data-testid": "resizable-handle" }),
+            };
+        });
 
         const mod = await import("@/lib/components/pages/SharedChatViewPage");
         SharedChatViewPage = mod.SharedChatViewPage;
@@ -87,5 +147,23 @@ describe("SharedChatViewPage", () => {
 
         renderPage();
         expect(screen.getByText("Shared Chat Not Found")).toBeInTheDocument();
+    });
+
+    test("hides SessionSidePanel and toggle button when newNavigation flag is enabled", () => {
+        mockUseSharedSession.mockReturnValue(makeValidSession());
+        mockUseConfigContext.mockReturnValue({ configFeatureEnablement: { newNavigation: true } });
+
+        renderPage();
+        expect(screen.queryByTestId("session-side-panel")).not.toBeInTheDocument();
+        expect(screen.queryByTestId("showSessionsPanel")).not.toBeInTheDocument();
+    });
+
+    test("renders SessionSidePanel and toggle button when newNavigation flag is disabled", () => {
+        mockUseSharedSession.mockReturnValue(makeValidSession());
+        mockUseConfigContext.mockReturnValue({ configFeatureEnablement: { newNavigation: false } });
+
+        renderPage();
+        expect(screen.getByTestId("session-side-panel")).toBeInTheDocument();
+        expect(screen.getByTestId("showSessionsPanel")).toBeInTheDocument();
     });
 });


### PR DESCRIPTION
### What is the purpose of this change?

When the `newNavigation` feature flag is enabled, the shared-chat view (`SharedChatViewPage`) was still showing the old chat list UI — the `SessionSidePanel`, its `PanelLeftIcon` toggle button in the header, and the `ml-100` layout offsets that make space for the panel. This regressed alongside the new navigation experience and produced a duplicate/old sidebar visible on shared chat pages.

Resolves: [DATAGO-132718](https://sol-jira.atlassian.net/browse/DATAGO-132718)

### How was this change implemented?

Mirrored the flag-gating pattern already used in `ChatPage.tsx`:

- `SharedChatViewPage.tsx` now reads `configFeatureEnablement.newNavigation` via `useConfigContext`.
- The `SessionSidePanel` slide-in container, the leading `PanelLeftIcon` toggle button in the `Header`, the `openSessionsPanel` navigation effect, and the `ml-100` layout offsets are all gated on `!useNewNav`.
- Added `data-testid="showSessionsPanel"` to the toggle button to match `ChatPage` and give tests a stable selector.

### Key Design Decisions

Followed the existing `ChatPage.tsx` gating pattern (`useNewNav` derived from `configFeatureEnablement.newNavigation`) rather than introducing a separate flag or a provider-level guard. Keeps the two chat surfaces symmetric and makes future removal of the old nav straightforward (one grep across pages).

### How was this change tested?

- [x] Unit tests: extended `src/stories/chat/SharedChatViewPage.test.tsx` with 2 new cases — `SessionSidePanel` + toggle hidden when `newNavigation: true`, rendered when `newNavigation: false`. Also generalized the existing mocks (added `useConfigContext` mock via `@/lib/hooks`, added `SessionSidePanel` to the `@/lib/components/chat` mock, updated `Header` mock to render `leadingAction`, neutralized `ResizablePanel*` for jsdom). All 5 tests pass.
- [x] Type check: `npx tsc --noEmit` — clean.
- [x] Lint: `npm run lint` on touched files — 0 errors (repo has pre-existing warnings unrelated to this change).
- [ ] Manual testing: to be verified by the author in the UI against both flag states.

### Is there anything the reviewers should focus on/be aware of?

- Please sanity-check that the `useNewNav` placement matches the behavior you'd expect inside the `openSessionsPanel` navigation effect — the effect now early-returns when the flag is on, which mirrors `ChatPage.tsx:491` but worth a second pair of eyes.
- No changes to `SharedSessionPage` (the standalone, outside-AppLayout view) — that surface doesn't render `SessionSidePanel` today. Flagging in case you'd expect the same audit elsewhere.

[DATAGO-132718]: https://sol-jira.atlassian.net/browse/DATAGO-132718?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<img width="1828" height="924" alt="CleanShot 2026-04-21 at 11 11 57" src="https://github.com/user-attachments/assets/4fea6e90-9b04-45a7-ba41-fb9569e2f82c" />
