### PR TITLE
fix(DATAGO-134083): Fix inline citations rendering format during response streaming

### DIFF
--- a/client/webui/frontend/src/lib/components/chat/ChatMessage.tsx
+++ b/client/webui/frontend/src/lib/components/chat/ChatMessage.tsx
@@ -17,7 +17,6 @@ import { Sources } from "@/lib/components/web/Sources";
 import { ImageSearchGrid } from "@/lib/components/research";
 import { isDeepResearchReportFilename } from "@/lib/utils/deepResearchUtils";
 import { hasDocumentSearchResults } from "@/lib/utils/sourceUrlHelpers";
-import { TextWithCitations } from "./Citation";
 import { parseCitations } from "@/lib/utils/citations";
 
 import DOMPurify from "dompurify";
@@ -547,27 +546,13 @@ const MessageContent = React.memo<{ message: MessageFE; isStreaming?: boolean; h
         }
 
         if (embeddedContent.length === 0) {
-            // Use MarkdownWrapper for streaming (smooth animation), TextWithCitations otherwise (citation support)
-            if (isStreaming) {
-                return <MarkdownWrapper content={displayText} isStreaming={isStreaming} />;
-            }
-            // Render text with citations if any exist
-            if (citations.length > 0) {
-                return <TextWithCitations text={displayText} citations={citations} onCitationClick={handleCitationClick} />;
-            }
-            return <MarkdownHTMLConverter>{displayText}</MarkdownHTMLConverter>;
+            return <MarkdownWrapper content={displayText} isStreaming={isStreaming} citations={citations} onCitationClick={handleCitationClick} />;
         }
 
         return (
             <div>
                 {renderError && <MessageBanner variant="error" message="Error rendering preview" />}
-                {isStreaming ? (
-                    <MarkdownWrapper content={modifiedText} isStreaming={isStreaming} />
-                ) : modifiedCitations.length > 0 ? (
-                    <TextWithCitations text={modifiedText} citations={modifiedCitations} onCitationClick={handleCitationClick} />
-                ) : (
-                    <MarkdownHTMLConverter>{modifiedText}</MarkdownHTMLConverter>
-                )}
+                <MarkdownWrapper content={modifiedText} isStreaming={isStreaming} citations={modifiedCitations} onCitationClick={handleCitationClick} />
                 {contentElements}
             </div>
         );

--- a/client/webui/frontend/src/lib/components/chat/Citation.tsx
+++ b/client/webui/frontend/src/lib/components/chat/Citation.tsx
@@ -10,7 +10,7 @@ import { getCitationTooltip, INDIVIDUAL_CITATION_PATTERN, parseCitationId } from
 
 /** Default max length for citation display text */
 const DEFAULT_CITATION_MAX_LENGTH = 60;
-import { MarkdownHTMLConverter } from "@/lib/components";
+import { MarkdownHTMLConverter } from "@/lib/components/common/MarkdownHTMLConverter";
 import { getThemeHtmlStyles } from "@/lib/utils/themeHtmlStyles";
 import { getSourceUrl } from "@/lib/utils/sourceUrlHelpers";
 import { Popover, PopoverContent, PopoverTrigger } from "@/lib/components/ui/popover";

--- a/client/webui/frontend/src/lib/components/common/MarkdownWrapper.tsx
+++ b/client/webui/frontend/src/lib/components/common/MarkdownWrapper.tsx
@@ -1,21 +1,30 @@
 import React from "react";
 import { MarkdownHTMLConverter } from "./MarkdownHTMLConverter";
 import { StreamingMarkdown } from "./StreamingMarkdown";
+import { TextWithCitations } from "@/lib/components/chat/Citation";
+import type { Citation } from "@/lib/utils/citations";
 
 interface MarkdownWrapperProps {
     content: string;
     isStreaming?: boolean;
     className?: string;
+    citations?: Citation[];
+    onCitationClick?: (citation: Citation) => void;
 }
 
 /**
  * A wrapper component that automatically chooses between StreamingMarkdown
  * (for smooth animated rendering during streaming) and MarkdownHTMLConverter
- * (for static content).
+ * (for static content). When citations are provided, citation markers are
+ * rendered as bubbles inline — both during and after streaming.
  */
-const MarkdownWrapper: React.FC<MarkdownWrapperProps> = ({ content, isStreaming, className }) => {
+const MarkdownWrapper: React.FC<MarkdownWrapperProps> = ({ content, isStreaming, className, citations, onCitationClick }) => {
     if (isStreaming) {
-        return <StreamingMarkdown content={content} className={className} />;
+        return <StreamingMarkdown content={content} className={className} citations={citations} onCitationClick={onCitationClick} />;
+    }
+
+    if (citations && citations.length > 0) {
+        return <TextWithCitations text={content} citations={citations} onCitationClick={onCitationClick} />;
     }
 
     return <MarkdownHTMLConverter className={className}>{content}</MarkdownHTMLConverter>;

--- a/client/webui/frontend/src/lib/components/common/StreamingMarkdown.tsx
+++ b/client/webui/frontend/src/lib/components/common/StreamingMarkdown.tsx
@@ -1,15 +1,23 @@
 import React from "react";
 import { MarkdownHTMLConverter } from "./MarkdownHTMLConverter";
+import { TextWithCitations } from "@/lib/components/chat/Citation";
 import { useStreamingSpeed, useStreamingAnimation } from "@/lib/hooks";
+import type { Citation } from "@/lib/utils/citations";
 
 interface StreamingMarkdownProps {
     content: string;
     className?: string;
+    citations?: Citation[];
+    onCitationClick?: (citation: Citation) => void;
 }
 
-const StreamingMarkdown: React.FC<StreamingMarkdownProps> = ({ content, className }) => {
+const StreamingMarkdown: React.FC<StreamingMarkdownProps> = ({ content, className, citations, onCitationClick }) => {
     const { state, contentRef } = useStreamingSpeed(content);
     const displayedContent = useStreamingAnimation(state, contentRef);
+
+    if (citations && citations.length > 0) {
+        return <TextWithCitations text={displayedContent} citations={citations} onCitationClick={onCitationClick} />;
+    }
 
     return <MarkdownHTMLConverter className={className}>{displayedContent}</MarkdownHTMLConverter>;
 };

--- a/client/webui/frontend/src/stories/common/StreamingMarkdown.test.tsx
+++ b/client/webui/frontend/src/stories/common/StreamingMarkdown.test.tsx
@@ -1,0 +1,85 @@
+/// <reference types="@testing-library/jest-dom" />
+import { render, waitFor } from "@testing-library/react";
+import { describe, test, expect } from "vitest";
+import * as matchers from "@testing-library/jest-dom/matchers";
+
+import { StreamingMarkdown } from "@/lib/components/common/StreamingMarkdown";
+import type { Citation } from "@/lib/utils/citations";
+
+expect.extend(matchers);
+
+const documentCitation: Citation = {
+    marker: "[[cite:idx0r0]]",
+    type: "document",
+    sourceId: 0,
+    position: 0,
+    citationId: "idx0r0",
+    source: {
+        citationId: "idx0r0",
+        filename: "report.pdf",
+        contentPreview: "...",
+        relevanceScore: 0.9,
+        metadata: {
+            primary_location: "Page 7",
+        },
+    },
+};
+
+// The streaming animation advances content over real time via requestAnimationFrame.
+// Tests use waitFor with a generous timeout so the animation can flush short content.
+const WAIT = { timeout: 4000 };
+
+describe("StreamingMarkdown", () => {
+    test("eventually renders markdown via MarkdownHTMLConverter when no citations are provided", async () => {
+        const { container } = render(<StreamingMarkdown content={"# hello\n\nworld"} />);
+
+        // Wait for the trailing paragraph so we know the animation has flushed the full content.
+        await waitFor(() => {
+            expect(container.querySelector("p")?.textContent).toBe("world");
+        }, WAIT);
+
+        const heading = container.querySelector("h1");
+        expect(heading).not.toBeNull();
+        expect(heading!.textContent).toBe("hello");
+    });
+
+    test("forwards className to MarkdownHTMLConverter when no citations are provided", async () => {
+        const { container } = render(<StreamingMarkdown content="plain text" className="custom-stream" />);
+
+        await waitFor(() => {
+            const wrapper = container.querySelector(".custom-stream");
+            expect(wrapper).not.toBeNull();
+            expect(wrapper!.textContent).toContain("plain text");
+        }, WAIT);
+    });
+
+    test("renders citation bubbles inline when citations are present", async () => {
+        const content = "Per the report [[cite:idx0r0]], revenue grew.";
+
+        const { container } = render(<StreamingMarkdown content={content} citations={[documentCitation]} />);
+
+        // Wait for the trailing text so the animation has flushed the full content,
+        // including the citation marker that precedes it.
+        await waitFor(() => {
+            expect(container.textContent).toContain("revenue grew.");
+        }, WAIT);
+
+        const badge = container.querySelector("button.citation-badge");
+        expect(badge).not.toBeNull();
+        expect(badge!.textContent).toContain("report.pdf");
+        expect(badge!.textContent).toContain("Page 7");
+
+        // Surrounding markdown text is preserved and the raw cite marker is consumed.
+        expect(container.textContent).toContain("Per the report");
+        expect(container.textContent).not.toContain("[[cite:idx0r0]]");
+    });
+
+    test("renders via MarkdownHTMLConverter when citations array is empty", async () => {
+        const { container } = render(<StreamingMarkdown content="just text" citations={[]} />);
+
+        await waitFor(() => {
+            expect(container.querySelector("p")?.textContent).toBe("just text");
+        }, WAIT);
+        expect(container.querySelector("button.citation-badge")).toBeNull();
+    });
+});


### PR DESCRIPTION
This pull request refactors how chat message content with citations is rendered, streamlining and centralizing citation handling in the UI. The main improvement is that citation bubbles are now rendered consistently during both streaming and static display, and the logic for when to show citations is moved into the `MarkdownWrapper` and `StreamingMarkdown` components.

**Rendering and citation handling improvements:**

* The `MarkdownWrapper` component now accepts `citations` and `onCitationClick` props, and automatically decides whether to render citation bubbles inline (using `TextWithCitations`) or fallback to plain markdown, both during and after streaming.
* The `StreamingMarkdown` component is updated to support citations, rendering citation bubbles inline during streaming if citations are provided.
* The chat message rendering logic in `ChatMessage.tsx` is simplified: instead of branching between `MarkdownWrapper`, `TextWithCitations`, and `MarkdownHTMLConverter`, it now always uses `MarkdownWrapper` and passes citation data as needed.
* The now-unnecessary direct import of `TextWithCitations` in `ChatMessage.tsx` is removed, since citation rendering is handled inside the markdown wrapper components.