### PR TITLE
fix(DATAGO-134087): Address laggy loading of recent-chats page

### DIFF
--- a/client/webui/frontend/src/lib/api/sessions/hooks.ts
+++ b/client/webui/frontend/src/lib/api/sessions/hooks.ts
@@ -38,15 +38,17 @@ export function useRecentSessions(maxItems: number = MAX_RECENT_CHATS) {
  * Hook to fetch paginated sessions with infinite scroll support.
  * Automatically invalidates on session events (new session, session updated, title updated, background task completed).
  */
-export function useInfiniteSessions(pageSize: number = 20, source?: string) {
+export function useInfiniteSessions(pageSize: number = 20, source?: string, options?: { enabled?: boolean }) {
     const queryClient = useQueryClient();
+    const enabled = options?.enabled ?? true;
 
     useEffect(() => {
+        if (!enabled) return;
         const invalidate = () => queryClient.invalidateQueries({ queryKey: sessionKeys.lists() });
         const events = ["new-chat-session", "session-updated", "session-title-updated", "background-task-completed"];
         events.forEach(e => window.addEventListener(e, invalidate));
         return () => events.forEach(e => window.removeEventListener(e, invalidate));
-    }, [queryClient]);
+    }, [queryClient, enabled]);
 
     return useInfiniteQuery({
         queryKey: [...sessionKeys.lists(), "infinite", pageSize, source],
@@ -54,6 +56,7 @@ export function useInfiniteSessions(pageSize: number = 20, source?: string) {
         getNextPageParam: lastPage => lastPage.meta.pagination.nextPage ?? undefined,
         initialPageParam: 1,
         refetchOnMount: "always",
+        enabled,
     });
 }
 

--- a/client/webui/frontend/src/lib/api/share/hooks.ts
+++ b/client/webui/frontend/src/lib/api/share/hooks.ts
@@ -26,10 +26,11 @@ export function useShareUsers(shareId: string | undefined) {
     });
 }
 
-export function useSharedWithMe() {
+export function useSharedWithMe(options?: { enabled?: boolean }) {
     return useQuery({
         queryKey: shareKeys.sharedWithMe(),
         queryFn: shareService.listSharedWithMe,
+        enabled: options?.enabled ?? true,
     });
 }
 

--- a/client/webui/frontend/src/lib/components/pages/RecentChatsPage.tsx
+++ b/client/webui/frontend/src/lib/components/pages/RecentChatsPage.tsx
@@ -140,8 +140,8 @@ export const RecentChatsPage: React.FC = () => {
 
     // Sessions fetched only for chat/scheduler tabs; shared tab uses its own query.
     const sessionSource = activeTab === "shared" ? "chat" : activeTab;
-    const { data, fetchNextPage, hasNextPage, isFetchingNextPage } = useInfiniteSessions(PAGE_SIZE, sessionSource);
-    const { data: sharedChats = [], isLoading: isLoadingShared } = useSharedWithMe();
+    const { data, fetchNextPage, hasNextPage, isFetchingNextPage } = useInfiniteSessions(PAGE_SIZE, sessionSource, { enabled: activeTab !== "shared" });
+    const { data: sharedChats = [], isLoading: isLoadingShared } = useSharedWithMe({ enabled: activeTab === "shared" });
     const sessions = useMemo(() => data?.pages.flatMap(page => page.data) ?? [], [data]);
 
     const [editingSessionId, setEditingSessionId] = useState<string | null>(null);

--- a/src/solace_agent_mesh/gateway/http_sse/services/session_service.py
+++ b/src/solace_agent_mesh/gateway/http_sse/services/session_service.py
@@ -1,7 +1,9 @@
+import json
 import logging
 import uuid
 from typing import TYPE_CHECKING, Optional, List, Dict, Any
 
+from sqlalchemy import or_
 from sqlalchemy.orm import Session as DbSession
 
 from ..repository import (
@@ -39,6 +41,60 @@ class SessionService:
     def is_persistence_enabled(self) -> bool:
         """Checks if the service is configured with a persistent backend."""
         return self.component and self.component.database_url is not None
+
+    def _find_sessions_with_running_background_tasks(
+        self, db: DbSession, user_id: UserId, session_ids: list[str]
+    ) -> dict[str, bool]:
+        """Return {session_id: True} for sessions in `session_ids` that have a
+        background task still running for `user_id`.
+
+        Scoped at the SQL layer to (user, page's sessions, background mode,
+        non-terminal status) so cost is bounded by page size, not by total
+        background-task history. task_metadata is parsed only for the matching
+        rows since chat-side completion can lead TaskModel.status.
+        """
+        if not session_ids:
+            return {}
+
+        from ..repository.models import ChatTaskModel
+        from ..repository.models.task_model import TaskModel
+
+        rows = (
+            db.query(ChatTaskModel.session_id, ChatTaskModel.task_metadata)
+            .join(TaskModel, TaskModel.id == ChatTaskModel.id)
+            .filter(
+                ChatTaskModel.user_id == user_id,
+                ChatTaskModel.session_id.in_(session_ids),
+                TaskModel.execution_mode == "background",
+                TaskModel.end_time.is_(None),
+                or_(
+                    TaskModel.status.is_(None),
+                    TaskModel.status.in_(["running", "pending"]),
+                ),
+            )
+            .all()
+        )
+
+        terminal_statuses = {"completed", "error", "failed"}
+        session_task_map: dict[str, bool] = {}
+        for session_id, raw_metadata in rows:
+            if not session_id:
+                continue
+            if raw_metadata:
+                try:
+                    metadata = (
+                        json.loads(raw_metadata)
+                        if isinstance(raw_metadata, str)
+                        else raw_metadata
+                    )
+                    if metadata.get("status") in terminal_statuses:
+                        continue
+                except Exception as e:
+                    log.warning(
+                        f"[get_user_sessions] Failed to parse task metadata for session {session_id}: {e}"
+                    )
+            session_task_map[session_id] = True
+        return session_task_map
 
     def get_user_sessions(
         self,
@@ -86,56 +142,9 @@ class SessionService:
                     session.project_name = project_map.get(session.project_id)
 
         # Check for running background tasks in these sessions
-        task_repo = TaskRepository()
         session_ids = [s.id for s in sessions]
-        
-        # Get all running background tasks for this user
-        running_bg_tasks = task_repo.find_background_tasks_by_status(db, status=None)
-        running_bg_tasks = [
-            task for task in running_bg_tasks
-            if task.status in [None, "running", "pending"] and task.end_time is None and task.user_id == user_id
-        ]
-        
-        log.info(f"[get_user_sessions] Found {len(running_bg_tasks)} running background tasks for user {user_id}")
-        
-        # Create a map of session_id -> has_running_background_task
-        # Query ChatTaskModel to find which sessions these tasks belong to
-        # Also filter out tasks that have been marked as completed in their metadata
-        from ..repository.models import ChatTaskModel
-        import json
-        session_task_map = {}
-        if running_bg_tasks:
-            task_ids = [task.id for task in running_bg_tasks]
-            log.info(f"[get_user_sessions] Looking up chat tasks for task IDs: {task_ids}")
-            
-            # Query chat tasks for these task IDs
-            chat_tasks = db.query(ChatTaskModel).filter(
-                ChatTaskModel.id.in_(task_ids),
-                ChatTaskModel.user_id == user_id
-            ).all()
-            
-            log.info(f"[get_user_sessions] Found {len(chat_tasks)} chat tasks")
-            
-            for chat_task in chat_tasks:
-                if chat_task.session_id:
-                    # Check if task metadata indicates completion
-                    is_completed = False
-                    if chat_task.task_metadata:
-                        try:
-                            metadata = json.loads(chat_task.task_metadata) if isinstance(chat_task.task_metadata, str) else chat_task.task_metadata
-                            task_status = metadata.get("status")
-                            is_completed = task_status in ["completed", "error", "failed"]
-                            log.debug(f"[get_user_sessions] Task {chat_task.id} metadata status: {task_status}, is_completed: {is_completed}")
-                        except Exception as e:
-                            log.warning(f"[get_user_sessions] Failed to parse task metadata for {chat_task.id}: {e}")
-                    
-                    # Only mark session as having running task if task is not completed
-                    if not is_completed:
-                        session_task_map[chat_task.session_id] = True
-                        log.debug(f"[get_user_sessions] Session {chat_task.session_id} has running background task {chat_task.id}")
-                    else:
-                        log.debug(f"[get_user_sessions] Task {chat_task.id} is completed, not marking session as having running task")
-        
+        session_task_map = self._find_sessions_with_running_background_tasks(db, user_id, session_ids)
+
         # Add background task status to sessions
         for session in sessions:
             session.has_running_background_task = session_task_map.get(session.id, False)

--- a/src/solace_agent_mesh/gateway/http_sse/services/session_service.py
+++ b/src/solace_agent_mesh/gateway/http_sse/services/session_service.py
@@ -44,17 +44,17 @@ class SessionService:
 
     def _find_sessions_with_running_background_tasks(
         self, db: DbSession, user_id: UserId, session_ids: list[str]
-    ) -> dict[str, bool]:
-        """Return {session_id: True} for sessions in `session_ids` that have a
-        background task still running for `user_id`.
+    ) -> set[str]:
+        """Return the subset of `session_ids` that have a background task
+        still running for `user_id`.
 
         Scoped at the SQL layer to (user, page's sessions, background mode,
         non-terminal status) so cost is bounded by page size, not by total
         background-task history. task_metadata is parsed only for the matching
-        rows since chat-side completion can lead TaskModel.status.
+        rows because chat-side completion can lead TaskModel.status.
         """
         if not session_ids:
-            return {}
+            return set()
 
         from ..repository.models import ChatTaskModel
         from ..repository.models.task_model import TaskModel
@@ -76,10 +76,8 @@ class SessionService:
         )
 
         terminal_statuses = {"completed", "error", "failed"}
-        session_task_map: dict[str, bool] = {}
+        running: set[str] = set()
         for session_id, raw_metadata in rows:
-            if not session_id:
-                continue
             if raw_metadata:
                 try:
                     metadata = (
@@ -91,10 +89,10 @@ class SessionService:
                         continue
                 except Exception as e:
                     log.warning(
-                        f"[get_user_sessions] Failed to parse task metadata for session {session_id}: {e}"
+                        f"Failed to parse task metadata for session {session_id}: {e}"
                     )
-            session_task_map[session_id] = True
-        return session_task_map
+            running.add(session_id)
+        return running
 
     def get_user_sessions(
         self,
@@ -143,13 +141,9 @@ class SessionService:
 
         # Check for running background tasks in these sessions
         session_ids = [s.id for s in sessions]
-        session_task_map = self._find_sessions_with_running_background_tasks(db, user_id, session_ids)
-
-        # Add background task status to sessions
+        running = self._find_sessions_with_running_background_tasks(db, user_id, session_ids)
         for session in sessions:
-            session.has_running_background_task = session_task_map.get(session.id, False)
-            if session.has_running_background_task:
-                log.debug(f"[get_user_sessions] Marking session {session.id} as having running background task")
+            session.has_running_background_task = session.id in running
 
         return PaginatedResponse.create(sessions, total_count, pagination)
 
@@ -472,61 +466,10 @@ class SessionService:
                     session.project_name = project_map.get(session.project_id)
 
         # Check for running background tasks in these sessions
-        task_repo = TaskRepository()
         session_ids = [s.id for s in sessions]
-        
-        # Get all running background tasks for this user
-        running_bg_tasks = task_repo.find_background_tasks_by_status(db, status=None)
-        running_bg_tasks = [
-            task for task in running_bg_tasks
-            if task.status in [None, "running", "pending"] and task.end_time is None and task.user_id == user_id
-        ]
-        
-        log.info(f"[search_sessions] Found {len(running_bg_tasks)} running background tasks for user {user_id}")
-        
-        # Create a map of session_id -> has_running_background_task
-        # Query ChatTaskModel to find which sessions these tasks belong to
-        # Also filter out tasks that have been marked as completed in their metadata
-        from ..repository.models import ChatTaskModel
-        import json
-        session_task_map = {}
-        if running_bg_tasks:
-            task_ids = [task.id for task in running_bg_tasks]
-            log.info(f"[search_sessions] Looking up chat tasks for task IDs: {task_ids}")
-            
-            # Query chat tasks for these task IDs
-            chat_tasks = db.query(ChatTaskModel).filter(
-                ChatTaskModel.id.in_(task_ids),
-                ChatTaskModel.user_id == user_id
-            ).all()
-            
-            log.info(f"[search_sessions] Found {len(chat_tasks)} chat tasks")
-            
-            for chat_task in chat_tasks:
-                if chat_task.session_id:
-                    # Check if task metadata indicates completion
-                    is_completed = False
-                    if chat_task.task_metadata:
-                        try:
-                            metadata = json.loads(chat_task.task_metadata) if isinstance(chat_task.task_metadata, str) else chat_task.task_metadata
-                            task_status = metadata.get("status")
-                            is_completed = task_status in ["completed", "error", "failed"]
-                            log.info(f"[search_sessions] Task {chat_task.id} metadata status: {task_status}, is_completed: {is_completed}")
-                        except Exception as e:
-                            log.warning(f"[search_sessions] Failed to parse task metadata for {chat_task.id}: {e}")
-                    
-                    # Only mark session as having running task if task is not completed
-                    if not is_completed:
-                        session_task_map[chat_task.session_id] = True
-                        log.info(f"[search_sessions] Session {chat_task.session_id} has running background task {chat_task.id}")
-                    else:
-                        log.info(f"[search_sessions] Task {chat_task.id} is completed, not marking session as having running task")
-        
-        # Add background task status to sessions
+        running = self._find_sessions_with_running_background_tasks(db, user_id, session_ids)
         for session in sessions:
-            session.has_running_background_task = session_task_map.get(session.id, False)
-            if session.has_running_background_task:
-                log.info(f"[search_sessions] Marking session {session.id} as having running background task")
+            session.has_running_background_task = session.id in running
 
         log.info(
             "Search for '%s' by user %s returned %d results (total: %d)",

--- a/tests/unit/gateway/http_sse/services/test_session_service_background_tasks.py
+++ b/tests/unit/gateway/http_sse/services/test_session_service_background_tasks.py
@@ -1,0 +1,221 @@
+"""
+Tests for SessionService._find_sessions_with_running_background_tasks.
+
+Covers the SQL-side filtering semantics introduced when the unbounded
+find_background_tasks_by_status scan was replaced with a scoped join: a
+running task must surface, a task with terminal task_metadata must not, a
+foreground task must not, and tasks belonging to other users must not.
+"""
+
+import json
+
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import Session as DBSession, sessionmaker
+
+from solace_agent_mesh.gateway.http_sse.repository.models.base import Base
+from solace_agent_mesh.gateway.http_sse.repository.models.chat_task_model import (
+    ChatTaskModel,
+)
+from solace_agent_mesh.gateway.http_sse.repository.models.project_model import (
+    ProjectModel,  # register FK target for SessionModel.project_id
+)  # noqa: F401
+from solace_agent_mesh.gateway.http_sse.repository.models.session_model import (
+    SessionModel,
+)
+from solace_agent_mesh.gateway.http_sse.repository.models.task_model import TaskModel
+from solace_agent_mesh.gateway.http_sse.services.session_service import SessionService
+
+
+USER_ID = "user-1"
+OTHER_USER_ID = "user-2"
+
+
+@pytest.fixture()
+def engine():
+    eng = create_engine("sqlite:///:memory:")
+    Base.metadata.create_all(eng)
+    return eng
+
+
+@pytest.fixture()
+def session(engine):
+    SessionLocal = sessionmaker(bind=engine)
+    sess = SessionLocal()
+    yield sess
+    sess.rollback()
+    sess.close()
+
+
+@pytest.fixture()
+def service():
+    return SessionService()
+
+
+def _make_session(db: DBSession, session_id: str, user_id: str = USER_ID) -> None:
+    db.add(
+        SessionModel(
+            id=session_id,
+            name=session_id,
+            user_id=user_id,
+            source="chat",
+            created_time=1700000000000,
+            updated_time=1700000000000,
+        )
+    )
+
+
+def _make_task(
+    db: DBSession,
+    task_id: str,
+    session_id: str,
+    *,
+    user_id: str = USER_ID,
+    execution_mode: str = "background",
+    end_time: int | None = None,
+    status: str | None = None,
+    metadata_status: str | None = None,
+) -> None:
+    db.add(
+        TaskModel(
+            id=task_id,
+            user_id=user_id,
+            start_time=1700000000000,
+            end_time=end_time,
+            status=status,
+            execution_mode=execution_mode,
+        )
+    )
+    chat_metadata = (
+        json.dumps({"status": metadata_status}) if metadata_status else None
+    )
+    db.add(
+        ChatTaskModel(
+            id=task_id,
+            session_id=session_id,
+            user_id=user_id,
+            message_bubbles="[]",
+            task_metadata=chat_metadata,
+            created_time=1700000000000,
+        )
+    )
+
+
+class TestFindSessionsWithRunningBackgroundTasks:
+    def test_running_background_task_surfaces(self, session, service):
+        _make_session(session, "s-running")
+        _make_task(session, "t-running", "s-running", status="running")
+        session.flush()
+
+        result = service._find_sessions_with_running_background_tasks(
+            session, USER_ID, ["s-running"]
+        )
+        assert result == {"s-running"}
+
+    def test_task_with_terminal_metadata_is_excluded(self, session, service):
+        # TaskModel still says "running" but the chat_tasks metadata was already
+        # marked completed — the filter must respect that.
+        _make_session(session, "s-done")
+        _make_task(
+            session,
+            "t-done",
+            "s-done",
+            status="running",
+            metadata_status="completed",
+        )
+        session.flush()
+
+        result = service._find_sessions_with_running_background_tasks(
+            session, USER_ID, ["s-done"]
+        )
+        assert result == set()
+
+    def test_foreground_task_is_excluded(self, session, service):
+        _make_session(session, "s-foreground")
+        _make_task(
+            session,
+            "t-foreground",
+            "s-foreground",
+            execution_mode="foreground",
+            status="running",
+        )
+        session.flush()
+
+        result = service._find_sessions_with_running_background_tasks(
+            session, USER_ID, ["s-foreground"]
+        )
+        assert result == set()
+
+    def test_completed_task_with_end_time_is_excluded(self, session, service):
+        _make_session(session, "s-finished")
+        _make_task(
+            session,
+            "t-finished",
+            "s-finished",
+            status="completed",
+            end_time=1700000005000,
+        )
+        session.flush()
+
+        result = service._find_sessions_with_running_background_tasks(
+            session, USER_ID, ["s-finished"]
+        )
+        assert result == set()
+
+    def test_other_users_task_does_not_leak(self, session, service):
+        # Other user has a running background task in their own session — it
+        # must never surface even when the requested session_ids include the
+        # other user's session id.
+        _make_session(session, "s-other", user_id=OTHER_USER_ID)
+        _make_task(
+            session,
+            "t-other",
+            "s-other",
+            user_id=OTHER_USER_ID,
+            status="running",
+        )
+        session.flush()
+
+        result = service._find_sessions_with_running_background_tasks(
+            session, USER_ID, ["s-other"]
+        )
+        assert result == set()
+
+    def test_empty_session_ids_short_circuits(self, session, service):
+        # No DB hit; expectation is just an empty set without errors.
+        assert (
+            service._find_sessions_with_running_background_tasks(session, USER_ID, [])
+            == set()
+        )
+
+    def test_status_pending_surfaces(self, session, service):
+        _make_session(session, "s-pending")
+        _make_task(session, "t-pending", "s-pending", status="pending")
+        session.flush()
+
+        result = service._find_sessions_with_running_background_tasks(
+            session, USER_ID, ["s-pending"]
+        )
+        assert result == {"s-pending"}
+
+    def test_status_null_with_no_end_time_surfaces(self, session, service):
+        _make_session(session, "s-null")
+        _make_task(session, "t-null", "s-null", status=None)
+        session.flush()
+
+        result = service._find_sessions_with_running_background_tasks(
+            session, USER_ID, ["s-null"]
+        )
+        assert result == {"s-null"}
+
+    def test_only_requested_sessions_returned(self, session, service):
+        _make_session(session, "s-in-page")
+        _make_session(session, "s-out-of-page")
+        _make_task(session, "t-in", "s-in-page", status="running")
+        _make_task(session, "t-out", "s-out-of-page", status="running")
+        session.flush()
+
+        result = service._find_sessions_with_running_background_tasks(
+            session, USER_ID, ["s-in-page"]
+        )
+        assert result == {"s-in-page"}


### PR DESCRIPTION
The /recent-chats page was loading sessions via an unbounded full-table scan: SessionService.get_user_sessions called find_background_tasks_by_status with no filters, pulling every background task in the system into Python before filtering by user. Cost grew with total task history, not page size.

Replace with a single SQL query joining ChatTaskModel and TaskModel, scoped to the user, the page's session_ids, execution_mode=background, end_time IS NULL, and non-terminal status. The terminal-status check on task_metadata JSON now runs only on the matching rows. Same fix benefits the Scheduled Tasks tab, which shares this code path.

Frontend: gate useInfiniteSessions and useSharedWithMe on activeTab so each tab pays only for its own data instead of always firing both.