### PR TITLE
ci(DATAGO-134070): fix fossa upload on release-please pr's

### DIFF
--- a/.github/workflow-config.json
+++ b/.github/workflow-config.json
@@ -13,6 +13,9 @@
       "project_id": "SolaceLabs_solace-agent-mesh",
       "team": null,
       "labels": []
+    },
+    "guardian": {
+      "pr_scan_upload": true
     }
   }
 }


### PR DESCRIPTION
### What is the purpose of this change?

Fix FOSSA license scan uploads failing on release-please PRs. Without the `guardian` configuration, PR scans were not being uploaded, causing CI compliance checks to fail on release PRs.

### How was this change implemented?

Added a `guardian` block to `.github/workflow-config.json` with `pr_scan_upload` set to `true`. This enables FOSSA scan result uploads during PR workflows, ensuring release-please PRs pass the required guardian/FOSSA checks.

### How was this change tested?

- [ ] Manual testing: Verify FOSSA upload succeeds on a release-please PR with this config change
- [ ] Known limitations: Only testable by observing CI behavior on an actual PR

### Is there anything the reviewers should focus on/be aware of?

This is a minimal config-only change. Confirm that enabling `pr_scan_upload` globally is the intended behavior and won't cause unexpected FOSSA uploads on other PR types.
