### PR TITLE
ci: remove concurrency setting for push to main

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -9,10 +9,6 @@ on:
     branches:
       - main
 
-concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
-
 jobs:
   detect-context:
     name: Detect Context


### PR DESCRIPTION
### What is the purpose of this change?

Remove the workflow-level `concurrency` setting from the CI workflow to prevent push-to-main runs from being cancelled prematurely.

With the previous configuration, sequential pushes to `main` (e.g. back-to-back merges) would cancel in-progress CI runs for the same branch/workflow group. This is undesirable for the default branch, where every push should run CI to completion.

### How was this change implemented?

Removed the top-level `concurrency` block from `.github/workflows/ci.yaml`. This was a 4-line deletion with no other changes.

### Key Design Decisions

Concurrency groups with `cancel-in-progress: true` are useful for pull request branches to avoid redundant work, but on the default branch they can cause legitimate CI runs to be silently dropped. Removing the setting entirely ensures every merge to `main` gets a full CI run.

### How was this change tested?

- [x] Manual testing: verified the YAML is valid after the deletion
- [ ] Unit tests: N/A — workflow configuration change only
- [ ] Integration tests: CI behavior will be validated on subsequent merges to `main`
- [ ] Known limitations: pull request branches no longer benefit from automatic cancellation of outdated runs at the workflow level; individual jobs or a PR-scoped concurrency block could be added later if needed

### Is there anything the reviewers should focus on/be aware of?

This removes concurrency control for **all** trigger events in this workflow (both `pull_request` and `push`). If cancellation of superseded PR runs is still desired, a scoped concurrency group conditioned on `github.event_name` or applied at the job level could be reintroduced separately.
