### PR TITLE
fix(DATAGO-133916 ): extract_content_from_artifact spends 10-14 min per call summarising 35-66KB JSON

### DIFF
--- a/src/solace_agent_mesh/agent/sac/app.py
+++ b/src/solace_agent_mesh/agent/sac/app.py
@@ -165,6 +165,10 @@ class ExtractContentConfig(SamConfigBase):
         default=None,
         description="Specifies the LLM for extraction. String (ADK LLMRegistry name) or dict (LiteLlm config). Defaults to agent's LLM.",
     )
+    timeout_seconds: Optional[int] = Field(
+        default=300,
+        description="HTTP timeout (seconds) for the internal LLM call. The agent's default LiteLlm timeout (120s) is too short for extraction prompts that legitimately need 130-300s of generation time on richer artifacts (e.g. structured Chatter feeds). When the natural completion exceeds 120s, the litellm client times out and the configured num_retries kick in, producing 4-7 sequential retries while each upstream call eventually succeeds — total wall time ~840s. Set to null to inherit the LiteLlm wrapper default (120s).",
+    )
 
 
 class McpProcessingConfig(SamConfigBase):

--- a/src/solace_agent_mesh/agent/tools/builtin_artifact_tools.py
+++ b/src/solace_agent_mesh/agent/tools/builtin_artifact_tools.py
@@ -775,6 +775,7 @@ async def extract_content_from_artifact(
             "supported_binary_mime_types", []
         )
         model_config_for_extraction = extraction_config.get("model")
+        extraction_timeout_seconds = extraction_config.get("timeout_seconds", 300)
     except Exception as e:
         log.exception("%s Error retrieving tool configuration: %s", log_identifier, e)
         return ToolResult.error(
@@ -1013,7 +1014,28 @@ Based on analyzing the CSV data, I found 102 records containing 'Employee' in th
     )
 
     extracted_content_str = ""
+    # Override the per-call HTTP timeout and disable client-side retries for the
+    # internal LLM call. The agent's main LiteLlm carries timeout=120s in its
+    # _model_config, which is too short for extraction prompts that legitimately
+    # need 130-300s on richer artifacts (e.g. structured Chatter feeds). When the
+    # natural completion exceeds 120s, the litellm client times out and num_retries
+    # fires another full attempt against the proxy — observed in production as
+    # 4-7 sequential 120-180s upstream calls totalling ~840s wall time. The
+    # override is a per-async-task ContextVar, so it does not affect the agent's
+    # main reasoning loop or any concurrent task.
+    from ..adk.models.lite_llm import set_model_override, get_model_override
+    timeout_override: dict[str, Any] | None = None
+    if extraction_timeout_seconds:
+        timeout_override = {
+            "timeout": extraction_timeout_seconds,
+            "num_retries": 0,
+        }
+    previous_override = get_model_override()
     try:
+        if timeout_override is not None:
+            merged_override = dict(previous_override or {})
+            merged_override.update(timeout_override)
+            set_model_override(merged_override)
         log.info(
             "%s Executing internal LLM call for extraction. Goal: %s",
             log_identifier,
@@ -1165,6 +1187,9 @@ Based on analyzing the CSV data, I found 102 records containing 'Employee' in th
             f"The LLM failed to process the artifact content for your goal '{extraction_goal}'. Error: {e}",
             data={"filename": filename, "version_requested": str(version)}
         )
+    finally:
+        if timeout_override is not None:
+            set_model_override(previous_override)
 
     extracted_content_bytes = extracted_content_str.encode("utf-8")
     extracted_content_size_bytes = len(extracted_content_bytes)

--- a/src/solace_agent_mesh/agent/tools/builtin_artifact_tools.py
+++ b/src/solace_agent_mesh/agent/tools/builtin_artifact_tools.py
@@ -1868,7 +1868,31 @@ apply_embed_and_create_artifact_tool_def = BuiltinTool(
 extract_content_from_artifact_tool_def = BuiltinTool(
     name="extract_content_from_artifact",
     implementation=extract_content_from_artifact,
-    description="Loads an existing artifact, uses an internal LLM to process its content based on an 'extraction_goal,' and manages the output by returning it or saving it as a new artifact. IMPORTANT: If the tool returns an error status (e.g., 'error_encoding_failed', 'error_artifact_not_found'), you MUST relay this error to the user - do NOT attempt to generate or fabricate data. The tool will return a 'message_to_llm' field explaining the error.",
+    description=(
+        "Use an internal LLM to summarise, paraphrase, or qualitatively extract "
+        "information from a TEXT-BASED artifact (PDF, Markdown, plain text, "
+        "transcripts, HTML, source code, meeting notes, prose-style content). "
+        "Also handles supported binary types (e.g. images) when configured. "
+        "Each call makes one LLM request which may take 30s to several minutes "
+        "depending on artifact size and the LLM's generation rate.\n\n"
+        "USE WHEN: the goal is qualitative on unstructured/natural-language "
+        "content — e.g. \"summarise the meeting notes\", \"extract action items "
+        "from the transcript\", \"find references to product X in the doc\", "
+        "\"describe what is in this image\".\n\n"
+        "DO NOT USE for STRUCTURED data (JSON, CSV, TSV, YAML, XML, JSON Lines, "
+        "API response payloads, tabular query results). Running an LLM over "
+        "structured data to count/filter/aggregate fields is slow, wastes "
+        "tokens, and is unreliable compared to deterministic parsing. For "
+        "structured data, prefer (in order): a domain-specific tool that "
+        "already returns the field you need, query_data_with_sql for tabular "
+        "files when available, or load_artifact and reason over the parsed "
+        "content directly.\n\n"
+        "IMPORTANT: If the tool returns an error status (e.g. "
+        "'error_encoding_failed', 'error_artifact_not_found', "
+        "'error_llm_call_failed'), you MUST relay this error to the user - do "
+        "NOT attempt to generate or fabricate data. The tool returns a "
+        "'message_to_llm' field explaining the error."
+    ),
     category="artifact_management",
     category_name=CATEGORY_NAME,
     category_description=CATEGORY_DESCRIPTION,
@@ -1882,7 +1906,16 @@ extract_content_from_artifact_tool_def = BuiltinTool(
             ),
             "extraction_goal": adk_types.Schema(
                 type=adk_types.Type.STRING,
-                description="Natural language instruction for the LLM on what to extract or how to transform the content. May contain embeds.",
+                description=(
+                    "Natural-language instruction describing the qualitative "
+                    "extraction or transformation to perform on the artifact "
+                    "(e.g. 'summarise the meeting notes', 'list action items', "
+                    "'find every mention of product X with surrounding context'). "
+                    "Avoid goals that ask for exhaustive structured output over "
+                    "many records (e.g. 'for each of the 200 rows, extract every "
+                    "field') — those should use deterministic parsing or "
+                    "query_data_with_sql instead. May contain embeds."
+                ),
             ),
             "version": adk_types.Schema(
                 type=adk_types.Type.STRING,

--- a/src/solace_agent_mesh/agent/tools/builtin_artifact_tools.py
+++ b/src/solace_agent_mesh/agent/tools/builtin_artifact_tools.py
@@ -1014,6 +1014,28 @@ Based on analyzing the CSV data, I found 102 records containing 'Employee' in th
     )
 
     extracted_content_str = ""
+    # Surface a "starting" progress update so the user sees the agent is working
+    # during the long internal LLM call (typically 30-300s). Without this, the
+    # tool is opaque between tool_invocation_start and tool_result.
+    a2a_context = tool_context.state.get("a2a_context") if tool_context.state else None
+    if a2a_context and hasattr(host_component, "_publish_agent_status_signal_update"):
+        try:
+            artifact_kb = (
+                len(source_artifact_content_bytes) // 1024
+                if source_artifact_content_bytes else 0
+            )
+            await host_component._publish_agent_status_signal_update(
+                f"Extracting content from `{filename}` "
+                f"(~{artifact_kb}KB)... this can take 1-3 minutes for larger artifacts.",
+                a2a_context,
+            )
+        except Exception as e:
+            log.debug(
+                "%s Failed to publish extract-start status update: %s",
+                log_identifier,
+                e,
+            )
+
     # Override the per-call HTTP timeout and disable client-side retries for the
     # internal LLM call. The agent's main LiteLlm carries timeout=120s in its
     # _model_config, which is too short for extraction prompts that legitimately

--- a/tests/unit/agent/tools/test_builtin_artifact_tools.py
+++ b/tests/unit/agent/tools/test_builtin_artifact_tools.py
@@ -409,6 +409,98 @@ class TestExtractContentUsesHostComponentLlm:
             mock_tool_context_with_host._invocation_context.agent.host_component.get_lite_llm_model.assert_called_once()
 
 
+class TestExtractContentProgressStatus:
+    """Tests for the agent_progress_update emitted before the internal LLM call."""
+
+    def _make_tool_context(self, with_a2a_context: bool):
+        mock_context = Mock()
+        mock_inv = Mock()
+        mock_inv.artifact_service = AsyncMock()
+        mock_inv.app_name = "test_app"
+        mock_inv.user_id = "test_user"
+
+        mock_llm = Mock()
+        mock_llm.model = "gpt-4"
+        mock_host = Mock()
+        mock_host.get_lite_llm_model = Mock(return_value=mock_llm)
+        mock_host._publish_agent_status_signal_update = AsyncMock()
+
+        mock_agent = Mock()
+        mock_agent.host_component = mock_host
+        mock_inv.agent = mock_agent
+        mock_context._invocation_context = mock_inv
+
+        # tool_context.state is the ADK state proxy; we use a plain dict.
+        mock_context.state = (
+            {"a2a_context": {"logical_task_id": "task-123", "contextId": "ctx-1"}}
+            if with_a2a_context else {}
+        )
+        return mock_context
+
+    @pytest.mark.asyncio
+    async def test_publishes_status_when_a2a_context_present(self):
+        """A status update fires before the LLM call when an a2a_context is on tool_context.state."""
+        ctx = self._make_tool_context(with_a2a_context=True)
+        with patch(
+            "solace_agent_mesh.agent.tools.builtin_artifact_tools.load_artifact_content_or_metadata"
+        ) as mock_load, patch(
+            "solace_agent_mesh.agent.tools.builtin_artifact_tools.get_original_session_id"
+        ) as mock_session:
+            # 50KB artifact so the status text reports a non-zero size hint
+            mock_load.return_value = {
+                "status": "success",
+                "content": "X",
+                "mime_type": "text/plain",
+                "raw_bytes": b"X" * (50 * 1024),
+                "version": 0,
+            }
+            mock_session.return_value = "session123"
+            try:
+                await extract_content_from_artifact(
+                    filename="chatter_feed.json",
+                    extraction_goal="summarise",
+                    tool_context=ctx,
+                )
+            except Exception:
+                pass
+
+        publish = ctx._invocation_context.agent.host_component._publish_agent_status_signal_update
+        publish.assert_called_once()
+        status_text, a2a_context = publish.call_args.args
+        assert "chatter_feed.json" in status_text
+        assert "50KB" in status_text  # 50 * 1024 bytes // 1024
+        assert a2a_context["logical_task_id"] == "task-123"
+
+    @pytest.mark.asyncio
+    async def test_skipped_when_no_a2a_context(self):
+        """No status update fires when tool_context.state has no a2a_context."""
+        ctx = self._make_tool_context(with_a2a_context=False)
+        with patch(
+            "solace_agent_mesh.agent.tools.builtin_artifact_tools.load_artifact_content_or_metadata"
+        ) as mock_load, patch(
+            "solace_agent_mesh.agent.tools.builtin_artifact_tools.get_original_session_id"
+        ) as mock_session:
+            mock_load.return_value = {
+                "status": "success",
+                "content": "X",
+                "mime_type": "text/plain",
+                "raw_bytes": b"X",
+                "version": 0,
+            }
+            mock_session.return_value = "session123"
+            try:
+                await extract_content_from_artifact(
+                    filename="x.txt",
+                    extraction_goal="summarise",
+                    tool_context=ctx,
+                )
+            except Exception:
+                pass
+
+        publish = ctx._invocation_context.agent.host_component._publish_agent_status_signal_update
+        publish.assert_not_called()
+
+
 class TestDeleteArtifact:
     """Test cases for delete_artifact function."""
 


### PR DESCRIPTION
This pull request improves the reliability and user experience of the artifact content extraction tool by allowing longer LLM call timeouts and providing better progress feedback for long-running operations. The main changes are grouped below:

**Timeout configuration and handling:**

* Added a new `timeout_seconds` configuration option to `ExtractContentConfig`, allowing customization of the HTTP timeout for internal LLM calls (defaulting to 300 seconds, up from the previous 120 seconds) to better handle large or complex artifacts.
* Updated the extraction tool to read and apply the `timeout_seconds` value from the configuration, ensuring that long-running LLM calls do not trigger unnecessary retries and excessive total wait times.
* Implemented logic to override the per-call LLM timeout and disable client-side retries during extraction, using a context variable to ensure these settings are scoped to the extraction task and do not affect other agent operations. The previous override is restored after the call completes. [[1]](diffhunk://#diff-6873b498ddc39bb547f26d7667f87db74c7b7c199410fc652fa2d7f974798a35R1017-R1060) [[2]](diffhunk://#diff-6873b498ddc39bb547f26d7667f87db74c7b7c199410fc652fa2d7f974798a35R1212-R1214)

**User feedback improvements:**

* Added a progress update at the start of extraction to inform users that the agent is working on a potentially long-running task, improving transparency for operations that may take 1–3 minutes or longer.