### PR TITLE
ci(DATAGO-132880): add annotation for sam community version

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -67,8 +67,6 @@
   "pull-request-header": ":robot: I have created a release *beep* *boop*",
   "packages": {
     ".": {
-      "package-name": "solace-agent-mesh",
-      "component": "",
       "changelog-path": "CHANGELOG.md",
       "extra-files": ["cli/__init__.py"]
     }


### PR DESCRIPTION
### What is the purpose of this change?

Remove `package-name` and `component` fields from `release-please-config.json` to correct the annotation configuration for the SAM community version release process.

### How was this change implemented?

Deleted two lines from the root package configuration in `release-please-config.json`:
- `"package-name": "solace-agent-mesh"` — removes the explicit package name override
- `"component": ""` — removes the empty component field

This allows release-please to use its default behavior for these fields instead of the explicit overrides.

### How was this change tested?

- [ ] Manual testing: Verified the release-please config is valid JSON after the change
- [ ] Known limitations: Full validation requires a release-please dry run or an actual release cycle to confirm correct behavior

### Is there anything the reviewers should focus on/be aware of?

Confirm that removing `package-name` and `component` does not unintentionally change the release PR title format, tag naming, or changelog generation behavior. These fields influence how release-please names releases and tags, so the defaults should be verified against the expected convention.
