### PR TITLE
ci(DATAGO-133169): fix maas-build-actions container

### DIFF
--- a/.github/workflows/release-readiness-check.yaml
+++ b/.github/workflows/release-readiness-check.yaml
@@ -211,7 +211,7 @@ jobs:
       - name: Run SonarQube hotspot checker
         id: sonarqube
         continue-on-error: true
-        uses: docker://ghcr.io/solacedev/maas-build-actions:latest
+        uses: docker://ghcr.io/solacelabs/maas-build-actions:latest
         env:
           SONARQUBE_PROJECT_KEY: ${{ secrets.SONARQUBE_PROJECT_KEY }}
           SONARQUBE_PROJECT_MAIN_BRANCH: "main"
@@ -279,7 +279,6 @@ jobs:
           guardian-key: ${{ secrets.GUARDIAN_API_TOKEN || secrets.GUARDIAN_API_KEY }}
           product-version: ${{ needs.resolve-context.outputs.clean_version }}
           fail-on-blocked: "true"
-          upload-logs: "true"
 
       - name: Capture Guardian status
         id: capture


### PR DESCRIPTION
### What is the purpose of this change?

Fix the maas-build-actions container reference and clean up a deprecated parameter in the release readiness check workflow.

### How was this change implemented?

- Updated the SonarQube hotspot checker Docker image reference from `ghcr.io/solacedev/maas-build-actions:latest` to `ghcr.io/solacelabs/maas-build-actions:latest` to point to the correct container registry.
- Removed the `upload-logs: "true"` parameter from the Guardian step.

### How was this change tested?

- [ ] Manual testing: Verify the workflow runs successfully with the corrected container reference
- [ ] Known limitations: Requires a workflow run to fully validate

### Is there anything the reviewers should focus on/be aware of?

Confirm that `ghcr.io/solacelabs/maas-build-actions:latest` is the correct registry path for the maas-build-actions container.
