### PR TITLE
fix(DATAGO-134139): stop cascading auth prompts in solace-chat's Atlassian heavy-query flow

### DIFF
--- a/src/solace_agent_mesh/agent/adk/embed_resolving_mcp_toolset.py
+++ b/src/solace_agent_mesh/agent/adk/embed_resolving_mcp_toolset.py
@@ -337,10 +337,33 @@ class EmbedResolvingMCPTool(_BaseMcpToolClass):
         return data
 
 
+    # Substring matching is only trusted for response payloads that are this
+    # small. Free-form tool output (Jira issues, Confluence pages, search
+    # results) routinely embeds substrings like "401 Unauthorized" or
+    # "403 Forbidden" in legitimate content (logs, error reports, status URLs
+    # like .../rest/api/3/status/10401, gravatar hashes that contain "403").
+    # Triggering re-auth on those was the cause of cascading "Pending user
+    # authorization" prompts mid-conversation.
+    _SUBSTRING_AUTH_CHECK_MAX_TEXT_LEN = 2000
+
     def _is_auth_error(self, result: dict) -> bool:
-        """Check if an MCP tool result indicates an authentication/authorization error."""
+        """Check if an MCP tool result indicates an authentication/authorization error.
+
+        Authoritative signals (always trusted):
+        - The MCP CallToolResult-level ``isError`` flag.
+        - A text item that parses as a JSON object with top-level
+          ``code`` or ``status`` equal to 401 / 403.
+
+        Heuristic signal (only when the result is already flagged as an
+        error AND the text item is small): substring match on
+        "401 unauthorized" / "403 forbidden". This is gated to avoid
+        false positives on large free-form tool output where legitimate
+        content can contain the substrings.
+        """
         if not isinstance(result, dict):
             return False
+
+        is_error_result = bool(result.get("isError"))
 
         content = result.get("content", [])
         if not isinstance(content, list):
@@ -352,7 +375,7 @@ class EmbedResolvingMCPTool(_BaseMcpToolClass):
 
             text = item.get("text", "")
 
-            # Try parsing as JSON (e.g. {"code":401,"message":"Unauthorized"})
+            # Structured signal: JSON object with top-level code/status.
             try:
                 parsed = json.loads(text)
                 if isinstance(parsed, dict):
@@ -364,12 +387,16 @@ class EmbedResolvingMCPTool(_BaseMcpToolClass):
             except (json.JSONDecodeError, TypeError):
                 pass
 
-            # Fall back to string matching
-            text_lower = text.lower()
-            if "401" in text_lower and "unauthorized" in text_lower:
-                return True
-            if "403" in text_lower and "forbidden" in text_lower:
-                return True
+            # Heuristic substring fallback — only when the result is
+            # explicitly an error AND the payload is small enough that the
+            # substring is plausibly the whole error message rather than
+            # incidental content.
+            if is_error_result and len(text) <= self._SUBSTRING_AUTH_CHECK_MAX_TEXT_LEN:
+                text_lower = text.lower()
+                if "401" in text_lower and "unauthorized" in text_lower:
+                    return True
+                if "403" in text_lower and "forbidden" in text_lower:
+                    return True
 
         return False
 

--- a/tests/unit/agent/adk/test_mcp_auth_error_detection.py
+++ b/tests/unit/agent/adk/test_mcp_auth_error_detection.py
@@ -47,23 +47,110 @@ class TestIsAuthError:
         }
         assert tool._is_auth_error(result) is True
 
-    def test_401_string_fallback(self, tool):
-        """Detect 401 from plain text containing '401' and 'unauthorized'."""
+    def test_401_string_fallback_with_is_error(self, tool):
+        """Detect 401 from plain text when the result is flagged isError=True."""
         result = {
+            "isError": True,
+            "content": [
+                {"type": "text", "text": "Error 401 Unauthorized"}
+            ],
+        }
+        assert tool._is_auth_error(result) is True
+
+    def test_403_string_fallback_with_is_error(self, tool):
+        """Detect 403 from plain text when the result is flagged isError=True."""
+        result = {
+            "isError": True,
+            "content": [
+                {"type": "text", "text": "Error 403 Forbidden"}
+            ],
+        }
+        assert tool._is_auth_error(result) is True
+
+    def test_string_fallback_ignored_without_is_error(self, tool):
+        """Substring matches in non-error results must not trigger re-auth.
+
+        This is the false-positive case: a successful tool result whose text
+        happens to contain '401 Unauthorized' or '403 Forbidden' (e.g., a Jira
+        issue's description quoting an unrelated error log) was previously
+        causing cascading auth prompts mid-conversation.
+        """
+        result_a = {
             "content": [
                 {"type": "text", "text": "Error 401 Unauthorized"}
             ]
         }
-        assert tool._is_auth_error(result) is True
-
-    def test_403_string_fallback(self, tool):
-        """Detect 403 from plain text containing '403' and 'forbidden'."""
-        result = {
+        result_b = {
             "content": [
                 {"type": "text", "text": "Error 403 Forbidden"}
             ]
         }
+        assert tool._is_auth_error(result_a) is False
+        assert tool._is_auth_error(result_b) is False
+
+    def test_string_fallback_ignored_for_large_payloads(self, tool):
+        """Substring matches in large payloads do not trigger re-auth even if
+        isError is set, because they're more likely incidental content than
+        a real error message."""
+        large_text = (
+            "x" * 5000 + " 401 Unauthorized in some embedded log " + "y" * 5000
+        )
+        result = {
+            "isError": True,
+            "content": [{"type": "text", "text": large_text}],
+        }
+        assert tool._is_auth_error(result) is False
+
+    def test_jira_issue_text_does_not_false_positive(self, tool):
+        """Real-world false-positive case from staging: a successful Jira
+        search result whose issue descriptions contain '401 Unauthorized' /
+        '403 Forbidden' substrings inside legitimate content (logs, status
+        URLs like .../rest/api/3/status/10401, gravatar hashes containing
+        '403'). The result is large free-form data, not an error response.
+        """
+        # Simulate a >2KB Jira issues response with the offending substrings.
+        issues_payload = (
+            '{"issues":['
+            '{"key":"DATAGO-130600","fields":{'
+            '"summary":"Datadog alert: SEMP call failed",'
+            '"description":"Got 401 Unauthorized from upstream SEMP API",'
+            '"status":{"self":"https://api.atlassian.com/.../status/10401",'
+            '"name":"Open"}'
+            '}}'
+            '],"nextPageToken":null,"isLast":true}'
+        )
+        # Pad the description to push the text over the substring-match
+        # threshold so we exercise the size gate too.
+        padded = issues_payload.replace(
+            "Got 401 Unauthorized from upstream SEMP API",
+            "Got 401 Unauthorized from upstream SEMP API. " + ("padding " * 400),
+        )
+        result = {"content": [{"type": "text", "text": padded}]}
+        assert tool._is_auth_error(result) is False
+
+    def test_json_code_still_matched_in_large_payloads(self, tool):
+        """A real top-level {"code": 401} stays detected regardless of size.
+
+        We only gate the substring fallback; the structured signal is
+        always trusted because it cannot be confused with incidental text.
+        """
+        big_padding = " padding" * 500
+        result = {
+            "content": [
+                {"type": "text", "text": '{"code":401,"message":"Unauthorized","extra":"' + big_padding + '"}'}
+            ]
+        }
         assert tool._is_auth_error(result) is True
+
+    def test_is_error_alone_is_not_an_auth_error(self, tool):
+        """An MCP error result that isn't auth-related should not trigger re-auth."""
+        result = {
+            "isError": True,
+            "content": [
+                {"type": "text", "text": "Internal server error: database unreachable"}
+            ],
+        }
+        assert tool._is_auth_error(result) is False
 
     def test_200_not_auth_error(self, tool):
         """A 200 response is not an auth error."""


### PR DESCRIPTION
## Summary

`EmbedResolvingMCPTool._is_auth_error` flagged any MCP tool result whose text contained both `"401"` and `"unauthorized"` (or `"403"` and `"forbidden"`) as an authentication failure. For free-form tool output — Jira issues, Confluence pages, search results — this triggers cascading "Pending user authorization." prompts mid-conversation whenever legitimate response content happens to include those substrings.

## Diagnosis

Diagnosed against the Atlassian MCP server on staging. A single `searchJiraIssuesUsingJql` response (~700KB, top-level keys `['issues','nextPageToken','isLast']`) matched the substring check four times:

| Substring | Where it actually appeared |
|---|---|
| `"401 Unauthorized"` | Inside a Jira issue description quoting an upstream SEMP API error log |
| `"403 Forbidden"` | Inside an issue description discussing S3 HeadBucket errors behind a corporate proxy |
| `"401"` | Jira's own status REST URL: `.../rest/api/3/status/10401` (the status ID literally is 10401) |
| `"403"` | Inside a Gravatar avatar URL hash that happened to contain `403` |

None of these were real auth failures. The result had:
- No top-level `isError`
- No top-level `code` / `status` of 401 / 403
- No nested 401 / 403 anywhere in the JSON tree (verified by walking the full structure)

The user saw two `"The 'JiraConfluenceAgent' agent requires authentication."` prompts during one heavy DATAGO bug query, with no underlying auth issue.

## Fix

Tighten `_is_auth_error`:

1. **Always trust structured signals** — text items that parse as JSON with top-level `code` or `status` equal to 401 / 403. Behavior unchanged.
2. **Gate the substring fallback** behind two conditions:
   - The MCP `CallToolResult.isError` flag is true. We only consider substring matches when we're already inside an error response, not a legitimate large data response.
   - The text item is at most 2 KB (`_SUBSTRING_AUTH_CHECK_MAX_TEXT_LEN`). Real auth error payloads are short; substring matches in larger payloads are dominated by incidental content.

A separate enterprise-side fix (PR #1080 in `solace-agent-mesh-enterprise`) made `save_credential(None)` a no-op so the false-positive trigger no longer destroys the persisted credential — but the user-visible re-auth prompts still fire from this path until this detector is fixed.

## Test plan

- [x] Existing tests updated where they implicitly relied on substring matching working without `isError` (now set `isError=True` to match real MCP shape).
- [x] New regression test reproducing the staging case: a large Jira-style response containing the offending substrings inside legitimate content. Asserts `_is_auth_error` returns `False`.
- [x] New test: large payload with `isError=True` and an embedded substring match — still `False` because it's beyond the size gate.
- [x] New test: structured `{"code": 401}` is detected even in a large payload (the structured signal is not gated).
- [x] New test: `isError=True` with non-auth-related text doesn't trigger re-auth.
- [x] `tests/unit/agent/adk/test_mcp_auth_error_detection.py` — 22 tests pass.