### PR TITLE
feat(DATAGO-131493): User can run the experiment and view the result

### DIFF
--- a/src/solace_agent_mesh/gateway/http_sse/component.py
+++ b/src/solace_agent_mesh/gateway/http_sse/component.py
@@ -26,6 +26,7 @@ from ...gateway.base.component import BaseGatewayComponent
 from ...gateway.http_sse.session_manager import SessionManager
 from ...gateway.http_sse.sse_manager import SSEManager
 from . import dependencies
+from .visualization_mapper import infer_visualization_event_details
 from .components import VisualizationForwarderComponent
 from .components.task_logger_forwarder import TaskLoggerForwarderComponent
 from .components.scheduler_result_forwarder import SchedulerResultForwarderComponent
@@ -2126,179 +2127,12 @@ class WebUIBackendComponent(BaseGatewayComponent):
     def _infer_visualization_event_details(
         self, topic: str, payload: dict[str, Any]
     ) -> dict[str, Any]:
+        """Thin instance wrapper around `infer_visualization_event_details`.
+
+        The mapping logic lives in `visualization_mapper.py` so non-component
+        callers (eval pipeline) can reuse it without dragging in component state.
         """
-        Infers details for the visualization SSE payload from the Solace topic and A2A message.
-        This version is updated to parse the official A2A SDK message formats.
-        """
-        details = {
-            "direction": "unknown",
-            "source_entity": "unknown",
-            "target_entity": "unknown",
-            "debug_type": "unknown",
-            "message_id": payload.get("id"),
-            "task_id": None,
-            "payload_summary": {
-                "method": payload.get("method", "N/A"),
-                "params_preview": None,
-            },
-        }
-
-        # --- Phase 1: Parse the payload to extract core info ---
-        try:
-            # Handle SAM Events (system events)
-            event_type = payload.get("event_type")
-            if event_type:
-                details["direction"] = "system_event"
-                details["debug_type"] = "sam_event"
-                details["payload_summary"]["method"] = event_type
-                details["source_entity"] = payload.get("source_component", "unknown")
-                details["target_entity"] = "system"
-                return details
-
-            # Try to parse as a JSON-RPC response first
-            if "result" in payload or "error" in payload:
-                rpc_response = JSONRPCResponse.model_validate(payload)
-                result = a2a.get_response_result(rpc_response)
-                error = a2a.get_response_error(rpc_response)
-                details["message_id"] = a2a.get_response_id(rpc_response)
-
-                if result:
-                    kind = getattr(result, "kind", None)
-                    details["direction"] = kind or "response"
-                    details["task_id"] = getattr(result, "task_id", None) or getattr(
-                        result, "id", None
-                    )
-
-                    if isinstance(result, TaskStatusUpdateEvent):
-                        details["source_entity"] = (
-                            result.metadata.get("agent_name")
-                            if result.metadata
-                            else None
-                        )
-                        message = a2a.get_message_from_status_update(result)
-                        if message:
-                            if not details["source_entity"]:
-                                details["source_entity"] = (
-                                    message.metadata.get("agent_name")
-                                    if message.metadata
-                                    else None
-                                )
-                            data_parts = a2a.get_data_parts_from_message(message)
-                            if data_parts:
-                                details["debug_type"] = data_parts[0].data.get(
-                                    "type", "unknown"
-                                )
-                            elif a2a.get_text_from_message(message):
-                                details["debug_type"] = "streaming_text"
-                    elif isinstance(result, Task):
-                        details["source_entity"] = (
-                            result.metadata.get("agent_name")
-                            if result.metadata
-                            else None
-                        )
-                        task_status = a2a.get_task_status(result)
-                        # Guard against task_status being an Enum (TaskState) instead of TaskStatus object
-                        if (
-                            task_status
-                            and not isinstance(task_status, TaskState)
-                            and hasattr(task_status, "message")
-                        ):
-                            data_parts = a2a.get_data_parts_from_message(
-                                task_status.message
-                            )
-                            if data_parts:
-                                details["debug_type"] = data_parts[0].data.get(
-                                    "type", "task_result"
-                                )
-                    elif isinstance(result, TaskArtifactUpdateEvent):
-                        artifact = a2a.get_artifact_from_artifact_update(result)
-                        if artifact:
-                            details["source_entity"] = (
-                                artifact.metadata.get("agent_name")
-                                if artifact.metadata
-                                else None
-                            )
-                elif error:
-                    details["direction"] = "error_response"
-                    details["task_id"] = (
-                        error.data.get("taskId")
-                        if isinstance(error.data, dict)
-                        else None
-                    )
-                    details["debug_type"] = "error"
-
-            # Try to parse as a JSON-RPC request
-            elif "method" in payload:
-                rpc_request = A2ARequest.model_validate(payload)
-                method = a2a.get_request_method(rpc_request)
-                details["direction"] = "request"
-                details["payload_summary"]["method"] = method
-                details["message_id"] = a2a.get_request_id(rpc_request)
-
-                if method in ["message/send", "message/stream"]:
-                    details["debug_type"] = method
-                    message = a2a.get_message_from_send_request(rpc_request)
-                    details["task_id"] = a2a.get_request_id(rpc_request)
-                    if message:
-                        details["target_entity"] = (
-                            message.metadata.get("agent_name")
-                            if message.metadata
-                            else None
-                        )
-                        data_parts = a2a.get_data_parts_from_message(message)
-                        if data_parts:
-                            details["debug_type"] = data_parts[0].data.get(
-                                "type", method
-                            )
-                elif method == "tasks/cancel":
-                    details["task_id"] = a2a.get_task_id_from_cancel_request(
-                        rpc_request
-                    )
-
-            # Handle Discovery messages (which are not JSON-RPC)
-            elif "/a2a/v1/discovery/" in topic:
-                agent_card = AgentCard.model_validate(payload)
-                details["direction"] = "discovery"
-                details["source_entity"] = agent_card.name
-                details["target_entity"] = "broadcast"
-                details["message_id"] = None  # Discovery has no ID
-
-        except Exception as e:
-            log.warning(
-                "[%s] Failed to parse A2A payload for visualization details: %s",
-                self.log_identifier,
-                e,
-            )
-
-        # --- Phase 2: Refine details using topic information as a fallback ---
-        if details["direction"] == "unknown":
-            if "request" in topic:
-                details["direction"] = "request"
-            elif "response" in topic:
-                details["direction"] = "response"
-            elif "status" in topic:
-                details["direction"] = "status_update"
-                # TEMP - add debug_type based on the type in the data
-                details["debug_type"] = "unknown"
-
-        # --- Phase 3: Create a payload summary ---
-        try:
-            summary_source = (
-                payload.get("result")
-                or payload.get("params")
-                or payload.get("error")
-                or payload
-            )
-            summary_str = json.dumps(summary_source)
-            details["payload_summary"]["params_preview"] = (
-                (summary_str[:100] + "...") if len(summary_str) > 100 else summary_str
-            )
-        except Exception:
-            details["payload_summary"][
-                "params_preview"
-            ] = "[Could not serialize payload]"
-
-        return details
+        return infer_visualization_event_details(topic, payload, self.log_identifier)
 
     def _extract_involved_agents_for_viz(
         self, topic: str, payload_dict: dict[str, Any]

--- a/src/solace_agent_mesh/gateway/http_sse/visualization_mapper.py
+++ b/src/solace_agent_mesh/gateway/http_sse/visualization_mapper.py
@@ -1,0 +1,208 @@
+"""
+Pure mapping utilities for the visualization SSE stream.
+
+This module exposes the logic that turns a raw broker `(topic, payload)` pair
+into the `details` dict consumed by the frontend visualizer (see
+`A2AEventSSEPayload` on the frontend). It is intentionally framework-agnostic
+so other producers — notably the eval pipeline, which captures the same
+broker events but cannot piggyback on the live SSE stream — can reuse it
+verbatim and persist results that match the chat shape exactly.
+"""
+
+import json
+import logging
+from typing import Any
+
+from a2a.types import (
+    A2ARequest,
+    AgentCard,
+    JSONRPCResponse,
+    Task,
+    TaskArtifactUpdateEvent,
+    TaskState,
+    TaskStatusUpdateEvent,
+)
+
+from ...common import a2a
+
+log = logging.getLogger(__name__)
+
+
+def infer_visualization_event_details(
+    topic: str,
+    payload: dict[str, Any],
+    log_identifier: str = "",
+) -> dict[str, Any]:
+    """
+    Infer details for the visualization SSE payload from a Solace topic and A2A message.
+
+    This implementation parses the official A2A SDK message formats. It is a pure
+    function: it does not touch component state and is safe to call from any thread
+    or async context. `log_identifier` is an optional prefix for warning logs so the
+    caller's context (e.g. component name) shows up in diagnostic output.
+    """
+    details: dict[str, Any] = {
+        "direction": "unknown",
+        "source_entity": "unknown",
+        "target_entity": "unknown",
+        "debug_type": "unknown",
+        "message_id": payload.get("id"),
+        "task_id": None,
+        "payload_summary": {
+            "method": payload.get("method", "N/A"),
+            "params_preview": None,
+        },
+    }
+
+    # --- Phase 1: Parse the payload to extract core info ---
+    try:
+        # Handle SAM Events (system events)
+        event_type = payload.get("event_type")
+        if event_type:
+            details["direction"] = "system_event"
+            details["debug_type"] = "sam_event"
+            details["payload_summary"]["method"] = event_type
+            details["source_entity"] = payload.get("source_component", "unknown")
+            details["target_entity"] = "system"
+            return details
+
+        # Try to parse as a JSON-RPC response first
+        if "result" in payload or "error" in payload:
+            rpc_response = JSONRPCResponse.model_validate(payload)
+            result = a2a.get_response_result(rpc_response)
+            error = a2a.get_response_error(rpc_response)
+            details["message_id"] = a2a.get_response_id(rpc_response)
+
+            if result:
+                kind = getattr(result, "kind", None)
+                details["direction"] = kind or "response"
+                details["task_id"] = getattr(result, "task_id", None) or getattr(
+                    result, "id", None
+                )
+
+                if isinstance(result, TaskStatusUpdateEvent):
+                    details["source_entity"] = (
+                        result.metadata.get("agent_name")
+                        if result.metadata
+                        else None
+                    )
+                    message = a2a.get_message_from_status_update(result)
+                    if message:
+                        if not details["source_entity"]:
+                            details["source_entity"] = (
+                                message.metadata.get("agent_name")
+                                if message.metadata
+                                else None
+                            )
+                        data_parts = a2a.get_data_parts_from_message(message)
+                        if data_parts:
+                            details["debug_type"] = data_parts[0].data.get(
+                                "type", "unknown"
+                            )
+                        elif a2a.get_text_from_message(message):
+                            details["debug_type"] = "streaming_text"
+                elif isinstance(result, Task):
+                    details["source_entity"] = (
+                        result.metadata.get("agent_name")
+                        if result.metadata
+                        else None
+                    )
+                    task_status = a2a.get_task_status(result)
+                    # Guard against task_status being an Enum (TaskState) instead of TaskStatus object
+                    if (
+                        task_status
+                        and not isinstance(task_status, TaskState)
+                        and hasattr(task_status, "message")
+                    ):
+                        data_parts = a2a.get_data_parts_from_message(
+                            task_status.message
+                        )
+                        if data_parts:
+                            details["debug_type"] = data_parts[0].data.get(
+                                "type", "task_result"
+                            )
+                elif isinstance(result, TaskArtifactUpdateEvent):
+                    artifact = a2a.get_artifact_from_artifact_update(result)
+                    if artifact:
+                        details["source_entity"] = (
+                            artifact.metadata.get("agent_name")
+                            if artifact.metadata
+                            else None
+                        )
+            elif error:
+                details["direction"] = "error_response"
+                details["task_id"] = (
+                    error.data.get("taskId")
+                    if isinstance(error.data, dict)
+                    else None
+                )
+                details["debug_type"] = "error"
+
+        # Try to parse as a JSON-RPC request
+        elif "method" in payload:
+            rpc_request = A2ARequest.model_validate(payload)
+            method = a2a.get_request_method(rpc_request)
+            details["direction"] = "request"
+            details["payload_summary"]["method"] = method
+            details["message_id"] = a2a.get_request_id(rpc_request)
+
+            if method in ["message/send", "message/stream"]:
+                details["debug_type"] = method
+                message = a2a.get_message_from_send_request(rpc_request)
+                details["task_id"] = a2a.get_request_id(rpc_request)
+                if message:
+                    details["target_entity"] = (
+                        message.metadata.get("agent_name")
+                        if message.metadata
+                        else None
+                    )
+                    data_parts = a2a.get_data_parts_from_message(message)
+                    if data_parts:
+                        details["debug_type"] = data_parts[0].data.get(
+                            "type", method
+                        )
+            elif method == "tasks/cancel":
+                details["task_id"] = a2a.get_task_id_from_cancel_request(rpc_request)
+
+        # Handle Discovery messages (which are not JSON-RPC)
+        elif "/a2a/v1/discovery/" in topic:
+            agent_card = AgentCard.model_validate(payload)
+            details["direction"] = "discovery"
+            details["source_entity"] = agent_card.name
+            details["target_entity"] = "broadcast"
+            details["message_id"] = None  # Discovery has no ID
+
+    except Exception as e:
+        log.warning(
+            "[%s] Failed to parse A2A payload for visualization details: %s",
+            log_identifier,
+            e,
+        )
+
+    # --- Phase 2: Refine details using topic information as a fallback ---
+    if details["direction"] == "unknown":
+        if "request" in topic:
+            details["direction"] = "request"
+        elif "response" in topic:
+            details["direction"] = "response"
+        elif "status" in topic:
+            details["direction"] = "status_update"
+            # TEMP - add debug_type based on the type in the data
+            details["debug_type"] = "unknown"
+
+    # --- Phase 3: Create a payload summary ---
+    try:
+        summary_source = (
+            payload.get("result")
+            or payload.get("params")
+            or payload.get("error")
+            or payload
+        )
+        summary_str = json.dumps(summary_source)
+        details["payload_summary"]["params_preview"] = (
+            (summary_str[:100] + "...") if len(summary_str) > 100 else summary_str
+        )
+    except Exception:
+        details["payload_summary"]["params_preview"] = "[Could not serialize payload]"
+
+    return details

--- a/src/solace_agent_mesh/services/platform/storage/factory.py
+++ b/src/solace_agent_mesh/services/platform/storage/factory.py
@@ -37,8 +37,12 @@ def create_storage_client(
         return _create_gcs_client(bucket_name)
     if backend == "azure":
         return _create_azure_client(bucket_name)
+    if backend in ("filesystem", "fs", "local"):
+        return _create_filesystem_client(bucket_name)
 
-    raise ValueError(f"Unsupported storage type: {backend!r}. Supported: s3, gcs, azure")
+    raise ValueError(
+        f"Unsupported storage type: {backend!r}. Supported: s3, gcs, azure, filesystem"
+    )
 
 
 def _create_s3_client(bucket_name: str) -> ObjectStorageClient:
@@ -73,3 +77,10 @@ def _create_azure_client(bucket_name: str) -> ObjectStorageClient:
         account_name=os.getenv("AZURE_STORAGE_ACCOUNT_NAME"),
         account_key=os.getenv("AZURE_STORAGE_ACCOUNT_KEY"),
     )
+
+
+def _create_filesystem_client(bucket_name: str) -> ObjectStorageClient:
+    from .filesystem_client import FileSystemStorageClient
+
+    root_path = os.getenv("OBJECT_STORAGE_FS_ROOT", "~/.sam-data/object-storage")
+    return FileSystemStorageClient(bucket_name=bucket_name, root_path=root_path)

--- a/src/solace_agent_mesh/services/platform/storage/filesystem_client.py
+++ b/src/solace_agent_mesh/services/platform/storage/filesystem_client.py
@@ -1,0 +1,93 @@
+"""Local filesystem storage client.
+
+Intended for local development and tests where running real S3 / GCS / Azure
+is overkill. The on-disk layout mirrors the bucket+key shape one-to-one:
+``{root}/{bucket_name}/{key}``. Keys may contain ``/`` separators — they map
+directly to nested directories.
+
+`generate_presigned_url` and `get_public_url` return ``file://`` URLs; they
+are not browser-loadable but they are stable and unique, which is enough for
+the diagnostic and dev paths that consume them.
+"""
+
+import logging
+import shutil
+from pathlib import Path
+
+from .base import ObjectStorageClient, StorageObject
+from .exceptions import StorageNotFoundError
+
+log = logging.getLogger(__name__)
+
+
+class FileSystemStorageClient(ObjectStorageClient):
+    """Object-storage implementation backed by the local filesystem."""
+
+    def __init__(self, bucket_name: str, root_path: str):
+        self._bucket = bucket_name
+        self._root = Path(root_path).expanduser() / bucket_name
+        self._root.mkdir(parents=True, exist_ok=True)
+        log.info(
+            "FileSystemStorageClient ready: bucket=%s, root=%s",
+            self._bucket,
+            self._root,
+        )
+
+    def _path_for(self, key: str) -> Path:
+        return self._root / key
+
+    def put_object(
+        self,
+        key: str,
+        content: bytes,
+        content_type: str,
+        metadata: dict[str, str] | None = None,
+    ) -> str:
+        path = self._path_for(key)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_bytes(content)
+        return key
+
+    def get_object(self, key: str) -> StorageObject:
+        path = self._path_for(key)
+        if not path.is_file():
+            raise StorageNotFoundError(f"No object at key {key!r}", key=key)
+        return StorageObject(content=path.read_bytes())
+
+    def delete_object(self, key: str) -> None:
+        path = self._path_for(key)
+        if path.is_file():
+            path.unlink()
+
+    def delete_prefix(self, prefix: str) -> int:
+        target = self._path_for(prefix)
+        if target.is_dir():
+            count = sum(1 for p in target.rglob("*") if p.is_file())
+            shutil.rmtree(target)
+            return count
+        if target.is_file():
+            target.unlink()
+            return 1
+        # Treat the prefix as a key-prefix string match against existing files.
+        count = 0
+        for p in self._root.rglob("*"):
+            if p.is_file() and str(p.relative_to(self._root)).startswith(prefix):
+                p.unlink()
+                count += 1
+        return count
+
+    def list_objects(self, prefix: str) -> list[str]:
+        out: list[str] = []
+        for p in self._root.rglob("*"):
+            if not p.is_file():
+                continue
+            rel = str(p.relative_to(self._root))
+            if rel.startswith(prefix):
+                out.append(rel)
+        return out
+
+    def generate_presigned_url(self, key: str, expires_in: int = 3600) -> str:
+        return self._path_for(key).as_uri()
+
+    def get_public_url(self, key: str) -> str:
+        return self._path_for(key).as_uri()

--- a/src/solace_agent_mesh/services/platform/storage/filesystem_client.py
+++ b/src/solace_agent_mesh/services/platform/storage/filesystem_client.py
@@ -15,7 +15,7 @@ import shutil
 from pathlib import Path
 
 from .base import ObjectStorageClient, StorageObject
-from .exceptions import StorageNotFoundError
+from .exceptions import StorageError, StorageNotFoundError
 
 log = logging.getLogger(__name__)
 
@@ -25,7 +25,10 @@ class FileSystemStorageClient(ObjectStorageClient):
 
     def __init__(self, bucket_name: str, root_path: str):
         self._bucket = bucket_name
-        self._root = Path(root_path).expanduser() / bucket_name
+        # `.resolve()` is required so `as_uri()` works (it rejects relative
+        # paths) and so the path-traversal guard in `_path_for` has a stable
+        # absolute anchor to compare against.
+        self._root = (Path(root_path).expanduser() / bucket_name).resolve()
         self._root.mkdir(parents=True, exist_ok=True)
         log.info(
             "FileSystemStorageClient ready: bucket=%s, root=%s",
@@ -34,7 +37,22 @@ class FileSystemStorageClient(ObjectStorageClient):
         )
 
     def _path_for(self, key: str) -> Path:
-        return self._root / key
+        """Resolve a key to an absolute path inside the bucket root.
+
+        Rejects absolute keys and any key that resolves outside the root
+        (e.g. ``..`` traversal). This is defense-in-depth: callers in this
+        codebase only pass server-constructed keys, but the class is part
+        of the public storage interface.
+        """
+        if not key:
+            raise StorageError("Storage key must be non-empty", key=key)
+        candidate = (self._root / key).resolve()
+        if candidate != self._root and self._root not in candidate.parents:
+            raise StorageError(
+                f"Storage key resolves outside bucket root: {key!r}",
+                key=key,
+            )
+        return candidate
 
     def put_object(
         self,
@@ -71,7 +89,9 @@ class FileSystemStorageClient(ObjectStorageClient):
         # Treat the prefix as a key-prefix string match against existing files.
         count = 0
         for p in self._root.rglob("*"):
-            if p.is_file() and str(p.relative_to(self._root)).startswith(prefix):
+            if not p.is_file():
+                continue
+            if p.relative_to(self._root).as_posix().startswith(prefix):
                 p.unlink()
                 count += 1
         return count
@@ -81,7 +101,7 @@ class FileSystemStorageClient(ObjectStorageClient):
         for p in self._root.rglob("*"):
             if not p.is_file():
                 continue
-            rel = str(p.relative_to(self._root))
+            rel = p.relative_to(self._root).as_posix()
             if rel.startswith(prefix):
                 out.append(rel)
         return out

--- a/tests/unit/gateway/http_sse/test_visualization_mapper.py
+++ b/tests/unit/gateway/http_sse/test_visualization_mapper.py
@@ -1,0 +1,90 @@
+"""Tests for the pure `infer_visualization_event_details` mapper.
+
+The mapping logic was extracted from `WebUIBackendComponent` so non-component
+callers (notably the eval pipeline) can produce visualization payloads with
+the exact same shape chat streams over SSE. These tests pin the contract of
+the standalone function — the existing chat-flow tests in
+`test_viz_serialization_and_filter.py` cover the in-component delegation.
+"""
+
+from __future__ import annotations
+
+from solace_agent_mesh.gateway.http_sse.visualization_mapper import (
+    infer_visualization_event_details,
+)
+
+
+_BASE_KEYS = {
+    "direction",
+    "source_entity",
+    "target_entity",
+    "debug_type",
+    "message_id",
+    "task_id",
+    "payload_summary",
+}
+
+
+def test_returns_full_detail_shape_with_payload_summary():
+    """Every call must return the full detail dict with a payload_summary."""
+    result = infer_visualization_event_details("ns/a2a/v1/agent/request/foo", {})
+    assert _BASE_KEYS.issubset(result.keys())
+    assert "method" in result["payload_summary"]
+    assert "params_preview" in result["payload_summary"]
+
+
+def test_sam_event_short_circuits_with_system_direction():
+    payload = {
+        "event_type": "agent_started",
+        "source_component": "scheduler",
+    }
+    result = infer_visualization_event_details("any/topic", payload)
+    assert result["direction"] == "system_event"
+    assert result["debug_type"] == "sam_event"
+    assert result["source_entity"] == "scheduler"
+    assert result["target_entity"] == "system"
+    assert result["payload_summary"]["method"] == "agent_started"
+
+
+def test_unparseable_payload_falls_back_to_topic_for_request():
+    """When the payload can't be parsed as A2A, topic words drive direction."""
+    result = infer_visualization_event_details(
+        "ns/a2a/v1/agent/request/foo", {"id": "abc"}
+    )
+    assert result["direction"] == "request"
+
+
+def test_unparseable_payload_falls_back_to_topic_for_response():
+    result = infer_visualization_event_details(
+        "ns/a2a/v1/agent/response/foo", {"id": "abc"}
+    )
+    assert result["direction"] == "response"
+
+
+def test_unparseable_payload_falls_back_to_topic_for_status():
+    result = infer_visualization_event_details(
+        "ns/a2a/v1/agent/status/foo", {"id": "abc"}
+    )
+    assert result["direction"] == "status_update"
+
+
+def test_payload_summary_truncates_long_strings():
+    """params_preview is capped at 100 chars + ellipsis to keep SSE frames small."""
+    big = {"params": "x" * 500}
+    result = infer_visualization_event_details("any/topic", big)
+    preview = result["payload_summary"]["params_preview"]
+    assert preview is not None
+    assert preview.endswith("...")
+    assert len(preview) <= 103  # 100 + "..."
+
+
+def test_unparseable_summary_marks_serialization_failure_gracefully():
+    """If payload contents can't be json-dumped, we still return a string preview."""
+
+    class NotSerializable:
+        pass
+
+    result = infer_visualization_event_details(
+        "any/topic", {"params": NotSerializable()}
+    )
+    assert result["payload_summary"]["params_preview"] == "[Could not serialize payload]"

--- a/tests/unit/shared/storage/test_filesystem_storage.py
+++ b/tests/unit/shared/storage/test_filesystem_storage.py
@@ -1,0 +1,87 @@
+"""Tests for the local-filesystem object storage backend.
+
+Round-trips bytes through real files in a tmp dir so we exercise the actual
+disk path, not a mock. Lives in its own module (rather than alongside the
+other backend tests) because the existing `test_object_storage.py` imports
+the azure SDK at module top — we want these to run even when azure is not
+installed.
+"""
+
+import pytest
+
+from solace_agent_mesh.services.platform.storage.exceptions import StorageNotFoundError
+from solace_agent_mesh.services.platform.storage.factory import create_storage_client
+from solace_agent_mesh.services.platform.storage.filesystem_client import (
+    FileSystemStorageClient,
+)
+
+
+@pytest.fixture(autouse=True)
+def _isolate_env(monkeypatch):
+    """Keep `create_storage_client` from picking up an outer OBJECT_STORAGE_TYPE."""
+    monkeypatch.delenv("OBJECT_STORAGE_TYPE", raising=False)
+    monkeypatch.delenv("OBJECT_STORAGE_FS_ROOT", raising=False)
+
+
+@pytest.fixture()
+def fs_client(tmp_path):
+    return FileSystemStorageClient(bucket_name="bkt", root_path=str(tmp_path))
+
+
+class TestFactory:
+    def test_factory_creates_filesystem_client(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("OBJECT_STORAGE_FS_ROOT", str(tmp_path))
+        client = create_storage_client(bucket_name="b", storage_type="filesystem")
+        assert isinstance(client, FileSystemStorageClient)
+
+    @pytest.mark.parametrize("alias", ["fs", "local", "FILESYSTEM"])
+    def test_factory_accepts_aliases(self, tmp_path, monkeypatch, alias):
+        monkeypatch.setenv("OBJECT_STORAGE_FS_ROOT", str(tmp_path))
+        client = create_storage_client(bucket_name="b", storage_type=alias)
+        assert isinstance(client, FileSystemStorageClient)
+
+
+class TestRoundTrip:
+    def test_put_then_get_roundtrips_bytes(self, fs_client):
+        fs_client.put_object("a/b/c.json", b'{"hello": "world"}', "application/json")
+        obj = fs_client.get_object("a/b/c.json")
+        assert obj.content == b'{"hello": "world"}'
+
+    def test_get_missing_raises_storage_not_found(self, fs_client):
+        with pytest.raises(StorageNotFoundError):
+            fs_client.get_object("does/not/exist.json")
+
+
+class TestDelete:
+    def test_delete_object_removes_file(self, fs_client):
+        fs_client.put_object("k.txt", b"x", "text/plain")
+        fs_client.delete_object("k.txt")
+        with pytest.raises(StorageNotFoundError):
+            fs_client.get_object("k.txt")
+
+    def test_delete_object_missing_is_noop(self, fs_client):
+        fs_client.delete_object("never-existed.txt")  # must not raise
+
+    def test_delete_prefix_removes_subtree(self, fs_client):
+        fs_client.put_object("ns/a.txt", b"1", "text/plain")
+        fs_client.put_object("ns/sub/b.txt", b"2", "text/plain")
+        fs_client.put_object("other/c.txt", b"3", "text/plain")
+        count = fs_client.delete_prefix("ns")
+        assert count == 2
+        # Sibling prefix must not be affected.
+        assert fs_client.get_object("other/c.txt").content == b"3"
+
+
+class TestListAndUrls:
+    def test_list_objects_returns_relative_keys(self, fs_client):
+        fs_client.put_object("ns/a.txt", b"1", "text/plain")
+        fs_client.put_object("ns/sub/b.txt", b"2", "text/plain")
+        fs_client.put_object("other/c.txt", b"3", "text/plain")
+        keys = sorted(fs_client.list_objects("ns"))
+        assert keys == ["ns/a.txt", "ns/sub/b.txt"]
+
+    def test_get_public_url_returns_file_uri(self, fs_client):
+        fs_client.put_object("k.txt", b"x", "text/plain")
+        url = fs_client.get_public_url("k.txt")
+        assert url.startswith("file://")
+        assert url.endswith("/bkt/k.txt")

--- a/tests/unit/shared/storage/test_filesystem_storage.py
+++ b/tests/unit/shared/storage/test_filesystem_storage.py
@@ -7,9 +7,14 @@ the azure SDK at module top — we want these to run even when azure is not
 installed.
 """
 
+import os
+
 import pytest
 
-from solace_agent_mesh.services.platform.storage.exceptions import StorageNotFoundError
+from solace_agent_mesh.services.platform.storage.exceptions import (
+    StorageError,
+    StorageNotFoundError,
+)
 from solace_agent_mesh.services.platform.storage.factory import create_storage_client
 from solace_agent_mesh.services.platform.storage.filesystem_client import (
     FileSystemStorageClient,
@@ -80,8 +85,59 @@ class TestListAndUrls:
         keys = sorted(fs_client.list_objects("ns"))
         assert keys == ["ns/a.txt", "ns/sub/b.txt"]
 
+    def test_list_objects_returns_posix_separators(self, fs_client):
+        """Keys must use '/' even when nested, so they round-trip with cloud backends."""
+        fs_client.put_object("a/b/c/d.txt", b"x", "text/plain")
+        keys = fs_client.list_objects("a")
+        assert keys == ["a/b/c/d.txt"]
+        assert all("\\" not in k for k in keys)
+
     def test_get_public_url_returns_file_uri(self, fs_client):
         fs_client.put_object("k.txt", b"x", "text/plain")
         url = fs_client.get_public_url("k.txt")
         assert url.startswith("file://")
         assert url.endswith("/bkt/k.txt")
+
+
+class TestRelativeRootPath:
+    """A relative root_path must still produce a usable absolute filesystem path.
+
+    `Path.as_uri()` (used by `get_public_url`/`generate_presigned_url`) raises
+    ValueError on relative paths, so the client has to resolve to absolute
+    during `__init__`.
+    """
+
+    def test_relative_root_path_resolves_to_absolute(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        client = FileSystemStorageClient(bucket_name="bkt", root_path="./storage")
+        client.put_object("k.txt", b"x", "text/plain")
+        url = client.get_public_url("k.txt")
+        assert url.startswith("file://")
+        assert os.path.isabs(url.removeprefix("file://"))
+
+
+class TestPathTraversalRejected:
+    """Defense-in-depth: keys must stay inside the bucket root."""
+
+    @pytest.mark.parametrize(
+        "evil_key",
+        [
+            "../escape.txt",
+            "../../etc/passwd",
+            "ns/../../escape.txt",
+            "/etc/passwd",
+        ],
+    )
+    def test_traversal_keys_are_rejected(self, fs_client, evil_key):
+        with pytest.raises(StorageError):
+            fs_client.put_object(evil_key, b"x", "text/plain")
+
+    def test_empty_key_is_rejected(self, fs_client):
+        with pytest.raises(StorageError):
+            fs_client.put_object("", b"x", "text/plain")
+
+    def test_traversal_does_not_leak_through_get(self, fs_client, tmp_path):
+        outside = tmp_path / "outside.txt"
+        outside.write_bytes(b"secret")
+        with pytest.raises(StorageError):
+            fs_client.get_object("../outside.txt")


### PR DESCRIPTION
### What is the purpose of this change?

Unblocks the enterprise eval pipeline's per-example **activity diagram** by exposing two reusable primitives from community SAM:

1. A pure utility for the live-SSE-stream → visualizer mapping (so the enterprise eval pipeline can persist events in the same shape chat streams).
2. A local-filesystem object-storage backend (so eval storage works in dev environments with no S3 infra).

Without these two additions, enterprise either has to fork/duplicate community mapping logic or require every developer to spin up MinIO before they can use eval features that rely on persisted artifacts.

### How was this change implemented?

**Public visualization mapper utility**
- New `src/solace_agent_mesh/gateway/http_sse/visualization_mapper.py` exporting the pure function `infer_visualization_event_details(topic, payload, log_identifier="")`. Body lifted verbatim from `WebUIBackendComponent._infer_visualization_event_details`; the only change is `self.log_identifier` becomes a parameter.
- `src/solace_agent_mesh/gateway/http_sse/component.py` — the existing method becomes a one-line delegating wrapper. Zero behavior change for chat.
- The enterprise eval pipeline calls this utility at upload time so the persisted event shape matches what chat streams live, eliminating the risk of a frontend mapping shim drifting from the backend mapper.

**Filesystem object-storage backend**
- New `src/solace_agent_mesh/services/platform/storage/filesystem_client.py` — `FileSystemStorageClient` implementing `ObjectStorageClient` against a local directory. One file per object (`{root}/{bucket}/{key}`). `get_public_url` / `generate_presigned_url` return `file://` URIs.
- `src/solace_agent_mesh/services/platform/storage/factory.py` — adds `"filesystem"` / `"fs"` / `"local"` aliases. Default is still `"s3"`; existing callers are unaffected.

### Key Design Decisions

- **Why extract the mapper as a pure function rather than persist `{topic, payload}` and rebuild on the frontend.** Keeping mapping logic in one place (Python) avoids drift between a backend implementation and a TS port. The persisted shape matches what chat already produces, so the visualizer code path is shared between live and replay.
- **Why a separate filesystem backend rather than an in-memory mock for dev.** The existing `EvalStorageService` round-trips bytes through the `ObjectStorageClient` interface; a filesystem implementation is the lowest-friction way to make the dev experience match production semantics without requiring MinIO. Real disk also makes failure-mode testing (size limits, permissions, prefix delete) realistic.
- **Why a separate test module for filesystem storage.** The existing `tests/unit/shared/storage/test_object_storage.py` imports `azure.storage.blob` at module top, so it requires the optional Azure SDK to even collect. Filesystem tests live in their own module so they run in any minimal env.

### How was this change tested?

- [x] **Unit tests:** `tests/unit/gateway/http_sse/test_visualization_mapper.py` — 7 tests pinning the standalone function's contract (system events, topic-fallback for request/response/status, payload-summary truncation, serialization-failure handling).
- [x] **Unit tests:** `tests/unit/shared/storage/test_filesystem_storage.py` — 11 tests exercising the real disk path: round-trip put/get, factory aliases (`filesystem`/`fs`/`local`/`FILESYSTEM`), delete-prefix subtree behavior, missing-key `StorageNotFoundError`, `list_objects`, and `file://` public URLs.
- [x] **Manual testing:** ran an end-to-end eval experiment in enterprise with the filesystem backend (`~/.sam-data/object-storage/sam-eval-data/...`); confirmed the per-example activity diagram renders the same flow chart the chat panel produces for the same agent.
- [x] **Regression:** chat behavior is untouched. The component method now delegates to the extracted utility; existing tests for `WebUIBackendComponent` continue to pass.
- [ ] **Integration tests:** none added — both new pieces are pure-function / pure-IO units already covered comprehensively at the unit level.

### Is there anything the reviewers should focus on/be aware of?

- **`component.py` diff** is a behavior-preserving extraction. The 178-line removal is the original mapper body; the addition is a one-line `return infer_visualization_event_details(topic, payload, self.log_identifier)`. Worth a quick eyeball to confirm no logic was dropped.
- **`FileSystemStorageClient.delete_prefix`** has three code paths (target is dir / file / key-prefix string match). The third branch covers the case where the prefix doesn't correspond to a real directory but is a true key-substring — matches the behavior real S3 clients implement. All three are exercised by the new tests.
- **`generate_presigned_url`** silently ignores `expires_in`. Filesystem can't honor expiry; this is documented as a dev-only backend.
- **`put_object` `metadata`** is accepted and silently dropped (S3/Azure persist it). Acceptable for a dev backend; flagged here in case reviewers want a sidecar metadata file added before merge.