### PR TITLE
feat(DATAGO-130042): add local Entra ID JWT validation to auth middleware

### DIFF
--- a/src/solace_agent_mesh/shared/auth/jwt_validator.py
+++ b/src/solace_agent_mesh/shared/auth/jwt_validator.py
@@ -1,0 +1,232 @@
+"""
+Local JWT validation via JWKS.
+
+First supported issuer is Azure Active Directory (AAD). The module is named
+generically so a future Okta/Auth0/etc. caller can reuse the shape without a
+rename. The validator performs no network I/O on import — JWKS fetches happen
+lazily on the first `validate()` call and are cached by the underlying
+`PyJWKClient` (default lifespan 300s).
+
+Three-outcome contract (no exceptions for control flow):
+
+- VALID:    signature + iss/aud/tid/exp/nbf all pass.
+- NOT_AAD:  kid unknown to our JWKS, non-JWT shape, or issuer mismatch.
+            Caller should fall through to the next auth branch.
+- INVALID:  kid resolved but bad signature, expired, missing required claim,
+            alg=none/HS256 attempt, or aud/tid mismatch.
+            Caller must reject the request (401) — do not fall through.
+
+The aud/tid-mismatch-is-INVALID rule is deliberate: once we resolve a `kid`
+from AAD's JWKS, the token is *claiming* to be for us. Any failure past that
+point is a hard 401 rather than fall-through, which would otherwise open a
+confused-deputy hole if a downstream IdP path is ever misconfigured.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from enum import Enum
+
+import jwt
+from jwt import PyJWKClient
+
+log = logging.getLogger(__name__)
+
+_ALLOWED_ALGORITHMS: tuple[str, ...] = ("RS256",)
+
+
+class Outcome(Enum):
+    VALID = "valid"
+    NOT_AAD = "not_aad"
+    INVALID = "invalid"
+
+
+@dataclass(frozen=True)
+class AadValidatorConfig:
+    """Configuration for AAD JWT local validation.
+
+    `audience` tolerates either `api://<guid>` or bare `<guid>` — see
+    `accepted_audiences()`. `issuer_override` is provided for sovereign clouds
+    or to accept v1 tokens (https://sts.windows.net/{tenant}/).
+    """
+
+    tenant_id: str
+    audience: str
+    issuer: str | None = None
+    issuer_override: str | None = None
+    jwks_url: str | None = None
+    leeway_seconds: int = 60
+
+    def resolved_issuer(self) -> str:
+        if self.issuer_override:
+            return self.issuer_override
+        if self.issuer:
+            return self.issuer
+        return f"https://login.microsoftonline.com/{self.tenant_id}/v2.0"
+
+    def resolved_jwks_url(self) -> str:
+        if self.jwks_url:
+            return self.jwks_url
+        return f"https://login.microsoftonline.com/{self.tenant_id}/discovery/v2.0/keys"
+
+    def accepted_audiences(self) -> tuple[str, ...]:
+        """Normalise audience to tolerate GUID vs api://GUID shapes.
+
+        AAD issues tokens with the exact audience that was requested. If CI
+        requests `api://<guid>/.default` the `aud` claim is `api://<guid>`; if
+        a client requests the bare GUID it's just `<guid>`. Accepting both
+        removes a silent-401 misconfiguration footgun.
+        """
+        a = self.audience
+        if a.startswith("api://"):
+            return (a, a[len("api://") :])
+        return (a, f"api://{a}")
+
+
+@dataclass(frozen=True)
+class AadClaims:
+    sub: str | None
+    oid: str | None
+    appid: str | None
+    tid: str
+    aud: str
+    iss: str
+    email: str | None
+    name: str | None
+    preferred_username: str | None
+    upn: str | None
+    is_service_principal: bool
+    raw: dict
+
+
+@dataclass(frozen=True)
+class AadValidationOutcome:
+    outcome: Outcome
+    claims: AadClaims | None = None
+    reason: str | None = None
+
+
+def build_validator(cfg: AadValidatorConfig) -> AadTokenValidator:
+    """Build a validator with a fresh PyJWKClient.
+
+    PyJWKClient construction is lightweight (no network I/O); the first
+    `get_signing_key_from_jwt` call fetches JWKS and caches it.
+    """
+    jwks_client = PyJWKClient(cfg.resolved_jwks_url())
+    return AadTokenValidator(cfg, jwks_client)
+
+
+def _claims_from_payload(payload: dict) -> AadClaims:
+    appid = payload.get("appid") or payload.get("azp")
+    sub = payload.get("sub")
+    oid = payload.get("oid")
+    # App-only tokens (client-credentials): no `sub` tied to a human, only
+    # `oid`/`appid`. A user token has a real `sub`. `idtyp == "app"` is the
+    # most reliable signal when present; fall back to sub/oid heuristic.
+    idtyp = payload.get("idtyp")
+    if idtyp == "app":
+        is_service_principal = True
+    elif idtyp == "user":
+        is_service_principal = False
+    else:
+        is_service_principal = sub is None or sub == oid
+
+    return AadClaims(
+        sub=sub,
+        oid=oid,
+        appid=appid,
+        tid=payload.get("tid", ""),
+        aud=payload.get("aud", ""),
+        iss=payload.get("iss", ""),
+        email=payload.get("email"),
+        name=payload.get("name"),
+        preferred_username=payload.get("preferred_username"),
+        upn=payload.get("upn"),
+        is_service_principal=is_service_principal,
+        raw=payload,
+    )
+
+
+class AadTokenValidator:
+    def __init__(self, cfg: AadValidatorConfig, jwks_client: PyJWKClient) -> None:
+        self._cfg = cfg
+        self._jwks_client = jwks_client
+
+    def validate(self, token: str) -> AadValidationOutcome:
+        if not token or not isinstance(token, str) or token.count(".") != 2:
+            return AadValidationOutcome(
+                outcome=Outcome.NOT_AAD, reason="not a jwt shape"
+            )
+
+        try:
+            signing_key = self._jwks_client.get_signing_key_from_jwt(token)
+        except jwt.exceptions.PyJWKClientError as e:
+            # kid unknown to our JWKS (or JWKS fetch failed) → not our token.
+            return AadValidationOutcome(
+                outcome=Outcome.NOT_AAD, reason=f"kid not resolved: {e}"
+            )
+        except jwt.exceptions.DecodeError as e:
+            return AadValidationOutcome(
+                outcome=Outcome.NOT_AAD, reason=f"jwt decode error: {e}"
+            )
+
+        accepted_auds = list(self._cfg.accepted_audiences())
+        issuer = self._cfg.resolved_issuer()
+
+        try:
+            payload = jwt.decode(
+                token,
+                signing_key.key,
+                algorithms=list(_ALLOWED_ALGORITHMS),
+                audience=accepted_auds,
+                issuer=issuer,
+                leeway=self._cfg.leeway_seconds,
+                options={
+                    "require": ["exp", "iat", "iss", "aud"],
+                    "verify_signature": True,
+                    "verify_exp": True,
+                    "verify_nbf": True,
+                    "verify_iat": True,
+                    "verify_aud": True,
+                    "verify_iss": True,
+                },
+            )
+        except jwt.exceptions.InvalidIssuerError as e:
+            # Signed by AAD but not *our* issuer (e.g. v1 sts.windows.net,
+            # sovereign cloud). Fall through — another branch may handle it.
+            return AadValidationOutcome(
+                outcome=Outcome.NOT_AAD, reason=f"issuer mismatch: {e}"
+            )
+        except jwt.exceptions.InvalidTokenError as e:
+            # Sig failed, expired, aud mismatch, missing required claim,
+            # alg whitelist violation. Token claimed to be for us (kid
+            # resolved) but is broken — hard reject.
+            return AadValidationOutcome(
+                outcome=Outcome.INVALID, reason=str(e) or type(e).__name__
+            )
+
+        tid = payload.get("tid")
+        if not tid:
+            return AadValidationOutcome(
+                outcome=Outcome.INVALID, reason="missing tid claim"
+            )
+        if tid != self._cfg.tenant_id:
+            return AadValidationOutcome(
+                outcome=Outcome.INVALID,
+                reason=f"tid mismatch: got {tid}, expected {self._cfg.tenant_id}",
+            )
+
+        return AadValidationOutcome(
+            outcome=Outcome.VALID, claims=_claims_from_payload(payload)
+        )
+
+
+__all__ = [
+    "AadClaims",
+    "AadTokenValidator",
+    "AadValidationOutcome",
+    "AadValidatorConfig",
+    "Outcome",
+    "build_validator",
+]

--- a/src/solace_agent_mesh/shared/auth/middleware.py
+++ b/src/solace_agent_mesh/shared/auth/middleware.py
@@ -5,14 +5,15 @@ Provides reusable OAuth2 token validation middleware that works with any
 component that has OAuth configuration.
 """
 
-import re
-import httpx
 import logging
-from fastapi import Request as FastAPIRequest
-from fastapi.responses import JSONResponse
-from fastapi import status
+import re
 
+import httpx
+from fastapi import Request as FastAPIRequest
+from fastapi import status
+from fastapi.responses import JSONResponse
 from solace_ai_connector.common.observability import MonitorLatency
+
 from solace_agent_mesh.gateway.http_sse.utils.sam_token_helpers import (
     is_sam_token_enabled,
 )
@@ -24,9 +25,7 @@ log = logging.getLogger(__name__)
 # Share IDs are 21-char nanoid strings ([A-Za-z0-9_-]{21}).
 # The {21} length constraint prevents false matches on sub-routes
 # like /link/..., /shared-with-me, or /{share_id}/users.
-_SHARE_SOFT_AUTH_RE = re.compile(
-    r"^/api/v1/share/[A-Za-z0-9_-]{21}(?:/artifacts/.+)?$"
-)
+_SHARE_SOFT_AUTH_RE = re.compile(r"^/api/v1/share/[A-Za-z0-9_-]{21}(?:/artifacts/.+)?$")
 
 
 def _extract_access_token(request: FastAPIRequest) -> str:
@@ -138,7 +137,9 @@ def _extract_user_identifier(user_info: dict) -> str:
     )
 
     if user_identifier and user_identifier.lower() == "unknown":
-        log.warning("AuthMiddleware: IDP returned 'Unknown' as user identifier. Using fallback.")
+        log.warning(
+            "AuthMiddleware: IDP returned 'Unknown' as user identifier. Using fallback."
+        )
         return "sam_dev_user"
 
     return user_identifier
@@ -170,7 +171,9 @@ async def _create_user_state(
     final_user_id = user_identifier or email_from_auth or "sam_dev_user"
     if not final_user_id or final_user_id.lower() in ["unknown", "null", "none", ""]:
         final_user_id = "sam_dev_user"
-        log.warning("AuthMiddleware: Had to use fallback user ID due to invalid identifier")
+        log.warning(
+            "AuthMiddleware: Had to use fallback user ID due to invalid identifier"
+        )
 
     return {
         "id": final_user_id,
@@ -198,10 +201,67 @@ def create_oauth_middleware(component):
         AuthMiddleware class configured for the component
     """
 
+    # Eager config validation at mount time — misconfigured pairs should
+    # fail noisy (warning log) rather than silently 401 on first CI run.
+    _aad_tenant = (
+        component.get_config("aad_tenant_id", "")
+        if hasattr(component, "get_config")
+        else ""
+    )
+    _aad_aud = (
+        component.get_config("aad_audience", "")
+        if hasattr(component, "get_config")
+        else ""
+    )
+    if _aad_tenant and _aad_aud:
+        log.info(
+            "AuthMiddleware: AAD local JWT validation enabled for tenant=%s audience=%s",
+            _aad_tenant,
+            _aad_aud,
+        )
+    elif _aad_tenant or _aad_aud:
+        log.warning(
+            "AuthMiddleware: AAD local JWT validation requires both aad_tenant_id "
+            "and aad_audience; got tenant=%r audience=%r. Branch disabled.",
+            _aad_tenant,
+            _aad_aud,
+        )
+
     class AuthMiddleware:
         def __init__(self, app, component):
             self.app = app
             self.component = component
+            self._aad_validator = None
+            self._aad_validator_key = None
+
+        def _get_or_build_aad_validator(self, tenant_id: str, audience: str):
+            """Build or reuse a cached AAD validator.
+
+            One validator per (tenant, audience). Deployments use one tenant,
+            so the cache is effectively a singleton. First-call race is
+            harmless — a second builder just does a redundant JWKS fetch and
+            the validators are stateless.
+            """
+            key = (tenant_id, audience)
+            if self._aad_validator_key == key and self._aad_validator is not None:
+                return self._aad_validator
+            from solace_agent_mesh.shared.auth.jwt_validator import (
+                AadValidatorConfig,
+                build_validator,
+            )
+
+            issuer_override = (
+                self.component.get_config("aad_issuer_override", "") or None
+            )
+            self._aad_validator = build_validator(
+                AadValidatorConfig(
+                    tenant_id=tenant_id,
+                    audience=audience,
+                    issuer_override=issuer_override,
+                )
+            )
+            self._aad_validator_key = key
+            return self._aad_validator
 
         async def __call__(self, scope, receive, send):
             if scope["type"] != "http":
@@ -263,7 +323,9 @@ def create_oauth_middleware(component):
                     await self._handle_authenticated_request(
                         request, scope, receive, send, soft=True
                     )
-                elif await self._handle_authenticated_request(request, scope, receive, send):
+                elif await self._handle_authenticated_request(
+                    request, scope, receive, send
+                ):
                     return
             else:
                 request.state.user = {
@@ -273,17 +335,25 @@ def create_oauth_middleware(component):
                     "authenticated": True,
                     "auth_method": "development",
                 }
-                log.debug("AuthMiddleware: Set development user (frontend_use_authorization=false)")
+                log.debug(
+                    "AuthMiddleware: Set development user (frontend_use_authorization=false)"
+                )
 
             await self.app(scope, receive, send)
 
-        async def _handle_authenticated_request(self, request, scope, receive, send, soft: bool = False) -> bool:
+        async def _handle_authenticated_request(
+            self, request, scope, receive, send, soft: bool = False
+        ) -> bool:
             """
             Handle authentication for a request.
 
-            Supports both sam_access_token (new) and IdP access_token (existing)
-            for backwards compatibility. Tries sam_access_token validation first
-            (fast, local JWT verification), then falls back to IdP validation.
+            Ordered auth branches (first match wins):
+              1. sam_access_token  — locally-minted JWT, trust_manager-verified
+              2. AAD JWT           — local JWKS verification (opt-in via aad_*)
+              3. IdP               — external OAuth proxy /user_info fallback
+
+            AAD-INVALID results in a hard 401 (no fall-through); only AAD
+            kid-unresolved / issuer-mismatch falls through to the IdP branch.
 
             Args:
                 soft: If True, authentication failures are silently ignored
@@ -298,7 +368,9 @@ def create_oauth_middleware(component):
 
             if not access_token:
                 if soft:
-                    log.debug("AuthMiddleware: No access token (soft-auth, proceeding without user)")
+                    log.debug(
+                        "AuthMiddleware: No access token (soft-auth, proceeding without user)"
+                    )
                     return False
                 log.warning("AuthMiddleware: No access token found. Returning 401.")
                 response = JSONResponse(
@@ -320,7 +392,9 @@ def create_oauth_middleware(component):
             if trust_manager and is_sam_token_enabled(self.component):
                 try:
                     # Validate as sam_access_token using trust_manager (no task_id binding)
-                    claims = trust_manager.verify_user_claims_without_task_binding(access_token)
+                    claims = trust_manager.verify_user_claims_without_task_binding(
+                        access_token
+                    )
                     user_identifier = claims.get("sam_user_id")
                     # Success! It's a valid sam_access_token
                     # Extract roles from token, resolve scopes at request
@@ -337,7 +411,7 @@ def create_oauth_middleware(component):
                     claim_roles = claims.get("roles")
                     if claim_roles:
                         user_state["roles"] = claim_roles
-                    request.state.user  = user_state
+                    request.state.user = user_state
 
                     log.debug(
                         f"AuthMiddleware: Validated sam_access_token for user '{user_identifier}' "
@@ -346,18 +420,94 @@ def create_oauth_middleware(component):
                     return False  # Success - continue to app
 
                 except Exception as e:
-                    # Not a sam_access_token or verification failed
-                    # Fall through to IdP token validation below
-                    # TODO - distinguish invalid sam_access_token vs not a sam_access_token?
-                    log.warning(f"AuthMiddleware: Token is not a valid sam_access_token: {e}")
+                    # Not a sam_access_token or verification failed.
+                    # Fall through to AAD / IdP branches below.
+                    # Logged at debug, not warning: with AAD enabled, every
+                    # AAD token will pass through this except clause before
+                    # succeeding in the next branch — warning would flood.
+                    log.debug(
+                        f"AuthMiddleware: Token is not a valid sam_access_token: {e}"
+                    )
+
+            # AAD local JWT validation (opt-in via aad_tenant_id + aad_audience).
+            # Validates bearer tokens signed by AAD against JWKS locally — no
+            # OAuth proxy / Graph round-trip, so app-only (client-credentials)
+            # tokens work. Runs *after* sam_access_token (locally-minted wins)
+            # and *before* IdP (issuer mismatch falls through).
+            aad_tenant_id = self.component.get_config("aad_tenant_id", "")
+            aad_audience = self.component.get_config("aad_audience", "")
+            if aad_tenant_id and aad_audience:
+                from solace_agent_mesh.shared.auth.jwt_validator import Outcome
+
+                validator = self._get_or_build_aad_validator(
+                    aad_tenant_id, aad_audience
+                )
+                result = validator.validate(access_token)
+                if result.outcome is Outcome.VALID:
+                    claims = result.claims
+                    user_id = claims.sub or claims.oid or claims.appid
+                    # `.invalid` TLD (RFC 2606) is non-routable and can never
+                    # match a real allowed_domains entry in share ACLs.
+                    email = (
+                        claims.email
+                        or claims.preferred_username
+                        or claims.upn
+                        or f"svc-principal+{claims.appid}@aad-app-only.invalid"
+                    )
+                    request.state.user = {
+                        "id": user_id,
+                        "user_id": user_id,
+                        "email": email,
+                        "name": claims.name or claims.preferred_username or user_id,
+                        "authenticated": True,
+                        "auth_method": "aad_jwt",
+                        "is_service_principal": claims.is_service_principal,
+                        "service_principal_id": (
+                            claims.appid if claims.is_service_principal else None
+                        ),
+                    }
+                    log.debug(
+                        "AuthMiddleware: Validated AAD JWT principal=%s app_only=%s",
+                        user_id,
+                        claims.is_service_principal,
+                    )
+                    return False
+                if result.outcome is Outcome.INVALID:
+                    if soft:
+                        log.warning(
+                            "AuthMiddleware: AAD token rejected (soft-auth, proceeding): %s",
+                            result.reason,
+                        )
+                        request.state.auth_probe = True
+                        return False
+                    log.warning("AuthMiddleware: AAD token rejected: %s", result.reason)
+                    response = JSONResponse(
+                        status_code=status.HTTP_401_UNAUTHORIZED,
+                        content={
+                            "detail": "Invalid token",
+                            "error_type": "invalid_token",
+                        },
+                    )
+                    await response(scope, receive, send)
+                    return True
+                # NOT_AAD → fall through. Info (not debug) so misconfigured
+                # audience shows up in staging logs instead of silent IdP 401.
+                log.info(
+                    "AuthMiddleware: Token not AAD (%s); falling through to IdP",
+                    result.reason,
+                )
 
             # EXISTING: Fall back to IdP token validation (unchanged logic)
-            auth_service_url = getattr(self.component, "external_auth_service_url", None)
+            auth_service_url = getattr(
+                self.component, "external_auth_service_url", None
+            )
             auth_provider = getattr(self.component, "external_auth_provider", "generic")
 
             if not auth_service_url:
                 if soft:
-                    log.debug("AuthMiddleware: Auth service not configured (soft-auth, proceeding)")
+                    log.debug(
+                        "AuthMiddleware: Auth service not configured (soft-auth, proceeding)"
+                    )
                     return False
                 log.error("Auth service URL not configured.")
                 response = JSONResponse(
@@ -369,7 +519,9 @@ def create_oauth_middleware(component):
 
             if not await _validate_token(auth_service_url, auth_provider, access_token):
                 if soft:
-                    log.debug("AuthMiddleware: Token validation failed (soft-auth, proceeding without user)")
+                    log.debug(
+                        "AuthMiddleware: Token validation failed (soft-auth, proceeding without user)"
+                    )
                     return False
                 log.warning("AuthMiddleware: Token validation failed")
                 response = JSONResponse(
@@ -379,10 +531,14 @@ def create_oauth_middleware(component):
                 await response(scope, receive, send)
                 return True
 
-            user_info = await _get_user_info(auth_service_url, auth_provider, access_token)
+            user_info = await _get_user_info(
+                auth_service_url, auth_provider, access_token
+            )
             if not user_info:
                 if soft:
-                    log.debug("AuthMiddleware: Failed to get user info (soft-auth, proceeding without user)")
+                    log.debug(
+                        "AuthMiddleware: Failed to get user info (soft-auth, proceeding without user)"
+                    )
                     return False
                 log.warning("AuthMiddleware: Failed to get user info")
                 response = JSONResponse(
@@ -393,7 +549,9 @@ def create_oauth_middleware(component):
                 return True
 
             user_identifier = _extract_user_identifier(user_info)
-            email_from_auth, display_name = _extract_user_details(user_info, user_identifier)
+            email_from_auth, display_name = _extract_user_details(
+                user_info, user_identifier
+            )
 
             request.state.user = await _create_user_state(
                 user_identifier, email_from_auth, display_name

--- a/tests/unit/auth/test_jwt_validator.py
+++ b/tests/unit/auth/test_jwt_validator.py
@@ -1,0 +1,425 @@
+"""
+Unit tests for the local AAD JWT validator.
+
+Strategy:
+- Generate an RSA keypair in-test.
+- Sign test tokens with the private key (PyJWT RS256).
+- Stub `PyJWKClient.get_signing_key_from_jwt` to return the matching
+  public-key wrapper so we never touch the network.
+
+These tests exercise the validator's classification rules in isolation;
+middleware integration is covered in test_middleware_aad.py.
+"""
+
+from __future__ import annotations
+
+import time
+from dataclasses import dataclass
+
+import jwt
+import pytest
+from cryptography.hazmat.primitives import serialization
+from cryptography.hazmat.primitives.asymmetric import rsa
+
+from solace_agent_mesh.shared.auth.jwt_validator import (
+    AadTokenValidator,
+    AadValidatorConfig,
+    Outcome,
+)
+
+TENANT_ID = "11111111-1111-1111-1111-111111111111"
+APP_ID_URI = "api://22222222-2222-2222-2222-222222222222"
+APP_GUID = "22222222-2222-2222-2222-222222222222"
+ISSUER = f"https://login.microsoftonline.com/{TENANT_ID}/v2.0"
+
+
+@dataclass
+class _SigningKeyStub:
+    """Mimics the return of PyJWKClient.get_signing_key_from_jwt."""
+
+    key: object
+
+
+class _JwksStub:
+    """Drop-in stub for PyJWKClient.
+
+    `raise_error` forces get_signing_key_from_jwt to raise PyJWKClientError
+    (simulating kid-not-found / JWKS-fetch-failed).
+    """
+
+    def __init__(self, public_key, raise_error: bool = False):
+        self._public_key = public_key
+        self._raise = raise_error
+
+    def get_signing_key_from_jwt(self, token: str) -> _SigningKeyStub:
+        if self._raise:
+            raise jwt.exceptions.PyJWKClientError("kid not found in JWKS")
+        return _SigningKeyStub(key=self._public_key)
+
+
+@pytest.fixture(scope="module")
+def rsa_keys():
+    private_key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+    public_key = private_key.public_key()
+    private_pem = private_key.private_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PrivateFormat.PKCS8,
+        encryption_algorithm=serialization.NoEncryption(),
+    )
+    return private_key, public_key, private_pem
+
+
+def _encode(
+    payload: dict,
+    private_pem: bytes,
+    algorithm: str = "RS256",
+    headers: dict | None = None,
+) -> str:
+    return jwt.encode(
+        payload,
+        private_pem,
+        algorithm=algorithm,
+        headers=headers or {"kid": "test-kid"},
+    )
+
+
+def _default_config() -> AadValidatorConfig:
+    return AadValidatorConfig(tenant_id=TENANT_ID, audience=APP_ID_URI)
+
+
+def _valid_user_payload(now: int | None = None) -> dict:
+    now = now or int(time.time())
+    return {
+        "iss": ISSUER,
+        "aud": APP_ID_URI,
+        "sub": "user-sub-123",
+        "oid": "user-oid-456",
+        "tid": TENANT_ID,
+        "iat": now,
+        "nbf": now,
+        "exp": now + 3600,
+        "email": "alice@contoso.com",
+        "name": "Alice Example",
+        "preferred_username": "alice@contoso.com",
+        "ver": "2.0",
+        "idtyp": "user",
+    }
+
+
+def _valid_app_only_payload(now: int | None = None) -> dict:
+    now = now or int(time.time())
+    return {
+        "iss": ISSUER,
+        "aud": APP_ID_URI,
+        "oid": "sp-oid-789",
+        "appid": APP_GUID,
+        "azp": APP_GUID,
+        "tid": TENANT_ID,
+        "iat": now,
+        "nbf": now,
+        "exp": now + 3600,
+        "idtyp": "app",
+        "ver": "2.0",
+    }
+
+
+# --- positive cases -------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_valid_user_token(rsa_keys):
+    _, public_key, private_pem = rsa_keys
+    token = _encode(_valid_user_payload(), private_pem)
+    v = AadTokenValidator(_default_config(), _JwksStub(public_key))
+
+    result = v.validate(token)
+
+    assert result.outcome is Outcome.VALID
+    assert result.claims.sub == "user-sub-123"
+    assert result.claims.is_service_principal is False
+    assert result.claims.email == "alice@contoso.com"
+
+
+@pytest.mark.unit
+def test_valid_app_only_token(rsa_keys):
+    _, public_key, private_pem = rsa_keys
+    token = _encode(_valid_app_only_payload(), private_pem)
+    v = AadTokenValidator(_default_config(), _JwksStub(public_key))
+
+    result = v.validate(token)
+
+    assert result.outcome is Outcome.VALID
+    assert result.claims.appid == APP_GUID
+    assert result.claims.is_service_principal is True
+    assert result.claims.sub is None
+
+
+@pytest.mark.unit
+def test_leeway_absorbs_small_skew(rsa_keys):
+    _, public_key, private_pem = rsa_keys
+    now = int(time.time())
+    payload = _valid_user_payload(now)
+    payload["exp"] = now - 30  # 30s in the past, within 60s leeway
+    token = _encode(payload, private_pem)
+    v = AadTokenValidator(_default_config(), _JwksStub(public_key))
+
+    result = v.validate(token)
+
+    assert result.outcome is Outcome.VALID
+
+
+# --- audience normalisation ----------------------------------------------
+
+
+@pytest.mark.unit
+def test_audience_accepts_guid_form_when_configured_as_api_uri(rsa_keys):
+    """CI minted token with bare-GUID aud; config uses api://<guid>. Accept."""
+    _, public_key, private_pem = rsa_keys
+    payload = _valid_user_payload()
+    payload["aud"] = APP_GUID  # bare GUID
+    token = _encode(payload, private_pem)
+    cfg = AadValidatorConfig(tenant_id=TENANT_ID, audience=APP_ID_URI)
+    v = AadTokenValidator(cfg, _JwksStub(public_key))
+
+    result = v.validate(token)
+
+    assert result.outcome is Outcome.VALID
+
+
+@pytest.mark.unit
+def test_audience_accepts_api_uri_form_when_configured_as_guid(rsa_keys):
+    _, public_key, private_pem = rsa_keys
+    payload = _valid_user_payload()
+    payload["aud"] = APP_ID_URI
+    token = _encode(payload, private_pem)
+    cfg = AadValidatorConfig(tenant_id=TENANT_ID, audience=APP_GUID)
+    v = AadTokenValidator(cfg, _JwksStub(public_key))
+
+    result = v.validate(token)
+
+    assert result.outcome is Outcome.VALID
+
+
+# --- INVALID cases (hard 401, no fall-through) ---------------------------
+
+
+@pytest.mark.unit
+def test_expired_token(rsa_keys):
+    _, public_key, private_pem = rsa_keys
+    now = int(time.time())
+    payload = _valid_user_payload(now)
+    payload["exp"] = now - 3600  # well past any leeway
+    token = _encode(payload, private_pem)
+    v = AadTokenValidator(_default_config(), _JwksStub(public_key))
+
+    result = v.validate(token)
+
+    assert result.outcome is Outcome.INVALID
+
+
+@pytest.mark.unit
+def test_not_yet_valid(rsa_keys):
+    _, public_key, private_pem = rsa_keys
+    now = int(time.time())
+    payload = _valid_user_payload(now)
+    payload["nbf"] = now + 3600  # future nbf, past leeway
+    payload["iat"] = now + 3600
+    token = _encode(payload, private_pem)
+    v = AadTokenValidator(_default_config(), _JwksStub(public_key))
+
+    result = v.validate(token)
+
+    assert result.outcome is Outcome.INVALID
+
+
+@pytest.mark.unit
+def test_bad_signature(rsa_keys):
+    _, public_key, private_pem = rsa_keys
+    # Sign with a DIFFERENT private key; JWKS returns our real public key.
+    other_private = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+    other_pem = other_private.private_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PrivateFormat.PKCS8,
+        encryption_algorithm=serialization.NoEncryption(),
+    )
+    token = _encode(_valid_user_payload(), other_pem)
+    v = AadTokenValidator(_default_config(), _JwksStub(public_key))
+
+    result = v.validate(token)
+
+    assert result.outcome is Outcome.INVALID
+
+
+@pytest.mark.unit
+def test_alg_none_is_invalid(rsa_keys):
+    _, public_key, _ = rsa_keys
+    # Build an unsigned token manually — jwt.encode allows alg=none.
+    token = jwt.encode(
+        _valid_user_payload(), key="", algorithm="none", headers={"kid": "test-kid"}
+    )
+    v = AadTokenValidator(_default_config(), _JwksStub(public_key))
+
+    result = v.validate(token)
+
+    assert result.outcome is Outcome.INVALID
+
+
+@pytest.mark.unit
+def test_hs256_key_confusion_is_invalid(rsa_keys):
+    """
+    Classic alg-confusion: attacker flips header alg to HS256 and signs
+    with the JWKS-published public key material as the HMAC secret. Our
+    RS256 whitelist must reject this.
+
+    PyJWT refuses to sign with an asymmetric-shaped key (library-level
+    defense), so we construct the token manually to simulate the attacker.
+    """
+    import base64
+    import hashlib
+    import hmac
+    import json
+
+    _, public_key, _ = rsa_keys
+    public_pem = public_key.public_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PublicFormat.SubjectPublicKeyInfo,
+    )
+
+    def _b64(data: bytes) -> str:
+        return base64.urlsafe_b64encode(data).rstrip(b"=").decode()
+
+    header = _b64(
+        json.dumps({"alg": "HS256", "typ": "JWT", "kid": "test-kid"}).encode()
+    )
+    payload = _b64(json.dumps(_valid_user_payload()).encode())
+    signing_input = f"{header}.{payload}".encode()
+    signature = hmac.new(public_pem, signing_input, hashlib.sha256).digest()
+    token = f"{header}.{payload}.{_b64(signature)}"
+
+    v = AadTokenValidator(_default_config(), _JwksStub(public_key))
+
+    result = v.validate(token)
+
+    assert result.outcome is Outcome.INVALID
+
+
+@pytest.mark.unit
+def test_wrong_audience_is_invalid(rsa_keys):
+    """
+    Kid resolved in our JWKS — token *claims* to be for us. Audience
+    mismatch must be a hard 401, not a fall-through (confused-deputy).
+    """
+    _, public_key, private_pem = rsa_keys
+    payload = _valid_user_payload()
+    payload["aud"] = "api://some-other-app"
+    token = _encode(payload, private_pem)
+    v = AadTokenValidator(_default_config(), _JwksStub(public_key))
+
+    result = v.validate(token)
+
+    assert result.outcome is Outcome.INVALID
+
+
+@pytest.mark.unit
+def test_wrong_tenant_tid_is_invalid(rsa_keys):
+    _, public_key, private_pem = rsa_keys
+    payload = _valid_user_payload()
+    payload["tid"] = "99999999-9999-9999-9999-999999999999"
+    # Issuer must match the configured issuer (we verify iss before tid),
+    # so keep iss consistent with TENANT_ID; tid itself is the mismatch.
+    token = _encode(payload, private_pem)
+    v = AadTokenValidator(_default_config(), _JwksStub(public_key))
+
+    result = v.validate(token)
+
+    assert result.outcome is Outcome.INVALID
+
+
+@pytest.mark.unit
+def test_missing_tid_claim_is_invalid(rsa_keys):
+    _, public_key, private_pem = rsa_keys
+    payload = _valid_user_payload()
+    payload.pop("tid")
+    token = _encode(payload, private_pem)
+    v = AadTokenValidator(_default_config(), _JwksStub(public_key))
+
+    result = v.validate(token)
+
+    assert result.outcome is Outcome.INVALID
+
+
+# --- NOT_AAD cases (fall through to next auth branch) --------------------
+
+
+@pytest.mark.unit
+def test_kid_not_in_jwks_is_not_aad(rsa_keys):
+    _, public_key, private_pem = rsa_keys
+    token = _encode(_valid_user_payload(), private_pem)
+    v = AadTokenValidator(_default_config(), _JwksStub(public_key, raise_error=True))
+
+    result = v.validate(token)
+
+    assert result.outcome is Outcome.NOT_AAD
+
+
+@pytest.mark.unit
+def test_non_jwt_shape_is_not_aad(rsa_keys):
+    _, public_key, _ = rsa_keys
+    v = AadTokenValidator(_default_config(), _JwksStub(public_key))
+
+    result = v.validate("this-is-not-a-jwt")
+
+    assert result.outcome is Outcome.NOT_AAD
+
+
+@pytest.mark.unit
+def test_empty_token_is_not_aad(rsa_keys):
+    _, public_key, _ = rsa_keys
+    v = AadTokenValidator(_default_config(), _JwksStub(public_key))
+
+    result = v.validate("")
+
+    assert result.outcome is Outcome.NOT_AAD
+
+
+@pytest.mark.unit
+def test_wrong_issuer_is_not_aad(rsa_keys):
+    """
+    AAD-signed token (kid resolves), but issuer is a different tenant /
+    product (v1 sts.windows.net, different tenant). Fall through — might
+    be legitimate for a different auth branch.
+    """
+    _, public_key, private_pem = rsa_keys
+    payload = _valid_user_payload()
+    payload["iss"] = "https://sts.windows.net/99999999-9999-9999-9999-999999999999/"
+    token = _encode(payload, private_pem)
+    v = AadTokenValidator(_default_config(), _JwksStub(public_key))
+
+    result = v.validate(token)
+
+    assert result.outcome is Outcome.NOT_AAD
+
+
+# --- config helpers ------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_accepted_audiences_expands_api_uri():
+    cfg = AadValidatorConfig(tenant_id=TENANT_ID, audience=APP_ID_URI)
+    assert cfg.accepted_audiences() == (APP_ID_URI, APP_GUID)
+
+
+@pytest.mark.unit
+def test_accepted_audiences_expands_bare_guid():
+    cfg = AadValidatorConfig(tenant_id=TENANT_ID, audience=APP_GUID)
+    assert cfg.accepted_audiences() == (APP_GUID, APP_ID_URI)
+
+
+@pytest.mark.unit
+def test_issuer_override_wins():
+    cfg = AadValidatorConfig(
+        tenant_id=TENANT_ID,
+        audience=APP_ID_URI,
+        issuer_override="https://sts.windows.net/tenant/",
+    )
+    assert cfg.resolved_issuer() == "https://sts.windows.net/tenant/"

--- a/tests/unit/auth/test_middleware_aad.py
+++ b/tests/unit/auth/test_middleware_aad.py
@@ -1,0 +1,461 @@
+"""
+Integration tests for the AAD JWT branch in the OAuth middleware.
+
+These tests do NOT exercise the validator itself (covered in
+test_jwt_validator.py). They monkey-patch `build_validator` with a stub that
+returns canned outcomes, so we can assert the middleware's behavior for each
+(outcome × soft/hard × config-state) combination.
+
+Mirrors enterprise/tests/unit/auth/test_middleware_sam_access_token.py in
+structure — same MockComponent/MockTrustManager patterns.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from fastapi import Request as FastAPIRequest
+
+from solace_agent_mesh.shared.auth.jwt_validator import (
+    AadClaims,
+    AadValidationOutcome,
+    Outcome,
+)
+from solace_agent_mesh.shared.auth.middleware import create_oauth_middleware
+
+TENANT_ID = "11111111-1111-1111-1111-111111111111"
+APP_ID_URI = "api://22222222-2222-2222-2222-222222222222"
+APP_GUID = "22222222-2222-2222-2222-222222222222"
+
+
+class MockComponent:
+    """Mock component. AAD config keys default to empty (branch disabled)
+    unless explicitly set."""
+
+    def __init__(
+        self,
+        aad_tenant_id: str = "",
+        aad_audience: str = "",
+        aad_issuer_override: str = "",
+        sam_access_token_enabled: bool = False,
+    ):
+        self.trust_manager = None
+        self.authorization_service = None
+        self.external_auth_service_url = "http://test-auth-service"
+        self.external_auth_provider = "azure"
+        self._config = {
+            "frontend_use_authorization": True,
+            "sam_access_token": {"enabled": sam_access_token_enabled},
+            "aad_tenant_id": aad_tenant_id,
+            "aad_audience": aad_audience,
+            "aad_issuer_override": aad_issuer_override,
+        }
+
+    def get_config(self, key, default=None):
+        return self._config.get(key, default)
+
+
+class _StubValidator:
+    """Returns pre-canned outcomes for each validate() call."""
+
+    def __init__(self, outcome: AadValidationOutcome):
+        self.outcome = outcome
+        self.calls: list[str] = []
+
+    def validate(self, token: str) -> AadValidationOutcome:
+        self.calls.append(token)
+        return self.outcome
+
+
+def _user_claims() -> AadClaims:
+    return AadClaims(
+        sub="user-sub-123",
+        oid="user-oid-456",
+        appid=None,
+        tid=TENANT_ID,
+        aud=APP_ID_URI,
+        iss=f"https://login.microsoftonline.com/{TENANT_ID}/v2.0",
+        email="alice@contoso.com",
+        name="Alice Example",
+        preferred_username="alice@contoso.com",
+        upn=None,
+        is_service_principal=False,
+        raw={},
+    )
+
+
+def _app_only_claims() -> AadClaims:
+    return AadClaims(
+        sub=None,
+        oid="sp-oid-789",
+        appid=APP_GUID,
+        tid=TENANT_ID,
+        aud=APP_ID_URI,
+        iss=f"https://login.microsoftonline.com/{TENANT_ID}/v2.0",
+        email=None,
+        name=None,
+        preferred_username=None,
+        upn=None,
+        is_service_principal=True,
+        raw={},
+    )
+
+
+def _http_scope(path: str = "/api/v1/test", method: str = "GET") -> dict:
+    return {
+        "type": "http",
+        "path": path,
+        "method": method,
+        "headers": [(b"authorization", b"Bearer test-token")],
+        "query_string": b"",
+    }
+
+
+def _make_middleware_and_capture(component, patched_outcome):
+    """Helper: build middleware with build_validator patched to return a stub
+    yielding `patched_outcome`. Returns (middleware, mock_app, captured_dict,
+    stub_validator)."""
+    AuthMiddleware = create_oauth_middleware(component)
+
+    stub = _StubValidator(patched_outcome)
+
+    def _fake_build_validator(_cfg):
+        return stub
+
+    captured = {"state": None}
+    sent_messages = []
+
+    async def mock_app(scope, receive, send):
+        request = FastAPIRequest(scope, receive)
+        captured["state"] = getattr(request.state, "user", None)
+        captured["auth_probe"] = getattr(request.state, "auth_probe", None)
+
+    async def fake_send(message):
+        sent_messages.append(message)
+
+    middleware = AuthMiddleware(mock_app, component)
+
+    return (
+        middleware,
+        mock_app,
+        captured,
+        stub,
+        fake_send,
+        sent_messages,
+        _fake_build_validator,
+    )
+
+
+class TestAadMiddleware:
+    @pytest.mark.asyncio
+    @pytest.mark.unit
+    async def test_valid_aad_user_token_sets_user_state(self):
+        component = MockComponent(aad_tenant_id=TENANT_ID, aad_audience=APP_ID_URI)
+        outcome = AadValidationOutcome(outcome=Outcome.VALID, claims=_user_claims())
+        mw, _, captured, stub, fake_send, _, fake_bv = _make_middleware_and_capture(
+            component, outcome
+        )
+
+        with patch(
+            "solace_agent_mesh.shared.auth.jwt_validator.build_validator",
+            side_effect=fake_bv,
+        ):
+            await mw(_http_scope(), AsyncMock(), fake_send)
+
+        assert stub.calls == ["test-token"]
+        user = captured["state"]
+        assert user is not None
+        assert user["auth_method"] == "aad_jwt"
+        assert user["id"] == "user-sub-123"
+        assert user["email"] == "alice@contoso.com"
+        assert user["is_service_principal"] is False
+        assert user["service_principal_id"] is None
+
+    @pytest.mark.asyncio
+    @pytest.mark.unit
+    async def test_valid_aad_app_only_token_uses_invalid_tld_sentinel(self):
+        component = MockComponent(aad_tenant_id=TENANT_ID, aad_audience=APP_ID_URI)
+        outcome = AadValidationOutcome(outcome=Outcome.VALID, claims=_app_only_claims())
+        mw, _, captured, _, fake_send, _, fake_bv = _make_middleware_and_capture(
+            component, outcome
+        )
+
+        with patch(
+            "solace_agent_mesh.shared.auth.jwt_validator.build_validator",
+            side_effect=fake_bv,
+        ):
+            await mw(_http_scope(), AsyncMock(), fake_send)
+
+        user = captured["state"]
+        assert user["auth_method"] == "aad_jwt"
+        assert user["id"] == "sp-oid-789"  # sub None → oid
+        assert user["is_service_principal"] is True
+        assert user["service_principal_id"] == APP_GUID
+        # .invalid TLD must be non-matchable in share ACL checks
+        assert user["email"] == f"svc-principal+{APP_GUID}@aad-app-only.invalid"
+        assert user["email"].endswith(".invalid")
+
+    @pytest.mark.asyncio
+    @pytest.mark.unit
+    async def test_aad_invalid_outcome_returns_401_no_idp_fallback(self):
+        component = MockComponent(aad_tenant_id=TENANT_ID, aad_audience=APP_ID_URI)
+        outcome = AadValidationOutcome(
+            outcome=Outcome.INVALID, reason="audience mismatch"
+        )
+        mw, _, captured, _, fake_send, sent, fake_bv = _make_middleware_and_capture(
+            component, outcome
+        )
+
+        with (
+            patch(
+                "solace_agent_mesh.shared.auth.jwt_validator.build_validator",
+                side_effect=fake_bv,
+            ),
+            patch(
+                "solace_agent_mesh.shared.auth.middleware._validate_token",
+                new_callable=AsyncMock,
+            ) as mock_validate,
+            patch(
+                "solace_agent_mesh.shared.auth.middleware._get_user_info",
+                new_callable=AsyncMock,
+            ) as mock_user_info,
+        ):
+            await mw(_http_scope(), AsyncMock(), fake_send)
+
+            # Must not fall through to IdP
+            mock_validate.assert_not_called()
+            mock_user_info.assert_not_called()
+
+        # 401 response was sent
+        assert any(
+            m.get("type") == "http.response.start" and m.get("status") == 401
+            for m in sent
+        )
+        # request.state.user was never populated
+        assert captured["state"] is None
+
+    @pytest.mark.asyncio
+    @pytest.mark.unit
+    async def test_aad_invalid_soft_auth_continues_with_probe_flag(self):
+        component = MockComponent(aad_tenant_id=TENANT_ID, aad_audience=APP_ID_URI)
+        outcome = AadValidationOutcome(outcome=Outcome.INVALID, reason="bad sig")
+        mw, _, captured, _, fake_send, sent, fake_bv = _make_middleware_and_capture(
+            component, outcome
+        )
+
+        # Soft-auth path matches /api/v1/share/<21-char id>
+        soft_path = "/api/v1/share/" + ("a" * 21)
+
+        with patch(
+            "solace_agent_mesh.shared.auth.jwt_validator.build_validator",
+            side_effect=fake_bv,
+        ):
+            await mw(_http_scope(path=soft_path), AsyncMock(), fake_send)
+
+        # No 401 sent; probe flag raised for downstream
+        assert not any(
+            m.get("type") == "http.response.start" and m.get("status") == 401
+            for m in sent
+        )
+        assert captured["auth_probe"] is True
+
+    @pytest.mark.asyncio
+    @pytest.mark.unit
+    async def test_aad_not_aad_outcome_falls_through_to_idp(self):
+        component = MockComponent(aad_tenant_id=TENANT_ID, aad_audience=APP_ID_URI)
+        outcome = AadValidationOutcome(
+            outcome=Outcome.NOT_AAD, reason="issuer mismatch"
+        )
+        mw, _, captured, _, fake_send, _, fake_bv = _make_middleware_and_capture(
+            component, outcome
+        )
+
+        with (
+            patch(
+                "solace_agent_mesh.shared.auth.jwt_validator.build_validator",
+                side_effect=fake_bv,
+            ),
+            patch(
+                "solace_agent_mesh.shared.auth.middleware._validate_token",
+                new_callable=AsyncMock,
+            ) as mock_validate,
+            patch(
+                "solace_agent_mesh.shared.auth.middleware._get_user_info",
+                new_callable=AsyncMock,
+            ) as mock_user_info,
+        ):
+            mock_validate.return_value = True
+            mock_user_info.return_value = {
+                "sub": "idp-user@example.com",
+                "email": "idp-user@example.com",
+                "name": "IdP User",
+            }
+            await mw(_http_scope(), AsyncMock(), fake_send)
+
+            mock_validate.assert_called_once()
+
+        user = captured["state"]
+        assert user is not None
+        assert user["auth_method"] == "oidc"
+
+    @pytest.mark.asyncio
+    @pytest.mark.unit
+    async def test_aad_config_missing_skips_branch(self):
+        """No AAD config → branch never runs → IdP handles the token."""
+        component = MockComponent()  # no aad_* keys
+        mw = create_oauth_middleware(component)(AsyncMock(), component)
+
+        captured = {"state": None}
+        sent = []
+
+        async def fake_send(message):
+            sent.append(message)
+
+        async def mock_app(scope, receive, send):
+            request = FastAPIRequest(scope, receive)
+            captured["state"] = getattr(request.state, "user", None)
+
+        mw.app = mock_app
+
+        with (
+            patch(
+                "solace_agent_mesh.shared.auth.jwt_validator.build_validator"
+            ) as mock_build,
+            patch(
+                "solace_agent_mesh.shared.auth.middleware._validate_token",
+                new_callable=AsyncMock,
+            ) as mock_validate,
+            patch(
+                "solace_agent_mesh.shared.auth.middleware._get_user_info",
+                new_callable=AsyncMock,
+            ) as mock_user_info,
+        ):
+            mock_validate.return_value = True
+            mock_user_info.return_value = {
+                "sub": "idp-user@example.com",
+                "email": "idp-user@example.com",
+                "name": "IdP User",
+            }
+            await mw(_http_scope(), AsyncMock(), fake_send)
+
+            # Validator was never built
+            mock_build.assert_not_called()
+            # IdP path was used
+            mock_validate.assert_called_once()
+
+        assert captured["state"]["auth_method"] == "oidc"
+
+    @pytest.mark.asyncio
+    @pytest.mark.unit
+    async def test_aad_config_partial_disables_branch(self):
+        """Only one of the pair set → branch disabled (fails noisy at mount)."""
+        component = MockComponent(aad_tenant_id=TENANT_ID, aad_audience="")
+        mw = create_oauth_middleware(component)(AsyncMock(), component)
+
+        captured = {"state": None}
+        sent = []
+
+        async def fake_send(message):
+            sent.append(message)
+
+        async def mock_app(scope, receive, send):
+            request = FastAPIRequest(scope, receive)
+            captured["state"] = getattr(request.state, "user", None)
+
+        mw.app = mock_app
+
+        with (
+            patch(
+                "solace_agent_mesh.shared.auth.jwt_validator.build_validator"
+            ) as mock_build,
+            patch(
+                "solace_agent_mesh.shared.auth.middleware._validate_token",
+                new_callable=AsyncMock,
+            ) as mock_validate,
+            patch(
+                "solace_agent_mesh.shared.auth.middleware._get_user_info",
+                new_callable=AsyncMock,
+            ) as mock_user_info,
+        ):
+            mock_validate.return_value = True
+            mock_user_info.return_value = {
+                "sub": "idp-user@example.com",
+                "email": "idp-user@example.com",
+                "name": "IdP User",
+            }
+            await mw(_http_scope(), AsyncMock(), fake_send)
+
+            mock_build.assert_not_called()
+
+        assert captured["state"]["auth_method"] == "oidc"
+
+    @pytest.mark.asyncio
+    @pytest.mark.unit
+    async def test_aad_branch_does_not_run_when_sam_token_succeeds(self):
+        """Ordering contract: sam_access_token wins over AAD.
+
+        `is_sam_token_enabled` is an enterprise-only check (stubbed to False
+        in the community repo), so we patch it to True here to exercise the
+        ordering contract.
+        """
+        component = MockComponent(
+            aad_tenant_id=TENANT_ID,
+            aad_audience=APP_ID_URI,
+            sam_access_token_enabled=True,
+        )
+
+        class _SuccessTrustManager:
+            def verify_user_claims_without_task_binding(self, token):
+                return {
+                    "sub": "sam-user@example.com",
+                    "sam_user_id": "sam-user@example.com",
+                    "email": "sam-user@example.com",
+                    "name": "SAM User",
+                }
+
+        component.trust_manager = _SuccessTrustManager()
+
+        outcome = AadValidationOutcome(outcome=Outcome.VALID, claims=_user_claims())
+        mw, _, captured, _, fake_send, _, fake_bv = _make_middleware_and_capture(
+            component, outcome
+        )
+
+        with (
+            patch(
+                "solace_agent_mesh.shared.auth.middleware.is_sam_token_enabled",
+                return_value=True,
+            ),
+            patch(
+                "solace_agent_mesh.shared.auth.jwt_validator.build_validator",
+                side_effect=fake_bv,
+            ) as mock_build,
+        ):
+            await mw(_http_scope(), AsyncMock(), fake_send)
+
+            # sam_access_token won; AAD validator never built
+            mock_build.assert_not_called()
+
+        user = captured["state"]
+        assert user["auth_method"] == "sam_access_token"
+        assert user["id"] == "sam-user@example.com"
+
+    @pytest.mark.asyncio
+    @pytest.mark.unit
+    async def test_validator_cache_reused_across_calls(self):
+        component = MockComponent(aad_tenant_id=TENANT_ID, aad_audience=APP_ID_URI)
+        outcome = AadValidationOutcome(outcome=Outcome.VALID, claims=_user_claims())
+        mw, _, captured, stub, fake_send, _, fake_bv = _make_middleware_and_capture(
+            component, outcome
+        )
+
+        with patch(
+            "solace_agent_mesh.shared.auth.jwt_validator.build_validator",
+            side_effect=fake_bv,
+        ) as mock_build:
+            await mw(_http_scope(), AsyncMock(), fake_send)
+            await mw(_http_scope(), AsyncMock(), fake_send)
+
+        # build_validator called exactly once across two requests
+        assert mock_build.call_count == 1
+        assert len(stub.calls) == 2


### PR DESCRIPTION
### What is the purpose of this change?

Adds a third authentication branch to `shared/auth/middleware.py` that validates Microsoft Entra ID JWTs **locally via JWKS**, positioned between the existing `sam_access_token` path and the IdP `/user_info` fallback.

**Motivation.** The existing IdP fallback path routes bearer tokens through the OAuth proxy's `/user_info` endpoint, which calls Microsoft Graph's `/oidc/userinfo`. Graph rejects **app-only tokens** (no `sub` claim — only `oid` and `appid`) because the OIDC `userinfo` spec requires `sub`. This blocks any caller authenticating as a service principal, e.g. CI workflows minting tokens via GitHub OIDC federation.

This PR adds a local-verification branch so app-only Entra ID tokens can reach the backend without touching Graph. Users with real Graph-compatible tokens are unaffected — they still flow through the existing IdP path.

Jira: [DATAGO-130042](https://sol-jira.atlassian.net/browse/DATAGO-130042)

### Companion PR

Consumed by **[SolaceDev/solace-chat#428](https://github.com/SolaceDev/solace-chat/pull/428)**, which:
- Mints an app-only Entra ID token in CI via GitHub OIDC federation (no client secret)
- Hands it to Playwright as `Authorization: Bearer <token>` for smoke tests against staging
- Adds the `aad_tenant_id` / `aad_audience` / `aad_issuer_override` config keys to its `webui.yaml` that activate the branch introduced here

Without this PR, those config keys are defined but have no consumer — the bearer would still 401 against `/user_info`.

### How is this accomplished?

**New module: `src/solace_agent_mesh/shared/auth/jwt_validator.py`**

Generic local JWKS-based JWT verification, with Entra ID as the first supported issuer (module deliberately named `jwt_validator` rather than `aad_jwt_validator` so a future Okta/Auth0/etc. local-verify caller can reuse the shape). Public surface:

- `AadValidatorConfig` — tenant, audience, optional issuer/JWKS overrides, 60s leeway. `accepted_audiences()` normalises between `api://<guid>` and bare `<guid>` so either CI configuration works.
- `AadTokenValidator.validate(token) -> AadValidationOutcome` — three-outcome tagged union (enum, not string): `VALID`, `NOT_AAD`, `INVALID`. No exceptions for control flow.
- `AadClaims` — structured view of the validated payload with an `is_service_principal` flag derived from the `idtyp` claim (falls back to sub/oid heuristic).
- `build_validator()` — factory. `PyJWKClient` construction is lightweight (no network I/O); the first `validate()` call fetches JWKS and caches it for 300s.

**Three-outcome contract:**

| Outcome | Trigger | Middleware reaction |
|---|---|---|
| `VALID` | sig + `iss`/`aud`/`tid`/`exp`/`nbf` all pass | Build `request.state.user`, 200 path |
| `NOT_AAD` | `PyJWKClientError` (kid unknown), non-JWT shape, issuer mismatch | Fall through to IdP branch |
| `INVALID` | kid resolved but bad sig, expired, missing claim, alg=none/HS256 attempt, aud mismatch, tid mismatch | Hard 401, no fallthrough |

The `aud`/`tid` mismatch → `INVALID` (not `NOT_AAD`) rule is a confused-deputy defense. Once a `kid` resolves in Entra ID's JWKS, the token is *claiming* to be for us — any failure past that point is a hard reject rather than handing the token to another branch that might happen to accept it.

**Middleware integration (`src/solace_agent_mesh/shared/auth/middleware.py`)**

- Ordered branches in `_handle_authenticated_request`: `sam_access_token` → **Entra ID JWT** → IdP. The AAD branch only runs when both `aad_tenant_id` and `aad_audience` are configured.
- `_get_or_build_aad_validator(tenant, audience)` helper caches one validator per `(tenant, audience)` tuple on the middleware instance. Lazy import of `jwt_validator` keeps `PyJWKClient` / `cryptography` off the import path for deployments that don't opt in.
- Eager mount-time config validation: logs `info` when enabled, `warning` + disables the branch if only one of the pair is set (fail noisy, not silent 401s).
- Soft-auth mode: `INVALID` outcome sets `request.state.auth_probe = True` and proceeds, matching the existing pattern for other branches.

**Identity shape**

- `user_id` = first of `sub`, `oid`, `appid`
- `email` = first of `email`, `preferred_username`, `upn`, else **`svc-principal+{appid}@aad-app-only.invalid`**. The IANA-reserved `.invalid` TLD (RFC 2606) means the sentinel can never coincidentally match an `allowed_domains` / `shared_user_emails` entry.
- `is_service_principal` + `service_principal_id` added to `request.state.user` so downstream code can branch on identity type without regexing the email.
- `auth_method = "aad_jwt"` flag for downstream branching.

**Dependencies:** no new ones. `pyjwt>=2.12.0` and `cryptography==46.0.7` are already in `pyproject.toml`.

### Security notes

Verified non-issues (confirmed during security review):
- **alg=none / HS256 key confusion** — `algorithms=("RS256",)` passed explicitly to `jwt.decode`. PyJWT 2.x removed auto-detect; passing `algorithms` is mandatory and RS256-only blocks both.
- **`jku` / `x5u` header injection** — `PyJWKClient` ignores these; only `kid` is used against the configured URL.
- **Confused-deputy via mixed branches** — aud/tid mismatch post-kid-resolution is hard 401, does not fall through.
- **Email-keyed authorization** — audited `share.py::can_be_accessed_by_user`, `shared_user_emails`, `project_service.py::get_accessible_projects`, `routers/auth.py`, `routers/users.py`, `local_file_identity_service.py`. All use exact-match equality or display-only; the `.invalid`-TLD sentinel is non-matchable across all of them.
- **Dev bypass interaction** — `_handle_authenticated_request` is not called when `frontend_use_authorization=false` (short-circuit earlier in the file). The new branch is unreachable in dev deployments.

### Tests

29 new unit tests — all passing, and the full community suite (4959/4959) remains green.

**`tests/unit/auth/test_jwt_validator.py`** (20 tests) — validator in isolation. Generates an RSA keypair via `cryptography`, signs test tokens with PyJWT, stubs `PyJWKClient.get_signing_key_from_jwt`:

- Valid app-only / valid user tokens (claim extraction, `is_service_principal` flag)
- Expired, not-yet-valid, bad-signature → `INVALID`
- `alg=none`, HS256 key-confusion (hand-forged with `hmac.new`) → `INVALID`
- Wrong audience → `INVALID` (post-kid-resolution tightening)
- Wrong tenant `tid` → `INVALID`
- Wrong issuer → `NOT_AAD`
- Kid not in JWKS → `NOT_AAD`
- Non-JWT shape / empty token → `NOT_AAD`
- Missing `tid` → `INVALID`
- Leeway absorbs small clock skew
- `accepted_audiences()` normalisation both directions (`api://<guid>` ↔ bare GUID)

**`tests/unit/auth/test_middleware_aad.py`** (9 tests) — middleware integration. Reuses `MockComponent`/`MockTrustManager` patterns, stubs the validator to return canned outcomes:

- `VALID` user token / `VALID` app-only token (asserts `.invalid` TLD sentinel + `is_service_principal`)
- `INVALID` → 401 JSON response, IdP path **not** called
- `INVALID` under soft-auth → `request.state.auth_probe = True`, returns `False`
- `NOT_AAD` → IdP fall-through path runs
- No config → branch skipped, existing behaviour preserved
- Partial config → branch disabled, warning logged at mount
- sam_token precedence: AAD branch does not run when sam_token succeeds

### Anything reviews should focus on/be aware of?

- **Opt-in only.** With `aad_tenant_id` / `aad_audience` unset (default), the branch is skipped entirely — zero behaviour change for existing deployments. The lazy import means even the `PyJWKClient` dependency isn't touched.
- **Confused-deputy rule (`aud`/`tid` mismatch = hard 401).** Deliberate — a previous draft of this plan fell through on audience mismatch, which relied on the downstream proxy also enforcing audience. Tighter rule here guards against proxy misconfiguration.
- **`.invalid` TLD sentinel.** Intentionally non-matchable. Every email-keyed authorization call site was audited before merge; findings are in the [plan doc](https://sol-jira.atlassian.net/browse/DATAGO-130042) under "Risks §A".
- **`sam_access_token` log downgrade (warning → debug).** Once this lands, every real Entra ID token passes through the sam-token `except` clause before succeeding in the new branch. Warning-level volume would explode. Downgrade prevents that — failures are now only loud when they end up as 401s.
- **Out of scope for this PR**: multi-audience support, v1-token `sts.windows.net` issuer, Azure sovereign clouds, conditional access / revocation checks, lifting the branch into a formal provider class. All tracked as follow-ups in the plan.
- **Deployment gating**: companion PR (`solace-chat#428`) must have its staging pod configured with `AAD_TENANT_ID`, `AAD_AUDIENCE`, `FRONTEND_USE_AUTHORIZATION=true` before the cron will succeed end-to-end.

### Verification

```bash
cd solace-agent-mesh
uv run pytest tests/unit/auth/ -v    # 29/29 green
uv run pytest                        # full community suite green
```

After merge + staging deploy, trigger `playwright-smoke-tests.yaml` on `solace-chat` via `workflow_dispatch` — expected: end-to-end green (OIDC mint → bearer → local JWKS verify → 200).

[DATAGO-130042]: https://sol-jira.atlassian.net/browse/DATAGO-130042