### PR TITLE
fix(DATAGO-133950): forward unknown attrs through ADK's session-service wrappers

### DIFF
--- a/src/solace_agent_mesh/agent/adk/services.py
+++ b/src/solace_agent_mesh/agent/adk/services.py
@@ -369,6 +369,14 @@ class FilteringSessionService(BaseSessionService):
         """
         self._wrapped = wrapped_service
 
+    def __getattr__(self, name: str) -> Any:
+        # Forward backend-specific attributes (e.g. DatabaseSessionService's
+        # database_session_factory, which enterprise's SecretSessionManager
+        # reaches in for) that aren't part of BaseSessionService. Only fires
+        # on lookup miss, so the explicit wrapper methods above still take
+        # precedence and add their filtering/retry behaviour.
+        return getattr(self._wrapped, name)
+
     async def get_session(
         self,
         *,
@@ -490,6 +498,14 @@ class RetryingSessionService(BaseSessionService):
 
     def __init__(self, wrapped_service: BaseSessionService):
         self._wrapped = wrapped_service
+
+    def __getattr__(self, name: str) -> Any:
+        # Forward backend-specific attributes (e.g. DatabaseSessionService's
+        # database_session_factory, which enterprise's SecretSessionManager
+        # reaches in for) that aren't part of BaseSessionService. Only fires
+        # on lookup miss, so the explicit wrapper methods above still take
+        # precedence and add their retry behaviour.
+        return getattr(self._wrapped, name)
 
     async def get_session(
         self,

--- a/tests/unit/agent/adk/test_auto_summarization_services.py
+++ b/tests/unit/agent/adk/test_auto_summarization_services.py
@@ -10,6 +10,7 @@ from google.genai import types as adk_types
 from solace_agent_mesh.agent.adk.services import (
     _filter_session_by_latest_compaction,
     FilteringSessionService,
+    RetryingSessionService,
 )
 
 
@@ -411,3 +412,67 @@ class TestFilteringSessionService:
 
         wrapped.append_event.assert_called_once_with(session, event)
         assert result == event
+
+
+class TestSessionServiceWrapperPassthrough:
+    """Regression tests: wrappers must expose backend-specific attributes.
+
+    Two known consumers reach past BaseSessionService into DatabaseSessionService
+    instance attrs:
+
+    * ``database_session_factory`` - read by enterprise's SecretSessionManager;
+      missing it crashes the agent at startup with AttributeError.
+    * ``db_engine`` - probed via hasattr() by app_base._get_db_engines_from_components
+      to register the agent DB in the broker-level health check. Missing it
+      silently disables the health check rather than raising.
+
+    Both must reach through the wrappers.
+    """
+
+    def test_filtering_service_forwards_database_session_factory(self):
+        wrapped = Mock()
+        wrapped.database_session_factory = "sentinel-factory"
+
+        service = FilteringSessionService(wrapped)
+
+        assert service.database_session_factory == "sentinel-factory"
+
+    def test_retrying_service_forwards_database_session_factory(self):
+        wrapped = Mock()
+        wrapped.database_session_factory = "sentinel-factory"
+
+        service = RetryingSessionService(wrapped)
+
+        assert service.database_session_factory == "sentinel-factory"
+
+    def test_stacked_wrappers_forward_database_session_factory(self):
+        """Filtering(Retrying(SQL)) - the actual production composition."""
+        wrapped = Mock()
+        wrapped.database_session_factory = "sentinel-factory"
+
+        service = FilteringSessionService(RetryingSessionService(wrapped))
+
+        assert service.database_session_factory == "sentinel-factory"
+
+    def test_wrappers_forward_db_engine_for_health_check_probe(self):
+        """app_base uses hasattr(svc, 'db_engine') - must return True through wrappers."""
+        wrapped = Mock(spec=["db_engine"])
+        wrapped.db_engine = "sentinel-engine"
+
+        retrying = RetryingSessionService(wrapped)
+        filtering = FilteringSessionService(wrapped)
+        stacked = FilteringSessionService(RetryingSessionService(wrapped))
+
+        for service in (retrying, filtering, stacked):
+            assert hasattr(service, "db_engine")
+            assert service.db_engine == "sentinel-engine"
+
+    def test_passthrough_raises_when_underlying_service_lacks_attribute(self):
+        """A truly missing attribute must still raise AttributeError, not None."""
+        # InMemorySessionService has no database_session_factory; the wrappers
+        # must surface the AttributeError rather than swallow it.
+        wrapped = Mock(spec=[])  # empty spec -> no attributes at all
+        service = RetryingSessionService(wrapped)
+
+        with pytest.raises(AttributeError):
+            _ = service.database_session_factory


### PR DESCRIPTION
## Summary

`RetryingSessionService` and `FilteringSessionService` only proxy the explicit `BaseSessionService` API, hiding `DatabaseSessionService` instance attrs that two consumers rely on. Add a narrow `__getattr__` to both wrappers so unknown attribute lookups fall through to the wrapped service.

## Why

Two consumers reach past `BaseSessionService` into the underlying SQL service:

| Consumer | Attribute | Failure mode |
|---|---|---|
| Enterprise `SecretSessionManager.__init__` (`solace_agent_mesh_enterprise/auth/secret_session_manager.py:34`) | `database_session_factory` | **Hard** — `AttributeError` blocks agent startup whenever a SQL `session_service` is configured. This is the staging failure. |
| `common/app_base._get_db_engines_from_components` (line 167) | `db_engine` | **Silent** — `hasattr()` returns `False` through the wrapper, so the agent DB has been quietly dropping out of the broker-level DB health check ever since #1458 landed. |

Staging stack trace from the enterprise pod:

```
File "/opt/venv/lib/python3.11/site-packages/solace_agent_mesh_enterprise/auth/secret_session_manager.py", line 34, in __init__
    self._session_factory = self._session_service.database_session_factory
AttributeError: 'RetryingSessionService' object has no attribute 'database_session_factory'
```

## Fix

Single `__getattr__` on each wrapper that delegates to `self._wrapped`. `__getattr__` only fires on attribute-lookup miss, so the explicit wrapper methods (filtering / retry) still take precedence and add their behaviour; only attributes the wrapper itself doesn't define hit the passthrough. Genuinely missing attributes still raise `AttributeError`.

## Audit of other consumers

I swept the codebase for any other consumer reading non-`BaseSessionService` attributes off the session service. None found beyond the two above:

- `agent/protocol/event_handlers.py:2870`, `agent/adk/runner.py:1602/1618` — standard API calls + truthy checks only.
- `gateway/http_sse/dependencies.py:get_adk_session_service` — uses `create_session_service_from_config` directly without wrapping (#1458's design), so its consumers see the raw `DatabaseSessionService`.
- `gateway/http_sse/routers/sessions.py` and `routers/artifacts.py` — different `session_service` (gateway chat-session metadata module, not ADK).

## Test plan

- [x] New regression tests in `tests/unit/agent/adk/test_auto_summarization_services.py`:
  - `database_session_factory` reachable through `FilteringSessionService`
  - `database_session_factory` reachable through `RetryingSessionService`
  - `database_session_factory` reachable through stacked `Filtering(Retrying(SQL))` (the production composition)
  - `db_engine` reachable via `hasattr()` probe through every wrapper combo (the silent-failure case)
  - Genuinely missing attributes still raise `AttributeError`
- [x] All 17 tests in the file pass locally.
- [x] Live-reproduced the exact `service.database_session_factory` lookup that enterprise's `SecretSessionManager` performs — works through the production wrapper stack.
- [ ] Verify on staging after merge that the enterprise pod starts and that the agent DB now appears in the broker DB health check.