### PR TITLE
ci(DATAGO-133304): fix concurrency in sam community

### DIFF
--- a/.github/workflows/build-push-image.yaml
+++ b/.github/workflows/build-push-image.yaml
@@ -19,6 +19,11 @@ on:
         type: boolean
         required: false
         default: false
+      is_release_merge:
+        description: "True when this build is for a release-please merge to the default branch. Controls whether the bare version tag is applied."
+        type: boolean
+        required: false
+        default: false
     outputs:
       version:
         description: "Semantic version that was built"
@@ -49,6 +54,11 @@ on:
         default: true
       run_container_scan:
         description: "Run Prisma Cloud container scan on built images."
+        type: boolean
+        required: false
+        default: false
+      is_release_merge:
+        description: "True when this build is for a release-please merge. Controls whether the bare version tag is applied."
         type: boolean
         required: false
         default: false
@@ -266,8 +276,7 @@ jobs:
           SHORT_SHA: ${{ needs.prepare-metadata.outputs.short_sha }}
           RELEASE_TAG: ${{ needs.prepare-metadata.outputs.release_tag }}
           COMMIT_SHA: ${{ needs.prepare-metadata.outputs.commit_hash }}
-          DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
-          REF_NAME: ${{ github.ref_name }}
+          IS_RELEASE_MERGE: ${{ inputs.is_release_merge }}
         run: |
           set -euo pipefail
 
@@ -277,7 +286,7 @@ jobs:
           BUILD_TIME="$(date -u +'%Y-%m-%dT%H:%M:%SZ')"
 
           TAGS=("${IMG}:${VERSION}-${SHORT_SHA}")
-          if [[ "$REF_NAME" == "$DEFAULT_BRANCH" ]]; then
+          if [[ "$IS_RELEASE_MERGE" == "true" ]]; then
             TAGS+=("${IMG}:${VERSION}")
             TAGS+=("${IMG}:${RELEASE_TAG}")
           fi

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -16,12 +16,14 @@ concurrency:
 jobs:
   detect-context:
     name: Detect Context
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     outputs:
       is_release_please_pr: ${{ steps.context.outputs.is_release_please_pr }}
       is_regular_pr: ${{ steps.context.outputs.is_regular_pr }}
       is_push_to_main: ${{ steps.context.outputs.is_push_to_main }}
       is_fork_pr: ${{ steps.context.outputs.is_fork_pr }}
+      is_release_please_merge: ${{ steps.context.outputs.is_release_please_merge }}
+      release_version: ${{ steps.context.outputs.release_version }}
       pr_base_sha: ${{ steps.context.outputs.pr_base_sha }}
     steps:
       - id: context
@@ -32,12 +34,26 @@ jobs:
           IS_PUSH_TO_MAIN: ${{ github.event_name == 'push' && github.ref_name == github.event.repository.default_branch }}
           IS_REGULAR_PR: ${{ github.event_name == 'pull_request' && !github.event.pull_request.head.repo.fork && !contains(github.event.pull_request.head.ref, 'release-please') }}
           IS_RELEASE_PLEASE_PR: ${{ contains(github.event.pull_request.head.ref, 'release-please') }}
+          HEAD_COMMIT_MESSAGE: ${{ github.event.head_commit.message }}
         run: |
           echo "Determining context..."
           echo "is_fork_pr=$IS_FORK_PR" >> "$GITHUB_OUTPUT"
           echo "is_push_to_main=$IS_PUSH_TO_MAIN" >> "$GITHUB_OUTPUT"
           echo "is_regular_pr=$IS_REGULAR_PR" >> "$GITHUB_OUTPUT"
           echo "is_release_please_pr=$IS_RELEASE_PLEASE_PR" >> "$GITHUB_OUTPUT"
+
+          # Detect release-please merge: push to main where the merge commit
+          # message matches release-please's title pattern (proven in release-post-process.yml).
+          IS_RELEASE_PLEASE_MERGE=false
+          RELEASE_VERSION=""
+          if [[ "$IS_PUSH_TO_MAIN" == "true" && "$HEAD_COMMIT_MESSAGE" =~ ^chore(\(.*\))?:\ release\ ([0-9]+\.[0-9]+\.[0-9]+) ]]; then
+            IS_RELEASE_PLEASE_MERGE=true
+            RELEASE_VERSION="${BASH_REMATCH[2]}"
+          fi
+
+
+          echo "is_release_please_merge=$IS_RELEASE_PLEASE_MERGE" >> "$GITHUB_OUTPUT"
+          echo "release_version=$RELEASE_VERSION" >> "$GITHUB_OUTPUT"
   pr-size-check:
     name: PR Size Check
     needs: detect-context
@@ -109,7 +125,7 @@ jobs:
       custom_setup_script: "uv export --format requirements-txt --no-dev --output-file requirements.txt"
       additional_scan_params: |
         fossa.branch=${{ github.event_name == 'pull_request' && 'PR' || 'main' }}
-        fossa.revision=${{ github.event.pull_request.head.ref || github.sha }}
+        fossa.revision=${{ needs.detect-context.outputs.release_version || github.event.pull_request.head.ref || github.sha }}
     secrets:
       FOSSA_API_KEY: ${{ secrets.FOSSA_API_KEY }}
 
@@ -149,6 +165,7 @@ jobs:
       ref: ${{ github.event.pull_request.head.ref || github.ref_name }}
       push_to_ecr: ${{ fromJSON(needs.detect-context.outputs.is_push_to_main) || fromJSON(needs.detect-context.outputs.is_release_please_pr) }}
       run_container_scan: ${{ fromJSON(needs.detect-context.outputs.is_regular_pr) }}
+      is_release_merge: ${{ fromJSON(needs.detect-context.outputs.is_release_please_merge) }}
     secrets: inherit
 
   # ── Release-please PR: release readiness ──────────────────────

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,5 +1,5 @@
 name: CI
-
+run-name: "CI (`${{ github.event_name == 'push' && 'main' || (contains(github.event.pull_request.head.ref, 'release-please') && 'Release-Please PR' || format('PR `#{0}`', github.event.pull_request.number)) || '' }}`)"
 on:
   push:
     branches:
@@ -10,8 +10,8 @@ on:
       - main
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  group: ${{ github.event_name == 'pull_request' && format('ci-pr-{0}', github.event.pull_request.number) || format('ci-main-{0}', github.run_id) }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' && !contains(github.event.pull_request.head.ref, 'release-please')  }}
 
 jobs:
   detect-context:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,5 +1,5 @@
 name: CI
-run-name: "CI (`${{ github.event_name == 'push' && 'main' || (contains(github.event.pull_request.head.ref, 'release-please') && 'Release-Please PR' || format('PR `#{0}`', github.event.pull_request.number)) || '' }}`)"
+run-name: "CI (${{ github.event_name == 'push' && '`main`' || (contains(github.event.pull_request.head.ref, 'release-please') && 'Release-Please PR' || format('PR `#{0}`', github.event.pull_request.number)) || '' }})"
 on:
   push:
     branches:

--- a/.github/workflows/release-please.yaml
+++ b/.github/workflows/release-please.yaml
@@ -20,7 +20,7 @@ jobs:
     environment: release-please
     permissions:
       contents: read
-      pull-requests: read
+      pull-requests: write
       id-token: write
       discussions: write
       issues: write
@@ -33,7 +33,7 @@ jobs:
     steps:
       - name: Run release-please (release only)
         id: release
-        uses: googleapis/release-please-action@16a9c90856f42705d54a6fda1823352bdc62cf38 # v4.4.0
+        uses: googleapis/release-please-action@45996ed1f6d02564a971a2fa1b5860e934307cf7 # v5.0.0
         with:
           token: ${{ secrets.SAM_RELEASE_PLEASE_TOKEN }}
           config-file: release-please-config.json
@@ -57,11 +57,11 @@ jobs:
           COMMIT_AUTHOR="$(gh api repos/${{ github.repository }}/commits/${{ github.sha }} --jq '.author.login')"
 
           if [[ -z "$COMMIT_AUTHOR" || "$COMMIT_AUTHOR" == "null" ]]; then
-            echo "Could not determine commit author for ${{ github.sha }}, skipping reviewer assignment."
+            echo "Could not determine commit author for `${{ github.sha }}`, skipping reviewer assignment."
             exit 0
           fi
 
-          echo "Adding $COMMIT_AUTHOR as reviewer on PR #$PR_NUMBER"
+          echo "Adding `COMMIT_AUTHOR` as reviewer on PR #`PR_NUMBER`"
           gh pr edit "$PR_NUMBER" --repo "${{ github.repository }}" --add-reviewer "$COMMIT_AUTHOR" || true
 
   post-process-release:


### PR DESCRIPTION


### What is the purpose of this change?

Fix CI concurrency behavior in the SAM community repository. The previous concurrency configuration (`github.workflow`-`github.ref`) caused unintended cancellation of push-to-main runs (e.g., release-please merges) and could also cancel in-progress CI on unrelated PR updates sharing the same ref.

### How was this change implemented?

Updated `.github/workflows/ci.yaml`:

- **Concurrency group**: Changed from `workflow-ref` to a conditional key — PR runs are grouped by PR number (`ci-pr-{number}`), while push-to-main runs use a unique run ID (`ci-main-{run_id}`) so they never cancel each other.
- **`cancel-in-progress`**: Changed from always `true` to only cancelling in-progress runs for `release-please` PRs. This prevents premature cancellation of main-branch CI and regular PR runs.
- **`run-name`**: Added a dynamic run name to make it easier to identify whether a workflow run was triggered by a push to main, a release-please PR, or a regular PR.

