### PR TITLE
fix(security): 2 improvements across 1 files

### DIFF
--- a/client/webui/frontend/src/auth/authCallback.tsx
+++ b/client/webui/frontend/src/auth/authCallback.tsx
@@ -9,12 +9,12 @@ function AuthCallback() {
         const refreshToken = params.get("refresh_token");
 
         if (samAccessToken) {
-            localStorage.setItem("sam_access_token", samAccessToken);
+            sessionStorage.setItem("sam_access_token", samAccessToken);
         }
         if (accessToken) {
-            localStorage.setItem("access_token", accessToken);
+            sessionStorage.setItem("access_token", accessToken);
             if (refreshToken) {
-                localStorage.setItem("refresh_token", refreshToken);
+                sessionStorage.setItem("refresh_token", refreshToken);
             }
             // Redirect to the main application page
             window.location.href = "/";


### PR DESCRIPTION
## Summary

fix(security): 2 improvements across 1 files

## Problem

**Severity**: `High` | **File**: `client/webui/frontend/src/auth/authCallback.tsx:L11`

The auth callback stores `access_token`, `sam_access_token`, and `refresh_token` in `localStorage`. Any successful XSS in the application (or malicious third-party script execution) can read and exfiltrate these long-lived credentials, enabling account/session takeover.

## Solution

Avoid storing bearer/refresh tokens in `localStorage`. Prefer secure, HttpOnly, SameSite cookies managed by the backend, or short-lived in-memory tokens with a hardened refresh flow. If browser storage is unavoidable, use `sessionStorage`, minimize token lifetime/scope, and enforce strong CSP + XSS defenses.

## Changes

- `client/webui/frontend/src/auth/authCallback.tsx` (modified)