### PR TITLE
fix(DATAGO-134263): honour per-node timeout in workflow agent calls

### DIFF
--- a/src/solace_agent_mesh/workflow/agent_caller.py
+++ b/src/solace_agent_mesh/workflow/agent_caller.py
@@ -20,6 +20,7 @@ from ..agent.utils.artifact_helpers import (
     format_artifact_uri,
 )
 from .app import WorkflowNode, WorkflowInvokeNode
+from .utils import parse_duration
 from .workflow_execution_context import WorkflowExecutionContext, WorkflowExecutionState
 
 if TYPE_CHECKING:
@@ -138,7 +139,11 @@ class AgentCaller:
 
         # Publish request
         await self._publish_agent_request(
-            node.agent_name, message, sub_task_id, workflow_context
+            node.agent_name,
+            message,
+            sub_task_id,
+            workflow_context,
+            self._resolve_node_timeout(node.timeout),
         )
 
         # Track in workflow context
@@ -227,7 +232,11 @@ class AgentCaller:
 
         # Publish request to the sub-workflow
         await self._publish_agent_request(
-            node.workflow_name, message, sub_task_id, workflow_context
+            node.workflow_name,
+            message,
+            sub_task_id,
+            workflow_context,
+            self._resolve_node_timeout(node.timeout),
         )
 
         # Track in workflow context
@@ -462,12 +471,36 @@ This is MANDATORY for the workflow to continue.
 
         return message
 
+    def _resolve_node_timeout(self, node_timeout: Optional[str]) -> float:
+        """
+        Resolve the timeout for a node call in seconds.
+
+        If the node defines its own ``timeout`` (e.g. "5m"), parse and use it;
+        otherwise fall back to the workflow-level ``default_node_timeout_seconds``.
+        Invalid per-node values fall back to the default with a warning rather
+        than failing the call.
+        """
+        default_timeout = float(
+            self.host.get_config("default_node_timeout_seconds", 300)
+        )
+        if not node_timeout:
+            return default_timeout
+        try:
+            return parse_duration(node_timeout)
+        except ValueError as e:
+            log.warning(
+                f"{self.host.log_identifier} Invalid per-node timeout '{node_timeout}', "
+                f"falling back to default_node_timeout_seconds={default_timeout}s: {e}"
+            )
+            return default_timeout
+
     async def _publish_agent_request(
         self,
         agent_name: str,
         message: A2AMessage,
         sub_task_id: str,
         workflow_context: WorkflowExecutionContext,
+        timeout_seconds: float,
     ):
         """Publish A2A request to agent."""
         log_id = f"{self.host.log_identifier}[PublishAgentRequest:{agent_name}]"
@@ -510,8 +543,9 @@ This is MANDATORY for the workflow to continue.
             f"{log_id} Published agent request to {request_topic} (sub_task_id: {sub_task_id})"
         )
 
-        # Set timeout tracking
-        timeout_seconds = self.host.get_config("default_node_timeout_seconds", 300)
+        # Set timeout tracking. Record the resolved timeout on the context so
+        # the timeout error message reports the value that actually fired.
+        workflow_context.set_sub_task_timeout(sub_task_id, timeout_seconds)
         self.host.cache_service.add_data(
             key=sub_task_id,
             value=workflow_context.workflow_task_id,

--- a/src/solace_agent_mesh/workflow/component.py
+++ b/src/solace_agent_mesh/workflow/component.py
@@ -392,10 +392,14 @@ class WorkflowExecutorComponent(SamComponentBase):
         if not node_id:
             return
 
-        timeout_seconds = self.get_config("default_node_timeout_seconds", 300)
+        timeout_seconds = workflow_context.get_sub_task_timeout(sub_task_id)
+        if timeout_seconds is None:
+            timeout_seconds = float(
+                self.get_config("default_node_timeout_seconds", 300)
+            )
         log.error(
             f"{self.log_identifier} Agent call timed out for node '{node_id}' "
-            f"(sub-task: {sub_task_id})"
+            f"(sub-task: {sub_task_id}) after {timeout_seconds} seconds"
         )
 
         # Create timeout error

--- a/src/solace_agent_mesh/workflow/workflow_execution_context.py
+++ b/src/solace_agent_mesh/workflow/workflow_execution_context.py
@@ -75,6 +75,7 @@ class WorkflowExecutionContext:
         # Sub-task tracking
         self.sub_task_to_node: Dict[str, str] = {}  # sub_task_id -> node_id
         self.node_to_sub_task: Dict[str, str] = {}  # node_id -> sub_task_id
+        self.sub_task_timeouts: Dict[str, float] = {}  # sub_task_id -> resolved timeout seconds
         self.lock = threading.Lock()
         self.cancellation_event = threading.Event()
 
@@ -102,6 +103,16 @@ class WorkflowExecutionContext:
         """Get all tracked sub-task IDs."""
         with self.lock:
             return list(self.sub_task_to_node.keys())
+
+    def set_sub_task_timeout(self, sub_task_id: str, timeout_seconds: float):
+        """Record the resolved timeout (in seconds) used for a sub-task."""
+        with self.lock:
+            self.sub_task_timeouts[sub_task_id] = timeout_seconds
+
+    def get_sub_task_timeout(self, sub_task_id: str) -> Optional[float]:
+        """Get the resolved timeout used for a sub-task, if known."""
+        with self.lock:
+            return self.sub_task_timeouts.get(sub_task_id)
 
     def cancel(self):
         """Signal cancellation."""

--- a/tests/unit/workflow/test_agent_caller.py
+++ b/tests/unit/workflow/test_agent_caller.py
@@ -12,17 +12,20 @@ from unittest.mock import Mock, MagicMock
 from solace_agent_mesh.workflow.agent_caller import AgentCaller
 from solace_agent_mesh.workflow.app import AgentNode, SwitchNode, SwitchCase
 from solace_agent_mesh.workflow.workflow_execution_context import (
+    WorkflowExecutionContext,
     WorkflowExecutionState,
 )
 
 
-def create_mock_host():
+def create_mock_host(default_node_timeout_seconds: int = 60):
     """Create a mock host component with required attributes."""
     host = Mock()
     host.log_identifier = "[Test]"
     host.dag_executor = Mock()
     host.dag_executor.nodes = {}
     host.dag_executor.resolve_value = Mock(side_effect=lambda v, s: v)
+    config = {"default_node_timeout_seconds": default_node_timeout_seconds}
+    host.get_config = Mock(side_effect=lambda key, default=None: config.get(key, default))
     return host
 
 
@@ -309,3 +312,75 @@ class TestResolveNodeInputImplicitMultipleDependencies:
         assert "step_1" in error_msg
         assert "step_2" in error_msg
         assert "explicit 'input' mapping" in error_msg
+
+
+class TestResolveNodeTimeout:
+    """Tests for per-node timeout resolution.
+
+    Regression coverage for DATAGO-134263 — the per-node ``timeout`` field
+    was previously declared on AgentNode/WorkflowInvokeNode but ignored at
+    runtime; the workflow-level ``default_node_timeout_seconds`` was always
+    used. These tests pin the new behaviour: per-node timeout wins, with
+    fallback to the workflow default.
+    """
+
+    def test_node_timeout_overrides_default(self):
+        host = create_mock_host(default_node_timeout_seconds=60)
+        caller = AgentCaller(host)
+        assert caller._resolve_node_timeout("5m") == 300.0
+        assert caller._resolve_node_timeout("30s") == 30.0
+        assert caller._resolve_node_timeout("1h") == 3600.0
+
+    def test_missing_node_timeout_uses_default(self):
+        host = create_mock_host(default_node_timeout_seconds=60)
+        caller = AgentCaller(host)
+        assert caller._resolve_node_timeout(None) == 60.0
+        assert caller._resolve_node_timeout("") == 60.0
+
+    def test_invalid_node_timeout_falls_back_to_default(self):
+        """Invalid duration strings should not crash the call — fall back."""
+        host = create_mock_host(default_node_timeout_seconds=60)
+        caller = AgentCaller(host)
+        assert caller._resolve_node_timeout("not-a-duration") == 60.0
+
+
+class TestPublishAgentRequestTimeout:
+    """Tests that the resolved timeout is propagated to cache + context."""
+
+    @pytest.mark.asyncio
+    async def test_publish_uses_passed_timeout_for_cache_expiry(self):
+        from a2a.types import Message, Role, TextPart, Part
+
+        host = create_mock_host(default_node_timeout_seconds=60)
+        host.namespace = "test"
+        host.workflow_name = "TestWorkflow"
+        host.cache_service = Mock()
+        host.publish_a2a_message = Mock()
+        caller = AgentCaller(host)
+
+        ctx = WorkflowExecutionContext(
+            workflow_task_id="wf-task-1",
+            a2a_context={"user_id": "u1", "session_id": "s1"},
+        )
+
+        message = Message(
+            messageId="m1",
+            role=Role.user,
+            parts=[Part(root=TextPart(text="hi"))],
+        )
+
+        await caller._publish_agent_request(
+            agent_name="TargetAgent",
+            message=message,
+            sub_task_id="sub-1",
+            workflow_context=ctx,
+            timeout_seconds=300.0,
+        )
+
+        # Cache expiry must use the passed timeout, not the default.
+        _, kwargs = host.cache_service.add_data.call_args
+        assert kwargs["expiry"] == 300.0
+        assert kwargs["key"] == "sub-1"
+
+        # Context must remember the resolved timeout for later error reporting.
+        assert ctx.get_sub_task_timeout("sub-1") == 300.0


### PR DESCRIPTION
### What is the purpose of this change?

The per-node `timeout` field on workflow `AgentNode` and `WorkflowInvokeNode` was declared in the Pydantic schema but **never consulted at runtime** — the agent caller always used the workflow-level `default_node_timeout_seconds`, silently discarding per-node overrides like `timeout: "5m"`.

Reported on the CBRE POC (SAM Ent v1.143.0) — a `classify_errors` node configured with `timeout: "5m"` was timing out after 60s because the workflow's `default_node_timeout_seconds: 60` was winning.

Jira: [DATAGO-134263](https://sol-jira.atlassian.net/browse/DATAGO-134263)

### How was this change implemented?

- `agent_caller.py`: new `_resolve_node_timeout()` helper parses the node's `timeout` string via `parse_duration` and falls back to `default_node_timeout_seconds`. Both `call_agent` and `call_workflow` now thread the resolved timeout into `_publish_agent_request`, which uses it for the cache-expiry that drives node-level timeouts. Invalid per-node duration strings log a warning and fall back to the default rather than failing the call.
- `workflow_execution_context.py`: added a `sub_task_timeouts` map with thread-safe `set_sub_task_timeout` / `get_sub_task_timeout` so the timeout handler can recover the actual value that fired.
- `component.py`: timeout error message now reports the resolved timeout (read from context), not the workflow default.

### Key Design Decisions

- Invalid per-node timeout strings fall back to the default with a warning — a malformed `timeout` shouldn't take down a workflow.
- Tracking is keyed by `sub_task_id` and stored on `WorkflowExecutionContext` (which already owns sub-task lifetime), so cleanup happens automatically when the context dies.

### How was this change tested?

- [x] Unit tests added in `tests/unit/workflow/test_agent_caller.py`:
  - `TestResolveNodeTimeout` — per-node timeout overrides default; missing/empty falls back; invalid string falls back.
  - `TestPublishAgentRequestTimeout` — cache expiry uses the passed timeout; context tracks it for later error reporting.
- [x] Manual testing in CBRE workflow environment (recommended)

Local `.venv` couldn't run the workflow unit suite (pre-existing — the installed `solace-ai-connector==3.3.4` is missing `common.observability`, which blocks collection of `tests/unit/workflow/*` on `main` too). CI should run them cleanly.

### Is there anything the reviewers should focus on?

- The fallback on invalid duration strings — reviewers may prefer hard-failing instead. I went with warn-and-fallback because the schema doesn't validate the format and a typo shouldn't take down a running workflow.
- `_publish_agent_request` is now invoked from two call sites (`call_agent`, `call_workflow`) — confirm both pass the resolved timeout correctly.

[DATAGO-134263]: https://sol-jira.atlassian.net/browse/DATAGO-134263?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ