### PR TITLE
feat(DATAGO-132732): Add singleAgentMode support to ChatContext

### DIFF
--- a/client/webui/frontend/src/lib/components/chat/ChatInputArea.tsx
+++ b/client/webui/frontend/src/lib/components/chat/ChatInputArea.tsx
@@ -55,7 +55,7 @@ const createEnhancedMessage = (command: ChatCommand, conversationContext?: strin
 export const ChatInputArea: React.FC<{ agents: AgentCardInfo[]; scrollToBottom?: () => void }> = ({ agents = [], scrollToBottom }) => {
     const navigate = useNavigate();
     const location = useLocation();
-    const { isResponding, isCancelling, selectedAgentName, sessionId, setSessionId, handleSubmit, handleCancel, uploadArtifactFile, displayError, artifacts, messages, startNewChatWithPrompt, pendingPrompt, clearPendingPrompt } = useChatContext();
+    const { isResponding, isCancelling, selectedAgentName, singleAgentMode, sessionId, setSessionId, handleSubmit, handleCancel, uploadArtifactFile, displayError, artifacts, messages, startNewChatWithPrompt, pendingPrompt, clearPendingPrompt } = useChatContext();
     const { handleAgentSelection } = useAgentSelection();
     const { settings } = useAudioSettings();
     const { configFeatureEnablement } = useConfigContext();
@@ -1068,27 +1068,31 @@ export const ChatInputArea: React.FC<{ agents: AgentCardInfo[]; scrollToBottom?:
                     <Paperclip className="size-4" />
                 </Button>
 
-                <div>Agent: </div>
-                <Select
-                    value={selectedAgentName}
-                    onValueChange={agentName => {
-                        handleAgentSelection(agentName);
-                    }}
-                    disabled={isResponding || agents.length === 0}
-                >
-                    <SelectTrigger className="w-[250px]">
-                        <SelectValue placeholder="Select an agent..." />
-                    </SelectTrigger>
-                    <SelectContent>
-                        {agents
-                            .filter(agent => !agent.isWorkflow)
-                            .map(agent => (
-                                <SelectItem key={agent.name} value={agent.name}>
-                                    {agent.displayName || agent.name}
-                                </SelectItem>
-                            ))}
-                    </SelectContent>
-                </Select>
+                {!singleAgentMode && (
+                    <>
+                        <div>Agent: </div>
+                        <Select
+                            value={selectedAgentName}
+                            onValueChange={agentName => {
+                                handleAgentSelection(agentName);
+                            }}
+                            disabled={isResponding || agents.length === 0}
+                        >
+                            <SelectTrigger className="w-[250px]">
+                                <SelectValue placeholder="Select an agent..." />
+                            </SelectTrigger>
+                            <SelectContent>
+                                {agents
+                                    .filter(agent => !agent.isWorkflow)
+                                    .map(agent => (
+                                        <SelectItem key={agent.name} value={agent.name}>
+                                            {agent.displayName || agent.name}
+                                        </SelectItem>
+                                    ))}
+                            </SelectContent>
+                        </Select>
+                    </>
+                )}
 
                 {/* Spacer to push buttons to the right */}
                 <div className="flex-1" />

--- a/client/webui/frontend/src/lib/contexts/ChatContext.ts
+++ b/client/webui/frontend/src/lib/contexts/ChatContext.ts
@@ -22,6 +22,7 @@ export interface ChatState {
     sessionOwnerEmail: string | null;
     currentTaskId: string | null;
     selectedAgentName: string;
+    singleAgentMode: boolean;
     notifications: Notification[];
     isCancelling: boolean;
     latestStatusText: React.RefObject<string | null>;
@@ -89,6 +90,7 @@ export interface ChatActions {
     handleCancel: () => void;
     addNotification: (message: string, type?: "success" | "info" | "warning") => void;
     setSelectedAgentName: React.Dispatch<React.SetStateAction<string>>;
+    setSingleAgentMode: React.Dispatch<React.SetStateAction<boolean>>;
     uploadArtifactFile: (file: File, overrideSessionId?: string, description?: string, silent?: boolean) => Promise<{ uri: string; sessionId: string } | { error: string } | null>;
     /** Side Panel Control Actions */
     setIsSidePanelCollapsed: React.Dispatch<React.SetStateAction<boolean>>;

--- a/client/webui/frontend/src/lib/providers/ChatProvider.tsx
+++ b/client/webui/frontend/src/lib/providers/ChatProvider.tsx
@@ -65,6 +65,7 @@ export const ChatProvider: React.FC<ChatProviderProps> = ({ children }) => {
     const [notifications, setNotifications] = useState<Notification[]>([]);
     const [currentTaskId, setCurrentTaskId] = useState<string | null>(null);
     const [selectedAgentName, setSelectedAgentName] = useState<string>("");
+    const [singleAgentMode, setSingleAgentMode] = useState<boolean>(false);
     const [isCancelling, setIsCancelling] = useState<boolean>(false);
     const [taskIdInSidePanel, setTaskIdInSidePanel] = useState<string | null>(null);
     const [isSidePanelCollapsed, setIsSidePanelCollapsed] = useState<boolean>(true);
@@ -2002,6 +2003,8 @@ export const ChatProvider: React.FC<ChatProviderProps> = ({ children }) => {
         addNotification,
         selectedAgentName,
         setSelectedAgentName,
+        singleAgentMode,
+        setSingleAgentMode,
         artifacts,
         allArtifacts,
         artifactsLoading,

--- a/client/webui/frontend/src/lib/providers/SharedChatProvider.tsx
+++ b/client/webui/frontend/src/lib/providers/SharedChatProvider.tsx
@@ -187,6 +187,7 @@ export function SharedChatProvider({ children, artifacts: initialArtifacts, ragD
             sessionOwnerEmail: null,
             currentTaskId: null,
             selectedAgentName: "",
+            singleAgentMode: false,
             notifications: [],
             isCancelling: false,
             latestStatusText,
@@ -262,6 +263,7 @@ export function SharedChatProvider({ children, artifacts: initialArtifacts, ragD
             handleCancel: () => {},
             addNotification: () => {},
             setSelectedAgentName: () => {},
+            setSingleAgentMode: () => {},
             uploadArtifactFile: async () => null,
 
             // Side Panel Control Actions


### PR DESCRIPTION
## Summary

Adds `singleAgentMode` support to the community library to enable URL-based single-agent mode in enterprise applications.

## Changes

### New Fields

**ChatContext.ts:**
- `singleAgentMode: boolean` - State indicating if single-agent mode is active
- `setSingleAgentMode` - Setter to control single-agent mode

**ChatProvider.tsx:**
- Initialize `singleAgentMode` state (default: `false`)
- Expose in context value

**SharedChatProvider.tsx:**
- Add field with `false` value (shared sessions don't support single-agent mode)
- Add no-op setter for interface compatibility

**ChatInputArea.tsx:**
- Conditionally hide agent selector when `singleAgentMode === true`
- Wrapped in `{!singleAgentMode && (<>...</>)}` guard

## Behavior

**Default (Normal Mode):**
- `singleAgentMode: false`
- Agent selector visible
- No breaking changes

**Single-Agent Mode (when enabled by consumer):**
- `singleAgentMode: true`
- Agent selector hidden
- User cannot change agents

## Testing

- ✅ All existing tests pass
- ✅ No breaking changes to existing behavior
- ✅ Backward compatible (defaults to false)

## Enterprise Usage

Enterprise applications can now control the agent selector visibility:

\`\`\`typescript
// In enterprise provider
const urlAgent = getAgentFromUrl(); // Parse ?agent= from URL
if (urlAgent) {
  setSingleAgentMode(true);
  setSelectedAgentName(urlAgent);
}
\`\`\`

## Related

- **Enterprise PR:** solace-agent-mesh-enterprise (to be created)
- **JIRA:** DATAGO-132732
- **Use Case:** Teams Gateway integration - lock each team channel to a dedicated agent

🤖 Generated with Claude Code