### PR TITLE
fix(DATAGO-133967): SSE viz queue overflow under high-fan-out tasks — UI progress freezes/skips events

### DIFF
--- a/src/solace_agent_mesh/gateway/http_sse/app.py
+++ b/src/solace_agent_mesh/gateway/http_sse/app.py
@@ -72,7 +72,7 @@ class WebUIBackendApp(BaseGatewayApp):
             "name": "sse_max_queue_size",
             "required": False,
             "type": "integer",
-            "default": 200,
+            "default": 1000,
             "description": "Maximum size of the SSE connection queues. Adjust based on expected load.",
         },
         {

--- a/src/solace_agent_mesh/gateway/http_sse/component.py
+++ b/src/solace_agent_mesh/gateway/http_sse/component.py
@@ -42,27 +42,27 @@ class _CompactionFutureEntry(TypedDict):
     expected_agent_id: str | None
 
 
-def _payload_excluded_from_visualization(payload: Any) -> bool:
-    """Mirror of routers.visualization._include_for_visualization but operating
-    on the raw payload dict before SSE serialization, so we can skip fan-out
-    entirely instead of building+dumping+parsing for every subscriber."""
+def _should_include_for_visualization(payload: Any) -> bool:
+    """Inspect the raw payload dict before SSE serialization so excluded
+    messages can be short-circuited instead of building+dumping+parsing
+    them for every subscriber."""
     if not isinstance(payload, dict):
-        return False
+        return True
     params = payload.get("params")
     if not isinstance(params, dict):
-        return False
+        return True
     message = params.get("message")
     if not isinstance(message, dict):
-        return False
+        return True
     metadata = message.get("metadata")
     if not isinstance(metadata, dict):
-        return False
+        return True
     setting = metadata.get("visualization")
-    if isinstance(setting, str):
-        return setting.lower() == "false"
     if isinstance(setting, bool):
-        return setting is False
-    return False
+        return setting is not False
+    if isinstance(setting, str):
+        return setting.lower() != "false"
+    return True
 
 try:
     from google.adk.artifacts import BaseArtifactService
@@ -1070,10 +1070,10 @@ class WebUIBackendComponent(BaseGatewayComponent):
                         continue
 
                     log.debug("%s [VIZ_DATA_RAW] Topic: %s", log_id_prefix, topic)
-                    event_details_for_owner = self._infer_visualization_event_details(
+                    event_details = self._infer_visualization_event_details(
                         topic, payload_dict
                     )
-                    task_id_for_context = event_details_for_owner.get("task_id")
+                    task_id_for_context = event_details.get("task_id")
                     message_owner_id = None
                     if task_id_for_context:
                         root_task_id = task_id_for_context.split(":", 1)[0]
@@ -1115,7 +1115,7 @@ class WebUIBackendComponent(BaseGatewayComponent):
                                         message_owner_id,
                                         task_id_for_context,
                                     )
-                    if _payload_excluded_from_visualization(payload_dict):
+                    if not _should_include_for_visualization(payload_dict):
                         continue
 
                     # Build + serialize once per A2A message; the resulting bytes
@@ -1127,26 +1127,25 @@ class WebUIBackendComponent(BaseGatewayComponent):
                         "event_type": "a2a_message",
                         "timestamp": datetime.now(timezone.utc).isoformat(),
                         "solace_topic": topic,
-                        "direction": event_details_for_owner["direction"],
-                        "source_entity": event_details_for_owner["source_entity"],
-                        "target_entity": event_details_for_owner["target_entity"],
-                        "message_id": event_details_for_owner["message_id"],
-                        "task_id": event_details_for_owner["task_id"],
-                        "payload_summary": event_details_for_owner["payload_summary"],
+                        "direction": event_details["direction"],
+                        "source_entity": event_details["source_entity"],
+                        "target_entity": event_details["target_entity"],
+                        "message_id": event_details["message_id"],
+                        "task_id": event_details["task_id"],
+                        "payload_summary": event_details["payload_summary"],
                         "full_payload": payload_dict,
-                        "debug_type": event_details_for_owner["debug_type"],
+                        "debug_type": event_details["debug_type"],
                     }
                     try:
                         viz_msg = {
                             "event": "a2a_message",
                             "data": json.dumps(viz_event_payload),
                         }
-                    except Exception as ser_err:
-                        log.error(
-                            "%s Failed to serialize viz message for topic %s: %s",
+                    except (TypeError, ValueError):
+                        log.exception(
+                            "%s Failed to serialize viz message for topic %s",
                             log_id_prefix,
                             topic,
-                            ser_err,
                         )
                         continue
 

--- a/src/solace_agent_mesh/gateway/http_sse/component.py
+++ b/src/solace_agent_mesh/gateway/http_sse/component.py
@@ -41,6 +41,29 @@ class _CompactionFutureEntry(TypedDict):
     future: asyncio.Future
     expected_agent_id: str | None
 
+
+def _payload_excluded_from_visualization(payload: Any) -> bool:
+    """Mirror of routers.visualization._include_for_visualization but operating
+    on the raw payload dict before SSE serialization, so we can skip fan-out
+    entirely instead of building+dumping+parsing for every subscriber."""
+    if not isinstance(payload, dict):
+        return False
+    params = payload.get("params")
+    if not isinstance(params, dict):
+        return False
+    message = params.get("message")
+    if not isinstance(message, dict):
+        return False
+    metadata = message.get("metadata")
+    if not isinstance(metadata, dict):
+        return False
+    setting = metadata.get("visualization")
+    if isinstance(setting, str):
+        return setting.lower() == "false"
+    if isinstance(setting, bool):
+        return setting is False
+    return False
+
 try:
     from google.adk.artifacts import BaseArtifactService
 except ImportError:
@@ -152,7 +175,7 @@ class WebUIBackendComponent(BaseGatewayComponent):
             log.error("%s Failed to retrieve configuration: %s", self.log_identifier, e)
             raise ValueError(f"Configuration retrieval error: {e}") from e
 
-        self.sse_max_queue_size = self.get_config("sse_max_queue_size", 200)
+        self.sse_max_queue_size = self.get_config("sse_max_queue_size", 1000)
         sse_buffer_max_age_seconds = self.get_config("sse_buffer_max_age_seconds", 600)
 
         self.sse_event_buffer = SSEEventBuffer(
@@ -1092,6 +1115,41 @@ class WebUIBackendComponent(BaseGatewayComponent):
                                         message_owner_id,
                                         task_id_for_context,
                                     )
+                    if _payload_excluded_from_visualization(payload_dict):
+                        continue
+
+                    # Build + serialize once per A2A message; the resulting bytes
+                    # are identical for every eligible stream. Doing this per-stream
+                    # under the viz lock made event-loop CPU scale as O(streams ×
+                    # payload_size) and was observed to overflow per-stream queues
+                    # under high-fan-out tasks (DATAGO incident, 2026-04-26).
+                    viz_event_payload = {
+                        "event_type": "a2a_message",
+                        "timestamp": datetime.now(timezone.utc).isoformat(),
+                        "solace_topic": topic,
+                        "direction": event_details_for_owner["direction"],
+                        "source_entity": event_details_for_owner["source_entity"],
+                        "target_entity": event_details_for_owner["target_entity"],
+                        "message_id": event_details_for_owner["message_id"],
+                        "task_id": event_details_for_owner["task_id"],
+                        "payload_summary": event_details_for_owner["payload_summary"],
+                        "full_payload": payload_dict,
+                        "debug_type": event_details_for_owner["debug_type"],
+                    }
+                    try:
+                        viz_msg = {
+                            "event": "a2a_message",
+                            "data": json.dumps(viz_event_payload),
+                        }
+                    except Exception as ser_err:
+                        log.error(
+                            "%s Failed to serialize viz message for topic %s: %s",
+                            log_id_prefix,
+                            topic,
+                            ser_err,
+                        )
+                        continue
+
                     async with self._get_visualization_lock():
                         for (
                             stream_id,
@@ -1134,54 +1192,9 @@ class WebUIBackendComponent(BaseGatewayComponent):
                                         break
 
                             if is_permitted:
-                                event_details = self._infer_visualization_event_details(
-                                    topic, payload_dict
+                                self._put_viz_msg_to_stream(
+                                    stream_id, sse_queue_for_stream, viz_msg, log_id_prefix
                                 )
-
-                                sse_event_payload = {
-                                    "event_type": "a2a_message",
-                                    "timestamp": datetime.now(timezone.utc).isoformat(),
-                                    "solace_topic": topic,
-                                    "direction": event_details["direction"],
-                                    "source_entity": event_details["source_entity"],
-                                    "target_entity": event_details["target_entity"],
-                                    "message_id": event_details["message_id"],
-                                    "task_id": event_details["task_id"],
-                                    "payload_summary": event_details["payload_summary"],
-                                    "full_payload": payload_dict,
-                                    "debug_type": event_details["debug_type"],
-                                }
-
-                                try:
-                                    viz_msg = {
-                                        "event": "a2a_message",
-                                        "data": json.dumps(sse_event_payload),
-                                    }
-                                    log.debug(
-                                        "%s Attempting to put message on SSE queue for stream %s. Queue size: %d",
-                                        log_id_prefix,
-                                        stream_id,
-                                        sse_queue_for_stream.qsize(),
-                                    )
-                                    self._put_viz_msg_to_stream(
-                                        stream_id, sse_queue_for_stream, viz_msg, log_id_prefix
-                                    )
-                                    log.debug(
-                                        "%s [VIZ_DATA_SENT] Stream %s: Topic: %s, Direction: %s",
-                                        log_id_prefix,
-                                        stream_id,
-                                        topic,
-                                        event_details["direction"],
-                                    )
-                                except Exception as send_err:
-                                    log.error(
-                                        "%s Failed to serialize/send viz message for stream %s: %s",
-                                        log_id_prefix,
-                                        stream_id,
-                                        send_err,
-                                    )
-                            else:
-                                pass
                 finally:
                     self._visualization_message_queue.task_done()
 

--- a/src/solace_agent_mesh/gateway/http_sse/routers/visualization.py
+++ b/src/solace_agent_mesh/gateway/http_sse/routers/visualization.py
@@ -15,7 +15,6 @@ from fastapi import (
     status,
 )
 from pydantic import BaseModel, Field
-import json
 from typing import List, Optional, Dict, Any, Set
 
 
@@ -209,70 +208,6 @@ def _resolve_user_identity_for_authorization(
             )
 
     return user_identity
-
-
-def _include_for_visualization(event_payload: Dict[str, Any]) -> bool:
-    """
-    Check if an event should be included for visualization based on metadata.
-
-    Args:
-        event_payload: The event payload containing event data
-
-    Returns:
-        False if the event should be excluded from visualization (when visualization is False),
-        True otherwise (include by default)
-    """
-    try:
-        # Get the data field from the event payload
-        data_str = event_payload.get("data")
-        if not data_str:
-            return True  # Include by default if no data
-
-        # Parse the JSON data
-        try:
-            data = json.loads(data_str)
-        except (json.JSONDecodeError, TypeError):
-            return True
-
-        # Look for the full_payload in the data
-        full_payload = data.get("full_payload")
-        if not full_payload:
-            return True
-
-        # Check if full_payload has params
-        params = full_payload.get("params")
-        if not params:
-            return True
-
-        # Check if params has message
-        message = params.get("message")
-        if not message:
-            return True
-
-        # Check if message has metadata
-        metadata = message.get("metadata")
-        if not metadata:
-            return True
-
-        # Check the visualization setting in metadata
-        visualization_setting = metadata.get("visualization")
-        if visualization_setting is not None and (
-            (
-                isinstance(visualization_setting, str)
-                and visualization_setting.lower() == "false"
-            )
-            or (
-                isinstance(visualization_setting, bool)
-                and visualization_setting is False
-            )
-        ):
-            return False
-
-        return True
-
-    except Exception as e:
-        log.warning("Error checking visualization filter for event: %s", e)
-        return True
 
 
 @router.post(
@@ -815,21 +750,20 @@ async def get_visualization_stream_events(
                             stream_id,
                         )
                         break
-                    if _include_for_visualization(event_payload):
-                        if trace_logger.isEnabledFor(logging.DEBUG):
-                            trace_logger.debug(
-                                "%s Yielding event for stream %s: %s",
-                                log_id_prefix,
-                                stream_id,
-                                event_payload,
-                            )
-                        else:
-                            log.debug(
-                                "%s Yielding event for stream %s",
-                                log_id_prefix,
-                                stream_id,
-                            )
-                        yield event_payload
+                    if trace_logger.isEnabledFor(logging.DEBUG):
+                        trace_logger.debug(
+                            "%s Yielding event for stream %s: %s",
+                            log_id_prefix,
+                            stream_id,
+                            event_payload,
+                        )
+                    else:
+                        log.debug(
+                            "%s Yielding event for stream %s",
+                            log_id_prefix,
+                            stream_id,
+                        )
+                    yield event_payload
                     sse_queue.task_done()
                 except asyncio.TimeoutError:
                     yield {"comment": "keep-alive"}

--- a/tests/unit/gateway/http_sse/test_sse_max_queue_size_defaults.py
+++ b/tests/unit/gateway/http_sse/test_sse_max_queue_size_defaults.py
@@ -1,0 +1,47 @@
+"""Pin the production default of ``sse_max_queue_size`` (1000).
+
+The default lives in two places that MUST agree:
+
+1. ``WebUIBackendApp.SPECIFIC_APP_SCHEMA_PARAMS`` — the schema default applied
+   when YAML omits the key.
+2. ``WebUIBackendComponent.__init__`` — the runtime fallback in the
+   ``self.get_config("sse_max_queue_size", 1000)`` call.
+
+These were bumped from 200 → 1000 as part of the DATAGO-133967 fix to give
+per-stream SSE queues enough headroom under high-fan-out tasks. An accidental
+revert of EITHER value would silently reintroduce the queue-overflow bug — so
+this test pins both.
+"""
+
+from __future__ import annotations
+
+import inspect
+
+from solace_agent_mesh.gateway.http_sse.app import WebUIBackendApp
+from solace_agent_mesh.gateway.http_sse.component import WebUIBackendComponent
+
+
+def test_app_schema_default_is_1000():
+    schema = {
+        param["name"]: param
+        for param in WebUIBackendApp.SPECIFIC_APP_SCHEMA_PARAMS
+    }
+    assert schema["sse_max_queue_size"]["default"] == 1000, (
+        "WebUIBackendApp schema default for sse_max_queue_size must be 1000 "
+        "to prevent SSE queue overflow under high-fan-out tasks (DATAGO-133967)."
+    )
+
+
+def test_component_runtime_fallback_is_1000():
+    """Pin the literal default in component.__init__'s get_config call.
+
+    We use inspect.getsource rather than constructing the component because
+    WebUIBackendComponent.__init__ pulls in FastAPI/uvicorn/SAC App/etc. The
+    literal-string check is sufficient: the only way this passes is if the
+    second positional arg of the get_config call is exactly ``1000``.
+    """
+    src = inspect.getsource(WebUIBackendComponent.__init__)
+    assert 'self.get_config("sse_max_queue_size", 1000)' in src, (
+        "Runtime fallback for sse_max_queue_size in WebUIBackendComponent."
+        "__init__ must remain 1000 — see DATAGO-133967."
+    )

--- a/tests/unit/gateway/http_sse/test_viz_serialization_and_filter.py
+++ b/tests/unit/gateway/http_sse/test_viz_serialization_and_filter.py
@@ -161,7 +161,7 @@ async def test_excluded_payload_skips_all_streams_included_payload_reaches_them(
     enqueued = stream["sse_queue"].get_nowait()
     assert enqueued["event"] == "a2a_message"
     parsed = json.loads(enqueued["data"])
-    assert parsed["full_payload"] is included_payload
+    assert parsed["full_payload"] == included_payload
 
 
 # ─────────────────────────────────────────────────────────────────────────────
@@ -239,4 +239,4 @@ async def test_serialization_failure_skips_streams_and_continues_loop():
     assert stream["sse_queue"].qsize() == 1
     delivered = stream["sse_queue"].get_nowait()
     parsed = json.loads(delivered["data"])
-    assert parsed["full_payload"] is good_payload
+    assert parsed["full_payload"] == good_payload

--- a/tests/unit/gateway/http_sse/test_viz_serialization_and_filter.py
+++ b/tests/unit/gateway/http_sse/test_viz_serialization_and_filter.py
@@ -1,0 +1,242 @@
+"""Regression tests for the SSE visualization filter + fan-out path.
+
+These tests pin the DATAGO incident fix (DATAGO-133967): under high-fan-out
+tasks the gateway used to build+serialize the viz payload once per subscriber
+and skip excluded payloads only after dumping/parsing them. The loop now
+short-circuits excluded payloads and serializes once per A2A message.
+
+The tests use ``object.__new__(WebUIBackendComponent)`` plus minimal stubs so
+they can exercise the loop body without spinning up the heavy component
+__init__ (FastAPI/uvicorn/SAC App/etc).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import threading
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from solace_agent_mesh.gateway.http_sse import component as component_module
+from solace_agent_mesh.gateway.http_sse.component import (
+    WebUIBackendComponent,
+    _should_include_for_visualization,
+)
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Issue 3: unit tests for _should_include_for_visualization
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
+        None,
+        "not-a-dict",
+        123,
+        [],
+        {},  # missing params
+        {"params": "not-a-dict"},
+        {"params": {}},  # missing message
+        {"params": {"message": "not-a-dict"}},
+        {"params": {"message": {}}},  # missing metadata
+        {"params": {"message": {"metadata": "not-a-dict"}}},
+        {"params": {"message": {"metadata": {}}}},  # absent visualization key
+        {"params": {"message": {"metadata": {"visualization": True}}}},
+        {"params": {"message": {"metadata": {"visualization": "true"}}}},
+        {"params": {"message": {"metadata": {"visualization": "TRUE"}}}},
+        {"params": {"message": {"metadata": {"visualization": 0}}}},  # non-str/bool
+        {"params": {"message": {"metadata": {"visualization": None}}}},
+    ],
+)
+def test_should_include_returns_true_when_not_explicitly_excluded(payload):
+    assert _should_include_for_visualization(payload) is True
+
+
+@pytest.mark.parametrize(
+    "setting",
+    ["false", "False", "FALSE", "FaLsE"],
+)
+def test_should_include_returns_false_for_string_false_case_insensitive(setting):
+    payload = {"params": {"message": {"metadata": {"visualization": setting}}}}
+    assert _should_include_for_visualization(payload) is False
+
+
+def test_should_include_returns_false_for_boolean_false():
+    payload = {"params": {"message": {"metadata": {"visualization": False}}}}
+    assert _should_include_for_visualization(payload) is False
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Loop-test scaffolding
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+def _make_loop_stub(streams: dict | None = None):
+    """Build a minimal WebUIBackendComponent stub for the viz processor loop."""
+    holder = object.__new__(WebUIBackendComponent)
+    holder.log_identifier = "[TEST]"
+    holder._visualization_message_queue = asyncio.Queue()
+    holder._active_visualization_streams = streams or {}
+    holder._viz_stream_drop_counts = {}
+    holder._visualization_locks_lock = threading.Lock()
+    holder._visualization_locks = {}
+
+    holder.stop_signal = MagicMock()
+    holder.stop_signal.is_set.return_value = False
+
+    holder.task_context_manager = MagicMock()
+    holder.task_context_manager.get_context.return_value = None
+
+    holder._infer_visualization_event_details = MagicMock(
+        return_value={
+            "direction": "request",
+            "source_entity": "client",
+            "target_entity": "agent",
+            "debug_type": "a2a",
+            "message_id": "m1",
+            "task_id": None,
+            "payload_summary": {"method": "test", "params_preview": None},
+        }
+    )
+
+    return holder
+
+
+def _make_stream(topic: str) -> dict:
+    """Stream config that subscribes to `topic` exactly (no wildcards)."""
+    return {
+        "user_id": "user-1",
+        "abstract_targets": [
+            SimpleNamespace(status="subscribed", type="namespace_a2a_messages")
+        ],
+        "solace_topics": {topic},
+        "sse_queue": asyncio.Queue(maxsize=10),
+    }
+
+
+async def _run_loop_with_msgs(holder, msgs):
+    """Push msgs (then a None sentinel) and run the loop until it exits."""
+    for m in msgs:
+        await holder._visualization_message_queue.put(m)
+    await holder._visualization_message_queue.put(None)
+    await WebUIBackendComponent._visualization_message_processor_loop(holder)
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Issue 1: behavioral test for early-`continue` short-circuit
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_excluded_payload_skips_all_streams_included_payload_reaches_them():
+    """Excluded payloads (visualization=false) must not enqueue to ANY stream;
+    a non-excluded payload routed to the same stream MUST reach it. This pins
+    the DATAGO regression fix at component.py:1118."""
+    topic = "test/topic"
+    stream = _make_stream(topic)
+    holder = _make_loop_stub({"s1": stream})
+
+    excluded_payload = {
+        "params": {"message": {"metadata": {"visualization": "false"}}}
+    }
+    included_payload = {
+        "params": {"message": {"metadata": {"visualization": "true"}}}
+    }
+
+    await _run_loop_with_msgs(
+        holder,
+        [
+            {"topic": topic, "payload": excluded_payload},
+            {"topic": topic, "payload": included_payload},
+        ],
+    )
+
+    # Exactly one viz_msg should have been enqueued (the included one).
+    assert stream["sse_queue"].qsize() == 1
+    enqueued = stream["sse_queue"].get_nowait()
+    assert enqueued["event"] == "a2a_message"
+    parsed = json.loads(enqueued["data"])
+    assert parsed["full_payload"] is included_payload
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Issue 2: serialize-once-then-fan-out test
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_json_dumps_called_once_per_message_for_n_streams():
+    """With ≥2 eligible streams, json.dumps must run exactly once per A2A
+    message (NOT once per stream). Pins the fan-out optimization at
+    component.py:1124-1149 — a regression here would silently bring back the
+    O(streams × payload_size) CPU cost that overflowed per-stream queues."""
+    topic = "test/topic"
+    streams = {
+        "s1": _make_stream(topic),
+        "s2": _make_stream(topic),
+        "s3": _make_stream(topic),
+    }
+    holder = _make_loop_stub(streams)
+
+    payload = {"params": {"message": {"metadata": {}}}}
+
+    real_dumps = json.dumps
+    with patch.object(
+        component_module.json, "dumps", side_effect=real_dumps
+    ) as dumps_spy:
+        await _run_loop_with_msgs(
+            holder, [{"topic": topic, "payload": payload}]
+        )
+
+    # Exactly one serialization for the single A2A message, regardless of
+    # how many streams it fans out to.
+    assert dumps_spy.call_count == 1
+
+    # And every eligible stream got the SAME viz_msg dict.
+    msgs = [streams[sid]["sse_queue"].get_nowait() for sid in ("s1", "s2", "s3")]
+    assert all(m == msgs[0] for m in msgs)
+    # All streams share the same object instance — confirms a single build,
+    # not three identical-but-separate dicts.
+    assert msgs[0] is msgs[1] is msgs[2]
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Issue 4: serialization-failure branch
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_serialization_failure_skips_streams_and_continues_loop():
+    """A non-JSON-serializable payload (set, etc.) must raise TypeError inside
+    json.dumps, be caught by the narrow (TypeError, ValueError) handler, and
+    cause the loop to skip ALL streams for THAT message but continue to the
+    next event. Pins component.py:1144-1149."""
+    topic = "test/topic"
+    stream = _make_stream(topic)
+    holder = _make_loop_stub({"s1": stream})
+
+    # `set` is not JSON-serializable → json.dumps raises TypeError.
+    bad_payload = {
+        "params": {"message": {"metadata": {}}},
+        "extra": {1, 2, 3},
+    }
+    good_payload = {"params": {"message": {"metadata": {}}}}
+
+    await _run_loop_with_msgs(
+        holder,
+        [
+            {"topic": topic, "payload": bad_payload},
+            {"topic": topic, "payload": good_payload},
+        ],
+    )
+
+    # Only the good payload should have been delivered; the bad one is dropped.
+    assert stream["sse_queue"].qsize() == 1
+    delivered = stream["sse_queue"].get_nowait()
+    parsed = json.loads(delivered["data"])
+    assert parsed["full_payload"] is good_payload


### PR DESCRIPTION
## Summary
- Build + serialize each viz event **once per A2A message** instead of once per subscribed stream — eliminates O(streams × payload_size) CPU under the viz lock.
- Producer-side short-circuit when `metadata.visualization=false` so excluded events don't enter the fan-out at all.
- Drop the drain-side `_include_for_visualization` filter that re-parsed every dequeued event from JSON only to check the same flag.
- Bump `sse_max_queue_size` default 200 → 1000 as a tail-burst safety margin.

## Why
Datadog (solace-chat prod, 2026-04-26 14:43–15:01 UTC, single pod `i-0d08a319f28ac72e8`) showed 11 active viz streams with sustained per-stream queue overflow:

| Stream | Peak evictions | Active duration |
|---|---|---|
| c4fbcc2f… | 1,180 | 49 min |
| d37a8cf0… | 850 | 50 min |
| 8 streams synchronized at 14:43:49 | 320 each | ~17 min |

Aggregate: **3,380 messages dropped in 11.5 min on one pod** (~4.9/s sustained). The "Visualization message queue is over 90% full" warning never fired — the broker→processor ingest queue is fine. The bottleneck is purely **per-client SSE fan-out**: with multiple dashboards subscribed to one heavy task (138 tool calls + sub-agents), the event loop couldn't push fast enough through the per-stream 200-deep queues, even though the upstream queue was empty.

Root cause in `_visualization_message_processor_loop` (component.py): `sse_event_payload` build + `json.dumps()` ran **inside** the per-stream `for` loop while holding the viz lock. With 10 streams × ~50 KB payloads, that's ~500 KB of synchronous serialization per A2A message, no `await`. The drain side then ran `json.loads()` on every dequeued event just to read `metadata.visualization`. Net: producer and drain CPU both scaled with stream count × payload size.

## Test plan
- [x] `python -m pytest tests/unit/gateway/http_sse/` — **1242 passed, 23 skipped**
- [x] Helper smoke-tested across 9 cases (string `"false"`/`"FALSE"`, bool `False`, `"true"`, missing keys at every level, non-dict, `None`)
- [x] AST parse on all 3 modified files
- [x] Verified no frontend wire change — `viz_event_payload` keys (incl. `full_payload`) are identical, so `TaskProvider.tsx`, `taskVisualizerProcessor.ts`, `ChatSidePanel.tsx` are unaffected
- [ ] Soak in staging under a multi-tab high-tool-count task; confirm no eviction warnings on the same pod