### PR TITLE
fix(DATAGO-133559): Context usage indicator inflates after tasks with peer delegation

### DIFF
--- a/src/solace_agent_mesh/agent/sac/task_execution_context.py
+++ b/src/solace_agent_mesh/agent/sac/task_execution_context.py
@@ -42,6 +42,10 @@ class TaskExecutionContext:
         self.total_input_tokens: int = 0
         self.total_output_tokens: int = 0
         self.total_cached_input_tokens: int = 0
+        # Prompt tokens from the most recent agent LLM call — represents the
+        # peak context window occupancy for this task, unlike total_input_tokens
+        # which sums across every turn and inflates with each peer delegation.
+        self.last_input_tokens: int = 0
         self.token_usage_by_model: Dict[str, Dict[str, int]] = {}
         self.token_usage_by_source: Dict[str, Dict[str, int]] = {}
 
@@ -260,6 +264,8 @@ class TaskExecutionContext:
             self.total_input_tokens += input_tokens
             self.total_output_tokens += output_tokens
             self.total_cached_input_tokens += cached_input_tokens
+            if source == "agent":
+                self.last_input_tokens = input_tokens
 
             # Track by model
             if model not in self.token_usage_by_model:
@@ -301,6 +307,7 @@ class TaskExecutionContext:
                 "total_output_tokens": self.total_output_tokens,
                 "total_cached_input_tokens": self.total_cached_input_tokens,
                 "total_tokens": self.total_input_tokens + self.total_output_tokens,
+                "last_input_tokens": self.last_input_tokens,
                 "by_model": dict(self.token_usage_by_model),
                 "by_source": dict(self.token_usage_by_source),
             }

--- a/src/solace_agent_mesh/gateway/http_sse/routers/sessions.py
+++ b/src/solace_agent_mesh/gateway/http_sse/routers/sessions.py
@@ -1383,12 +1383,19 @@ async def get_session_context_usage(
         total_tasks = chat_task_count
         total_messages = chat_task_count * 2
 
+        # Peer subtasks (a2a_subtask_*) share this gateway session_id for
+        # observability but represent a different agent's internal work. Their
+        # token counts must not feed the current-agent context indicator, and
+        # their later start_time would otherwise trick the agent-switch filter
+        # below into treating the peer as the "current agent" whenever a peer
+        # completion is the most-recent row in the session.
         completed_tasks = (
             db.query(TaskModel)
             .filter(
                 TaskModel.session_id == session_id,
                 TaskModel.user_id == user_id,
                 TaskModel.total_input_tokens.isnot(None),
+                ~TaskModel.id.like("a2a_subtask_%"),
             )
             .order_by(desc(TaskModel.start_time))
             .all()
@@ -1467,8 +1474,16 @@ async def get_session_context_usage(
                 details = latest.token_usage_details or {}
                 current_tokens = int(details.get("post_compaction_remaining_tokens") or 0)
             else:
-                # currentContextTokens = latest task's input
-                current_tokens = latest.total_input_tokens or 0
+                # Context window occupancy = the last agent LLM call's prompt
+                # tokens, not the cumulative sum across turns. total_input_tokens
+                # inflates with every peer delegation (each follow-up turn adds
+                # the full growing context to the sum) and doesn't reflect what
+                # actually fills the window. Fall back to total_input_tokens
+                # only for historical rows written before last_input_tokens was
+                # tracked.
+                details = latest.token_usage_details or {}
+                last_input = details.get("last_input_tokens")
+                current_tokens = int(last_input) if last_input else (latest.total_input_tokens or 0)
 
             cached_tokens = real_latest.total_cached_input_tokens or 0
 


### PR DESCRIPTION
This pull request improves how the system tracks and reports prompt token usage for agent tasks, ensuring that the context window occupancy is accurately reflected rather than inflated by cumulative counts. The changes introduce a new metric for the most recent agent LLM call's prompt tokens and update the reporting and filtering logic to use this value, leading to more precise observability and user feedback.

**Token usage tracking improvements:**

* Added a new `last_input_tokens` attribute to `TaskExecutionContext` to record the prompt tokens from the most recent agent LLM call, representing the true context window occupancy for a task.
* Updated the `record_token_usage` method to set `last_input_tokens` only when the source is `"agent"`.
* Included `last_input_tokens` in the output of `get_token_usage_summary` for downstream reporting.

**Session and observability logic updates:**

* Modified the session context usage query to exclude peer subtasks (`a2a_subtask_*`) from context window calculations, preventing their token counts from affecting the current agent's indicators.
* Changed the logic for determining current context window occupancy to use `last_input_tokens` (falling back to `total_input_tokens` for older records), ensuring the value reflects the actual prompt size of the last agent LLM call.