### PR TITLE
fix(DATAGO-131321): enhance visualizer step cards

### DIFF
--- a/client/webui/frontend/src/lib/components/activities/VisualizerStepCard.tsx
+++ b/client/webui/frontend/src/lib/components/activities/VisualizerStepCard.tsx
@@ -7,6 +7,7 @@ import { useChatContext } from "@/lib/hooks";
 import { ImageSearchGrid } from "@/lib/components/research";
 import { NODE_COLORS } from "@/lib/constants";
 import type {
+    ArtifactInfo,
     ArtifactNotificationData,
     LLMCallData,
     LLMResponseToAgentData,
@@ -26,6 +27,10 @@ interface VisualizerStepCardProps {
     isHighlighted?: boolean;
     onClick?: () => void;
     variant?: "list" | "popover";
+    /** Custom artifact lookup by filename. Falls back to ChatContext artifacts when not provided. */
+    artifactLookup?: (filename: string) => ArtifactInfo | undefined;
+    /** Custom handler for viewing an artifact. Falls back to ChatContext side panel behavior when not provided. */
+    onViewArtifact?: (artifact: ArtifactInfo, version?: number) => void;
 }
 
 const LLMResponseToAgentDetails: FC<{ data: LLMResponseToAgentData }> = ({ data }) => {
@@ -77,7 +82,7 @@ const LLMResponseToAgentDetails: FC<{ data: LLMResponseToAgentData }> = ({ data 
     );
 };
 
-const VisualizerStepCard: FC<VisualizerStepCardProps> = ({ step, isHighlighted, onClick, variant = "list" }) => {
+const VisualizerStepCard: FC<VisualizerStepCardProps> = ({ step, isHighlighted, onClick, variant = "list", artifactLookup, onViewArtifact }) => {
     const { artifacts, setPreviewArtifact, setActiveSidePanelTab, setIsSidePanelCollapsed, navigateArtifactVersion } = useChatContext();
 
     const getStepIcon = () => {
@@ -242,28 +247,26 @@ const VisualizerStepCard: FC<VisualizerStepCardProps> = ({ step, isHighlighted, 
         const handleViewFile = async (e: MouseEvent) => {
             e.stopPropagation();
 
-            // Find the artifact by filename
-            const artifact = artifacts.find(a => a.filename === data.artifactName);
+            // Use custom lookup if provided, otherwise fall back to ChatContext artifacts
+            const artifact = artifactLookup ? artifactLookup(data.artifactName) : artifacts.find(a => a.filename === data.artifactName);
 
             if (artifact) {
-                // Switch to Files tab
-                setActiveSidePanelTab("files");
+                if (onViewArtifact) {
+                    // Delegate entirely to the consumer
+                    onViewArtifact(artifact, data.version);
+                } else {
+                    // Default ChatContext side panel behavior
+                    setActiveSidePanelTab("files");
+                    setIsSidePanelCollapsed(false);
+                    setPreviewArtifact(artifact);
 
-                // Expand side panel if collapsed
-                setIsSidePanelCollapsed(false);
-
-                // Set preview artifact to open the file (loads latest by default)
-                setPreviewArtifact(artifact);
-
-                // If a specific version is indicated in the workflow data, navigate to it
-                if (data.version !== undefined && data.version !== artifact.version) {
-                    // Wait a bit for the file to load, then navigate to the specific version
-                    setTimeout(() => {
-                        navigateArtifactVersion(artifact.filename, data.version!);
-                    }, 100);
+                    if (data.version !== undefined && data.version !== artifact.version) {
+                        setTimeout(() => {
+                            navigateArtifactVersion(artifact.filename, data.version!);
+                        }, 100);
+                    }
                 }
             }
-            // If artifact not found, do nothing (silent failure)
         };
 
         return (

--- a/client/webui/frontend/src/lib/components/activities/VisualizerStepCard.tsx
+++ b/client/webui/frontend/src/lib/components/activities/VisualizerStepCard.tsx
@@ -18,7 +18,7 @@ import type {
     WorkflowExecutionResultData,
     WorkflowExecutionStartData,
     WorkflowNodeExecutionResultData,
-    WorkflowNodeExecutionStartData,
+    WorkflowNodeExecutionStartData
 } from "@/lib/types";
 import { isString } from "@/lib/utils";
 

--- a/client/webui/frontend/src/stories/activities/VisualizerStepCard.stories.tsx
+++ b/client/webui/frontend/src/stories/activities/VisualizerStepCard.stories.tsx
@@ -1,5 +1,5 @@
 import type { Meta, StoryObj } from "@storybook/react-vite";
-import { expect, within } from "storybook/test";
+import { expect, fn, userEvent, within } from "storybook/test";
 
 import { VisualizerStepCard } from "@/lib/components/activities/VisualizerStepCard";
 
@@ -270,6 +270,50 @@ export const ArtifactNotification: Story = {
         const canvas = within(canvasElement);
         expect(canvas.getAllByText(/quarterly_report.pdf/)).toHaveLength(2);
         expect(canvas.getByText("View File")).toBeInTheDocument();
+    },
+};
+
+export const ArtifactNotificationWithCustomHandler: Story = {
+    args: {
+        step: {
+            id: "s-10b",
+            type: "AGENT_ARTIFACT_NOTIFICATION",
+            timestamp: ts,
+            title: "Artifact: quarterly_report.pdf",
+            data: {
+                artifactNotification: {
+                    artifactName: "quarterly_report.pdf",
+                    version: 3,
+                    mimeType: "application/pdf",
+                    description: "Q4 Sales Report — opened via custom handler",
+                },
+            },
+            ...baseStep,
+        },
+        artifactLookup: fn(() => ({
+            filename: "quarterly_report.pdf",
+            mime_type: "application/pdf",
+            size: 2048,
+            last_modified: new Date().toISOString(),
+            version: 1,
+        })),
+        onViewArtifact: fn(),
+    },
+    play: async ({ canvasElement, args }) => {
+        const canvas = within(canvasElement);
+
+        // "View File" button is rendered
+        const viewFileButton = canvas.getByText("View File");
+        expect(viewFileButton).toBeInTheDocument();
+
+        // Click "View File" — should use the custom props instead of ChatContext
+        await userEvent.click(viewFileButton);
+
+        expect(args.artifactLookup).toHaveBeenCalledWith("quarterly_report.pdf");
+        expect(args.onViewArtifact).toHaveBeenCalledWith(
+            expect.objectContaining({ filename: "quarterly_report.pdf" }),
+            3,
+        );
     },
 };
 

--- a/client/webui/frontend/src/stories/activities/VisualizerStepCard.test.tsx
+++ b/client/webui/frontend/src/stories/activities/VisualizerStepCard.test.tsx
@@ -74,6 +74,107 @@ describe("LLMResponseToAgentDetails expand/collapse (component extracted to modu
     });
 });
 
+const artifactStep = {
+    id: "s-artifact",
+    type: "AGENT_ARTIFACT_NOTIFICATION" as const,
+    timestamp: ts,
+    title: "Created Artifact - report.md",
+    data: {
+        artifactNotification: {
+            artifactName: "report.md",
+            version: 2,
+            mimeType: "text/markdown",
+            description: "A generated report",
+        },
+    },
+    ...baseStep,
+};
+
+const mockArtifact = {
+    filename: "report.md",
+    mime_type: "text/markdown",
+    size: 1024,
+    last_modified: new Date().toISOString(),
+    version: 1,
+};
+
+describe("VisualizerStepCard View File with custom props", () => {
+    test("uses artifactLookup and onViewArtifact when both are provided", async () => {
+        const artifactLookup = vi.fn().mockReturnValue(mockArtifact);
+        const onViewArtifact = vi.fn();
+
+        render(
+            <MemoryRouter>
+                <StoryProvider chatContextValues={{ sessionId: "test", artifacts: [] }}>
+                    <VisualizerStepCard step={artifactStep} artifactLookup={artifactLookup} onViewArtifact={onViewArtifact} />
+                </StoryProvider>
+            </MemoryRouter>
+        );
+
+        await userEvent.setup().click(screen.getByRole("button", { name: "View File" }));
+
+        expect(artifactLookup).toHaveBeenCalledWith("report.md");
+        expect(onViewArtifact).toHaveBeenCalledWith(mockArtifact, 2);
+    });
+
+    test("passes undefined version when step has no version", async () => {
+        const stepNoVersion = {
+            ...artifactStep,
+            data: {
+                artifactNotification: { artifactName: "report.md", mimeType: "text/markdown" },
+            },
+        };
+        const artifactLookup = vi.fn().mockReturnValue(mockArtifact);
+        const onViewArtifact = vi.fn();
+
+        render(
+            <MemoryRouter>
+                <StoryProvider chatContextValues={{ sessionId: "test", artifacts: [] }}>
+                    <VisualizerStepCard step={stepNoVersion} artifactLookup={artifactLookup} onViewArtifact={onViewArtifact} />
+                </StoryProvider>
+            </MemoryRouter>
+        );
+
+        await userEvent.setup().click(screen.getByRole("button", { name: "View File" }));
+
+        expect(onViewArtifact).toHaveBeenCalledWith(mockArtifact, undefined);
+    });
+
+    test("does not call onViewArtifact when artifactLookup returns undefined", async () => {
+        const artifactLookup = vi.fn().mockReturnValue(undefined);
+        const onViewArtifact = vi.fn();
+
+        render(
+            <MemoryRouter>
+                <StoryProvider chatContextValues={{ sessionId: "test", artifacts: [] }}>
+                    <VisualizerStepCard step={artifactStep} artifactLookup={artifactLookup} onViewArtifact={onViewArtifact} />
+                </StoryProvider>
+            </MemoryRouter>
+        );
+
+        await userEvent.setup().click(screen.getByRole("button", { name: "View File" }));
+
+        expect(artifactLookup).toHaveBeenCalledWith("report.md");
+        expect(onViewArtifact).not.toHaveBeenCalled();
+    });
+
+    test("falls back to ChatContext when props are not provided", async () => {
+        const setPreviewArtifact = vi.fn();
+
+        render(
+            <MemoryRouter>
+                <StoryProvider chatContextValues={{ sessionId: "test", artifacts: [mockArtifact], setPreviewArtifact }}>
+                    <VisualizerStepCard step={artifactStep} />
+                </StoryProvider>
+            </MemoryRouter>
+        );
+
+        await userEvent.setup().click(screen.getByRole("button", { name: "View File" }));
+
+        expect(setPreviewArtifact).toHaveBeenCalledWith(mockArtifact);
+    });
+});
+
 describe("VisualizerStepCard keyboard accessibility", () => {
     test("pressing Enter calls onClick when provided", () => {
         const onClick = vi.fn();


### PR DESCRIPTION
This pull request enhances the flexibility of the `VisualizerStepCard` component by allowing consumers to provide custom artifact lookup and artifact view handling logic. The main improvements are focused on making artifact interactions more customizable while maintaining backward compatibility with the default context behavior.

**Artifact interaction customization:**

* Added optional `artifactLookup` and `onViewArtifact` props to `VisualizerStepCardProps`, allowing consumers to override how artifacts are found and how viewing an artifact is handled. Falls back to the default ChatContext behavior if not provided.
* Updated the artifact view handler in `VisualizerStepCard` to use the custom `artifactLookup` and `onViewArtifact` if supplied; otherwise, it retains the original ChatContext-based logic for artifact preview and side panel navigation. [[1]](diffhunk://#diff-b4fc0eabe020ee6e1753df0f227923a18fbbcc1e93ff18cbb83f9ad8ba2801b6L245-R269) [[2]](diffhunk://#diff-b4fc0eabe020ee6e1753df0f227923a18fbbcc1e93ff18cbb83f9ad8ba2801b6L80-R85)

**Type and import updates:**

* Imported the `ArtifactInfo` type to support the new prop signatures.### What is the purpose of this change?

    Brief summary - what problem does this solve?

### How was this change implemented?

    High-level approach - what files/components changed and why?

### Key Design Decisions _(optional - delete if not applicable)_

    Why did you choose this approach over alternatives?

### How was this change tested?

- [ ] Manual testing: [describe scenarios]
- [ ] Unit tests: [new/modified tests]
- [ ] Integration tests: [if applicable]
- [ ] Known limitations: [what wasn't tested]

### Is there anything the reviewers should focus on/be aware of?

    Special attention areas, potential risks, or open questions
