### PR TITLE
fix(DATAGO-133911): SSE event replay silently disabled — gateway logs "Database not configured" despite SQL session_service

### DIFF
--- a/src/solace_agent_mesh/agent/adk/services.py
+++ b/src/solace_agent_mesh/agent/adk/services.py
@@ -471,6 +471,95 @@ class FilteringSessionService(BaseSessionService):
         """Delegate to wrapped service."""
         return await self._wrapped.append_event(session, event)
 
+
+class RetryingSessionService(BaseSessionService):
+    """Wrapper that retries append_event on stale-session race conditions.
+
+    The Google ADK Runner's internal loop calls session_service.append_event
+    directly (google.adk.runners._exec_with_plugin), bypassing
+    append_event_with_retry. When another writer (peer-agent delegation,
+    compaction, concurrent task) bumps the storage row's update_timestamp
+    between two appends, the in-memory session's last_update_time lags by
+    microseconds and ADK's strict `>` check raises a stale-session ValueError
+    that aborts the entire task.
+
+    This wrapper applies the same retry-and-refetch loop as
+    append_event_with_retry to every append_event call, so the ADK runner's
+    internal appends are protected too.
+    """
+
+    def __init__(self, wrapped_service: BaseSessionService):
+        self._wrapped = wrapped_service
+
+    async def get_session(
+        self,
+        *,
+        app_name: str,
+        user_id: str,
+        session_id: str,
+        config: Optional[Any] = None,
+    ) -> Optional[ADKSession]:
+        return await self._wrapped.get_session(
+            app_name=app_name,
+            user_id=user_id,
+            session_id=session_id,
+            config=config,
+        )
+
+    async def create_session(
+        self,
+        *,
+        app_name: str,
+        user_id: str,
+        state: Optional[dict[str, Any]] = None,
+        session_id: Optional[str] = None,
+    ) -> ADKSession:
+        return await self._wrapped.create_session(
+            app_name=app_name,
+            user_id=user_id,
+            state=state,
+            session_id=session_id,
+        )
+
+    async def delete_session(
+        self,
+        *,
+        app_name: str,
+        user_id: str,
+        session_id: str,
+    ) -> None:
+        return await self._wrapped.delete_session(
+            app_name=app_name,
+            user_id=user_id,
+            session_id=session_id,
+        )
+
+    async def list_sessions(
+        self,
+        *,
+        app_name: str,
+        user_id: Optional[str] = None,
+    ) -> Any:
+        return await self._wrapped.list_sessions(
+            app_name=app_name,
+            user_id=user_id,
+        )
+
+    async def append_event(
+        self,
+        session: ADKSession,
+        event: ADKEvent,
+    ) -> ADKEvent:
+        return await append_event_with_retry(
+            session_service=self._wrapped,
+            session=session,
+            event=event,
+            app_name=session.app_name,
+            user_id=session.user_id,
+            session_id=session.id,
+        )
+
+
 def create_session_service_from_config(
     config,
     log_identifier: str = "[SessionService]",
@@ -559,6 +648,11 @@ def initialize_session_service(component) -> BaseSessionService:
         run_db_migrations=True,
         migration_component=component,
     )
+
+    # Always wrap with RetryingSessionService so the ADK Runner's internal
+    # append_event calls (which bypass append_event_with_retry) survive
+    # stale-session races caused by concurrent writers on the same session row.
+    base_service = RetryingSessionService(base_service)
 
     # Check if auto-summarization is enabled from component config.
     # Use getattr with a default so this works when called from components

--- a/src/solace_agent_mesh/gateway/http_sse/routers/sse.py
+++ b/src/solace_agent_mesh/gateway/http_sse/routers/sse.py
@@ -11,7 +11,7 @@ from fastapi import APIRouter, Depends, Request as FastAPIRequest, HTTPException
 from sse_starlette.sse import EventSourceResponse
 
 from ....gateway.http_sse.sse_manager import SSEManager
-from ....gateway.http_sse.dependencies import get_sse_manager, get_user_id, SessionLocal, short_lived_session, _is_connection_error
+from ....gateway.http_sse.dependencies import get_sse_manager, get_user_id, short_lived_session, _is_connection_error
 from ....gateway.http_sse.repository.task_repository import TaskRepository
 
 log = logging.getLogger(__name__)
@@ -36,8 +36,10 @@ def _prepare_replay_events(
     Returns:
         List of event dictionaries with 'event' type and 'data' payload ready for SSE.
     """
+    from ....gateway.http_sse.dependencies import SessionLocal
+
     replay_events = []
-    
+
     if SessionLocal is None:
         log.warning("%sDatabase not configured, cannot replay events", log_prefix)
         return replay_events
@@ -124,6 +126,8 @@ def _get_task_info(task_id: str, log_prefix: str) -> Optional[bool]:
     Raises:
         HTTPException: 503 if database connection is unavailable during the query.
     """
+    from ....gateway.http_sse.dependencies import SessionLocal
+
     if SessionLocal is None:
         log.debug("%sDatabase not configured", log_prefix)
         return None


### PR DESCRIPTION
Also fixes https://sol-jira.atlassian.net/browse/DATAGO-133912

This pull request introduces a new retrying wrapper for session services to improve reliability during concurrent session updates, and refactors some import patterns in the SSE router to avoid circular dependencies and unnecessary imports. The most important changes are grouped below:

**Session Service Reliability Improvements:**

* Added a new `RetryingSessionService` class in `src/solace_agent_mesh/agent/adk/services.py` that wraps any `BaseSessionService` and transparently retries `append_event` calls on stale-session race conditions, ensuring that internal ADK runner appends are also protected.
* Updated `initialize_session_service` to always wrap the base session service with `RetryingSessionService`, so all session appends benefit from automatic retry logic.

**SSE Router Import Refactoring:**

* Removed the direct import of `SessionLocal` from the top of `src/solace_agent_mesh/gateway/http_sse/routers/sse.py` to prevent unnecessary or circular imports. It is now imported locally within functions where needed.
* Added local imports of `SessionLocal` inside `_prepare_replay_events` and `_get_task_info` functions in `src/solace_agent_mesh/gateway/http_sse/routers/sse.py` for safer and more targeted usage. [[1]](diffhunk://#diff-e2999058ace134a5961032b0806e510fa994c678f3075b90935fd80311a945beR39-R40) [[2]](diffhunk://#diff-e2999058ace134a5961032b0806e510fa994c678f3075b90935fd80311a945beR129-R130)