### PR TITLE
fix(DATAGO-134293): Recent chats navigation randomly displays other users' chat history

### DIFF
--- a/client/webui/frontend/src/lib/api/sessions/hooks.ts
+++ b/client/webui/frontend/src/lib/api/sessions/hooks.ts
@@ -8,6 +8,7 @@ import type { CompactSessionRequest, CompactSessionResponse, ContextUsage } from
 import { fetchModelConfigs } from "@/lib/api/models/service";
 import type { ModelConfig } from "@/lib/api/models/types";
 import { MAX_RECENT_CHATS } from "@/lib/constants/ui";
+import { useCacheUserId } from "@/lib/hooks/useCacheUserId";
 
 /**
  * Hook to fetch recent sessions for the navigation sidebar.
@@ -15,20 +16,21 @@ import { MAX_RECENT_CHATS } from "@/lib/constants/ui";
  */
 export function useRecentSessions(maxItems: number = MAX_RECENT_CHATS) {
     const queryClient = useQueryClient();
+    const userId = useCacheUserId();
 
     // Set up event listeners for automatic invalidation
     useEffect(() => {
         const handleSessionEvent = () => {
-            queryClient.invalidateQueries({ queryKey: sessionKeys.recent(maxItems) });
+            queryClient.invalidateQueries({ queryKey: sessionKeys.recent(userId, maxItems) });
         };
 
         const events = ["new-chat-session", "session-updated", "session-title-updated", "background-task-completed"];
         events.forEach(e => window.addEventListener(e, handleSessionEvent));
         return () => events.forEach(e => window.removeEventListener(e, handleSessionEvent));
-    }, [maxItems, queryClient]);
+    }, [maxItems, queryClient, userId]);
 
     return useQuery({
-        queryKey: sessionKeys.recent(maxItems),
+        queryKey: sessionKeys.recent(userId, maxItems),
         queryFn: () => sessionService.getRecentSessions(maxItems),
         refetchOnMount: "always",
     });
@@ -40,6 +42,7 @@ export function useRecentSessions(maxItems: number = MAX_RECENT_CHATS) {
  */
 export function useInfiniteSessions(pageSize: number = 20, source?: string, options?: { enabled?: boolean }) {
     const queryClient = useQueryClient();
+    const userId = useCacheUserId();
     const enabled = options?.enabled ?? true;
 
     useEffect(() => {
@@ -51,7 +54,7 @@ export function useInfiniteSessions(pageSize: number = 20, source?: string, opti
     }, [queryClient, enabled]);
 
     return useInfiniteQuery({
-        queryKey: [...sessionKeys.lists(), "infinite", pageSize, source],
+        queryKey: sessionKeys.infinite(userId, pageSize, source),
         queryFn: ({ pageParam }) => sessionService.getPaginatedSessions(pageParam, pageSize, source),
         getNextPageParam: lastPage => lastPage.meta.pagination.nextPage ?? undefined,
         initialPageParam: 1,

--- a/client/webui/frontend/src/lib/api/sessions/keys.ts
+++ b/client/webui/frontend/src/lib/api/sessions/keys.ts
@@ -1,12 +1,16 @@
 /**
  * Query keys for React Query caching and invalidation
  * Following the pattern: ['entity', ...filters/ids]
+ *
+ * List keys include `userId` so cached results from one user can never be
+ * served to another. Existing `lists()` prefix-invalidations still match
+ * because userId is appended after the "list" segment.
  */
 export const sessionKeys = {
     all: ["sessions"] as const,
     lists: () => [...sessionKeys.all, "list"] as const,
-    list: (filters?: { pageNumber?: number; pageSize?: number }) => [...sessionKeys.lists(), { filters }] as const,
-    recent: (maxItems: number) => [...sessionKeys.lists(), "recent", maxItems] as const,
+    recent: (userId: string, maxItems: number) => [...sessionKeys.lists(), "recent", userId, maxItems] as const,
+    infinite: (userId: string, pageSize: number, source?: string) => [...sessionKeys.lists(), "infinite", userId, pageSize, source] as const,
     details: () => [...sessionKeys.all, "detail"] as const,
     detail: (id: string) => [...sessionKeys.details(), id] as const,
     chatTasks: (id: string) => [...sessionKeys.detail(id), "chat-tasks"] as const,

--- a/client/webui/frontend/src/lib/api/share/hooks.ts
+++ b/client/webui/frontend/src/lib/api/share/hooks.ts
@@ -1,6 +1,7 @@
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { shareKeys } from "./keys";
 import * as shareService from "./service";
+import { useCacheUserId } from "@/lib/hooks/useCacheUserId";
 import type { CreateShareLinkRequest, UpdateShareLinkRequest, BatchAddShareUsersRequest, BatchDeleteShareUsersRequest } from "../../types/share";
 
 export function useShareLink(sessionId: string) {
@@ -27,8 +28,9 @@ export function useShareUsers(shareId: string | undefined) {
 }
 
 export function useSharedWithMe(options?: { enabled?: boolean }) {
+    const userId = useCacheUserId();
     return useQuery({
-        queryKey: shareKeys.sharedWithMe(),
+        queryKey: shareKeys.sharedWithMe(userId),
         queryFn: shareService.listSharedWithMe,
         enabled: options?.enabled ?? true,
     });

--- a/client/webui/frontend/src/lib/api/share/keys.ts
+++ b/client/webui/frontend/src/lib/api/share/keys.ts
@@ -9,6 +9,6 @@ export const shareKeys = {
     lists: () => [...shareKeys.all, "list"] as const,
     list: (filters?: { page?: number; pageSize?: number; search?: string }) => [...shareKeys.lists(), { filters }] as const,
     users: (shareId: string) => [...shareKeys.all, "users", shareId] as const,
-    sharedWithMe: () => [...shareKeys.all, "shared-with-me"] as const,
+    sharedWithMe: (userId: string) => [...shareKeys.all, "shared-with-me", userId] as const,
     view: (shareId: string) => [...shareKeys.all, "view", shareId] as const,
 };

--- a/client/webui/frontend/src/lib/components/chat/RecentChatsList.tsx
+++ b/client/webui/frontend/src/lib/components/chat/RecentChatsList.tsx
@@ -99,7 +99,8 @@ export function RecentChatsList({ maxItems = MAX_RECENT_CHATS }: RecentChatsList
     const { persistenceEnabled } = useConfigContext();
     const chatSharingEnabled = useIsChatSharingEnabled();
 
-    const { data: sessions = [], isLoading } = useRecentSessions(maxItems);
+    const { data: sessionsData, isLoading, isFetching } = useRecentSessions(maxItems);
+    const sessions = useMemo(() => sessionsData ?? [], [sessionsData]);
     const { data: sharedItems = [] } = useSharedWithMe();
     const markViewedMutation = useMarkSessionViewed();
 
@@ -180,7 +181,12 @@ export function RecentChatsList({ maxItems = MAX_RECENT_CHATS }: RecentChatsList
         }
     };
 
-    if (isLoading && entries.length === 0 && persistenceEnabled) {
+    // Show the spinner whenever the recent-sessions query has no resolved data
+    // for the current user yet — covers initial load and the brief window
+    // after a user-scoped cache key changes (e.g. user switch). Prevents any
+    // chance of rendering another user's stale list before the fetch settles.
+    const recentNotReady = sessionsData === undefined && isFetching;
+    if ((isLoading || recentNotReady) && entries.length === 0 && persistenceEnabled) {
         return (
             <div className="flex h-full flex-col items-center pt-[25%] text-xs text-(--secondary-text-wMain)">
                 <Spinner />

--- a/client/webui/frontend/src/lib/hooks/index.ts
+++ b/client/webui/frontend/src/lib/hooks/index.ts
@@ -7,6 +7,7 @@ export * from "./useAudioSettings";
 export * from "./useAuthContext";
 export * from "./useBackgroundTaskMonitor";
 export * from "./useBeforeUnload";
+export * from "./useCacheUserId";
 export * from "./useCollaborativeSession";
 export * from "./useChatContext";
 export * from "./useCitationClick";

--- a/client/webui/frontend/src/lib/hooks/useCacheUserId.ts
+++ b/client/webui/frontend/src/lib/hooks/useCacheUserId.ts
@@ -1,0 +1,16 @@
+import { useAuthContext } from "./useAuthContext";
+
+/**
+ * Returns a stable identifier for the current user, suitable for scoping
+ * React Query cache keys so one user can never see another user's cached
+ * results. Falls back to "anonymous" when authorization is disabled or the
+ * user has not yet been resolved (single-user / pre-auth case).
+ */
+export function useCacheUserId(): string {
+    const { userInfo } = useAuthContext();
+    const username = userInfo?.username;
+    if (typeof username === "string" && username.length > 0) return username;
+    const id = userInfo?.id;
+    if (typeof id === "string" && id.length > 0) return id;
+    return "anonymous";
+}

--- a/client/webui/frontend/src/lib/providers/AuthProvider.tsx
+++ b/client/webui/frontend/src/lib/providers/AuthProvider.tsx
@@ -1,4 +1,5 @@
 import React, { useState, useEffect, type ReactNode } from "react";
+import { useQueryClient } from "@tanstack/react-query";
 
 import { api, scheduleProactiveRefresh, cancelProactiveRefresh } from "@/lib/api";
 import { AuthContext } from "@/lib/contexts/AuthContext";
@@ -12,6 +13,7 @@ interface AuthProviderProps {
 export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
     const { configUseAuthorization, configAuthLoginUrl } = useConfigContext();
     const { fetchCsrfToken, clearCsrfToken } = useCsrfContext();
+    const queryClient = useQueryClient();
     const [isAuthenticated, setIsAuthenticated] = useState(false);
     const [isLoading, setIsLoading] = useState(true);
     const [userInfo, setUserInfo] = useState<Record<string, unknown> | null>(null);
@@ -101,6 +103,12 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
             localStorage.removeItem("access_token");
             localStorage.removeItem("sam_access_token");
             localStorage.removeItem("refresh_token");
+
+            // Drop every cached response synchronously — `removeQueries` evicts
+            // immediately (unlike `invalidateQueries`, which leaves stale data
+            // visible until the next refetch resolves), so no fragment of the
+            // previous user's data can render before the page reload below.
+            queryClient.removeQueries();
 
             // Clear local state
             setIsAuthenticated(false);

--- a/client/webui/frontend/src/stories/api/sessionHooks.test.tsx
+++ b/client/webui/frontend/src/stories/api/sessionHooks.test.tsx
@@ -1,0 +1,121 @@
+/**
+ * Integration tests for the user-scoping behaviour of useRecentSessions /
+ * useInfiniteSessions. When the auth-context user changes, both hooks must
+ * issue a fresh fetch under the new key rather than serving the prior user's
+ * cached pages.
+ */
+import React from "react";
+import { renderHook, waitFor } from "@testing-library/react";
+import { describe, test, expect, beforeEach, afterEach, vi } from "vitest";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+
+import { AuthContext, type AuthContextValue } from "@/lib/contexts/AuthContext";
+import { useRecentSessions, useInfiniteSessions } from "@/lib/api/sessions/hooks";
+import * as sessionService from "@/lib/api/sessions/service";
+import type { Session } from "@/lib/types";
+
+function makeAuthValue(userInfo: Record<string, unknown> | null): AuthContextValue {
+    return {
+        isAuthenticated: true,
+        useAuthorization: true,
+        login: () => {},
+        logout: () => {},
+        userInfo,
+    };
+}
+
+function makeSession(overrides: Partial<Session> = {}): Session {
+    return {
+        id: "sess-x",
+        name: "Session",
+        userId: "alice",
+        createdTime: "2024-01-01T00:00:00Z",
+        updatedTime: "2024-01-01T00:00:00Z",
+        ...overrides,
+    };
+}
+
+describe("useRecentSessions / useInfiniteSessions — auth user switch", () => {
+    let queryClient: QueryClient;
+    let recentSpy: ReturnType<typeof vi.spyOn>;
+    let infiniteSpy: ReturnType<typeof vi.spyOn>;
+
+    beforeEach(() => {
+        queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    });
+
+    afterEach(() => {
+        vi.restoreAllMocks();
+        queryClient.clear();
+    });
+
+    function makeWrapper(authValue: { current: AuthContextValue }) {
+        return function Wrapper({ children }: { children: React.ReactNode }) {
+            return (
+                <QueryClientProvider client={queryClient}>
+                    <AuthContext.Provider value={authValue.current}>{children}</AuthContext.Provider>
+                </QueryClientProvider>
+            );
+        };
+    }
+
+    test("useRecentSessions refetches under a new key when auth user switches", async () => {
+        const authRef = { current: makeAuthValue({ username: "alice" }) };
+        recentSpy = vi.spyOn(sessionService, "getRecentSessions").mockImplementation(async () => {
+            // Resolve based on the *current* auth user — emulate the server.
+            const u = authRef.current.userInfo?.username as string | undefined;
+            if (u === "alice") return [makeSession({ id: "alice-sess", name: "Alice's chat", userId: "alice" })];
+            if (u === "bob") return [makeSession({ id: "bob-sess", name: "Bob's chat", userId: "bob" })];
+            return [];
+        });
+
+        const wrapper = makeWrapper(authRef);
+
+        const { result, rerender } = renderHook(() => useRecentSessions(10), { wrapper });
+
+        await waitFor(() => expect(result.current.data).toBeDefined());
+        expect(result.current.data?.[0]?.id).toBe("alice-sess");
+        expect(recentSpy).toHaveBeenCalledTimes(1);
+
+        // Switch auth user — the query key changes, so a fresh fetch must occur
+        // and the data returned must be Bob's, not Alice's cached page.
+        authRef.current = makeAuthValue({ username: "bob" });
+        rerender();
+
+        await waitFor(() => expect(result.current.data?.[0]?.id).toBe("bob-sess"));
+        expect(recentSpy).toHaveBeenCalledTimes(2);
+
+        // Alice's cached entry must still be reachable under her own key —
+        // proving the new fetch went to a *different* cache slot.
+        const aliceCached = queryClient.getQueryData(["sessions", "list", "recent", "alice", 10]) as Session[] | undefined;
+        const bobCached = queryClient.getQueryData(["sessions", "list", "recent", "bob", 10]) as Session[] | undefined;
+        expect(aliceCached?.[0]?.id).toBe("alice-sess");
+        expect(bobCached?.[0]?.id).toBe("bob-sess");
+    });
+
+    test("useInfiniteSessions refetches under a new key when auth user switches", async () => {
+        const authRef = { current: makeAuthValue({ username: "alice" }) };
+        infiniteSpy = vi.spyOn(sessionService, "getPaginatedSessions").mockImplementation(async () => {
+            const u = authRef.current.userInfo?.username as string | undefined;
+            const session = u === "bob" ? makeSession({ id: "bob-sess", userId: "bob" }) : makeSession({ id: "alice-sess", userId: "alice" });
+            return {
+                data: [session],
+                meta: { pagination: { pageNumber: 1, count: 1, pageSize: 20, nextPage: null, totalPages: 1 } },
+            };
+        });
+
+        const wrapper = makeWrapper(authRef);
+
+        const { result, rerender } = renderHook(() => useInfiniteSessions(20), { wrapper });
+
+        await waitFor(() => expect(result.current.data).toBeDefined());
+        expect(result.current.data?.pages?.[0]?.data?.[0]?.id).toBe("alice-sess");
+        expect(infiniteSpy).toHaveBeenCalledTimes(1);
+
+        authRef.current = makeAuthValue({ username: "bob" });
+        rerender();
+
+        await waitFor(() => expect(result.current.data?.pages?.[0]?.data?.[0]?.id).toBe("bob-sess"));
+        expect(infiniteSpy).toHaveBeenCalledTimes(2);
+    });
+});

--- a/client/webui/frontend/src/stories/api/sessionKeys.test.ts
+++ b/client/webui/frontend/src/stories/api/sessionKeys.test.ts
@@ -1,0 +1,56 @@
+import { describe, test, expect } from "vitest";
+import { sessionKeys } from "@/lib/api/sessions/keys";
+
+describe("sessionKeys", () => {
+    test("all is the base key", () => {
+        expect(sessionKeys.all).toEqual(["sessions"]);
+    });
+
+    test("lists() extends all with 'list'", () => {
+        expect(sessionKeys.lists()).toEqual(["sessions", "list"]);
+    });
+
+    test("recent(userId, max) is scoped by userId", () => {
+        expect(sessionKeys.recent("alice", 10)).toEqual(["sessions", "list", "recent", "alice", 10]);
+    });
+
+    test("infinite(userId, pageSize, source?) is scoped by userId", () => {
+        expect(sessionKeys.infinite("alice", 20)).toEqual(["sessions", "list", "infinite", "alice", 20, undefined]);
+        expect(sessionKeys.infinite("alice", 20, "scheduler")).toEqual(["sessions", "list", "infinite", "alice", 20, "scheduler"]);
+    });
+
+    test("different userId values produce non-equal recent keys", () => {
+        expect(sessionKeys.recent("alice", 10)).not.toEqual(sessionKeys.recent("bob", 10));
+    });
+
+    test("different userId values produce non-equal infinite keys", () => {
+        expect(sessionKeys.infinite("alice", 20)).not.toEqual(sessionKeys.infinite("bob", 20));
+        expect(sessionKeys.infinite("alice", 20, "scheduler")).not.toEqual(sessionKeys.infinite("bob", 20, "scheduler"));
+    });
+
+    test("recent key starts with lists() prefix so prefix-invalidation matches", () => {
+        const key = sessionKeys.recent("alice", 10);
+        const prefix = sessionKeys.lists();
+        expect(key.slice(0, prefix.length)).toEqual(prefix);
+    });
+
+    test("infinite key starts with lists() prefix so prefix-invalidation matches", () => {
+        const key = sessionKeys.infinite("alice", 20, "scheduler");
+        const prefix = sessionKeys.lists();
+        expect(key.slice(0, prefix.length)).toEqual(prefix);
+    });
+
+    test("details() and detail(id) form the per-session key path", () => {
+        expect(sessionKeys.details()).toEqual(["sessions", "detail"]);
+        expect(sessionKeys.detail("sess-1")).toEqual(["sessions", "detail", "sess-1"]);
+    });
+
+    test("chatTasks(id) extends detail(id) with 'chat-tasks'", () => {
+        expect(sessionKeys.chatTasks("sess-1")).toEqual(["sessions", "detail", "sess-1", "chat-tasks"]);
+    });
+
+    test("contextUsage(id, agentName?) extends detail(id) with 'context-usage' and agent slot", () => {
+        expect(sessionKeys.contextUsage("sess-1")).toEqual(["sessions", "detail", "sess-1", "context-usage", null]);
+        expect(sessionKeys.contextUsage("sess-1", "agent-x")).toEqual(["sessions", "detail", "sess-1", "context-usage", "agent-x"]);
+    });
+});

--- a/client/webui/frontend/src/stories/api/shareKeys.test.ts
+++ b/client/webui/frontend/src/stories/api/shareKeys.test.ts
@@ -31,8 +31,8 @@ describe("shareKeys", () => {
         expect(shareKeys.users("share-abc")).toEqual(["shares", "users", "share-abc"]);
     });
 
-    test("sharedWithMe() extends all with 'shared-with-me'", () => {
-        expect(shareKeys.sharedWithMe()).toEqual(["shares", "shared-with-me"]);
+    test("sharedWithMe(userId) scopes by user so cached data can't leak across users", () => {
+        expect(shareKeys.sharedWithMe("alice")).toEqual(["shares", "shared-with-me", "alice"]);
     });
 
     test("view(shareId) extends all with 'view' and share id", () => {

--- a/client/webui/frontend/src/stories/chat/RecentChatsList.userSwitch.test.tsx
+++ b/client/webui/frontend/src/stories/chat/RecentChatsList.userSwitch.test.tsx
@@ -1,0 +1,104 @@
+/// <reference types="@testing-library/jest-dom" />
+/**
+ * Test for the recentNotReady spinner gate in RecentChatsList. When the auth
+ * user changes, useRecentSessions reads under a new (user-scoped) cache key
+ * so its data is briefly `undefined` while the fresh fetch is in-flight. The
+ * gate must keep the prior user's titles off-screen during that window.
+ */
+import { render, screen } from "@testing-library/react";
+import { describe, test, expect, vi, beforeEach } from "vitest";
+import * as matchers from "@testing-library/jest-dom/matchers";
+import { MemoryRouter } from "react-router-dom";
+
+expect.extend(matchers);
+
+type RecentResult = {
+    data: Array<{ id: string; name: string; updatedTime: string }> | undefined;
+    isLoading: boolean;
+    isFetching: boolean;
+};
+
+let recentResult: RecentResult = { data: undefined, isLoading: true, isFetching: true };
+
+async function loadList() {
+    vi.resetModules();
+
+    vi.doMock("@/lib/api/sessions", () => ({
+        useRecentSessions: () => recentResult,
+        useMarkSessionViewed: () => ({ mutate: vi.fn() }),
+    }));
+
+    vi.doMock("@/lib/api/share", () => ({
+        useSharedWithMe: () => ({ data: [], isLoading: false }),
+    }));
+
+    vi.doMock("@/lib/hooks", async () => {
+        const actual = await vi.importActual<typeof import("@/lib/hooks")>("@/lib/hooks");
+        return {
+            ...actual,
+            useChatContext: () => ({ sessionId: "current", handleSwitchSession: vi.fn(), currentTaskId: null }),
+            useConfigContext: () => ({ persistenceEnabled: true, configFeatureEnablement: { chatSharing: false } }),
+            useIsAutoTitleGenerationEnabled: () => false,
+            useIsChatSharingEnabled: () => false,
+            useTitleAnimation: (name: string) => ({ text: name, isAnimating: false, isGenerating: false }),
+        };
+    });
+
+    const mod = await import("@/lib/components/chat/RecentChatsList");
+    return mod.RecentChatsList;
+}
+
+async function renderList() {
+    const RecentChatsList = await loadList();
+    return render(
+        <MemoryRouter>
+            <RecentChatsList />
+        </MemoryRouter>
+    );
+}
+
+describe("RecentChatsList — recentNotReady spinner gate", () => {
+    beforeEach(() => {
+        recentResult = { data: undefined, isLoading: true, isFetching: true };
+    });
+
+    test("first paint with user A renders user A's titles", async () => {
+        recentResult = {
+            data: [{ id: "a-1", name: "Alice's Project Plan", updatedTime: new Date().toISOString() }],
+            isLoading: false,
+            isFetching: false,
+        };
+        const { container } = await renderList();
+
+        expect(await screen.findByText("Alice's Project Plan")).toBeInTheDocument();
+        // Sanity: no spinner visible when data is resolved.
+        expect(container.querySelector("[role='status']")).toBeNull();
+    });
+
+    test("during user switch (data: undefined, isFetching: true) prior user's titles are NOT visible", async () => {
+        // Simulate the in-flight window after auth user changes from A to B:
+        // the new userId-scoped key has no cached entry yet, so data===undefined
+        // even though isLoading might have already flipped false.
+        recentResult = { data: undefined, isLoading: false, isFetching: true };
+        await renderList();
+
+        // No previous-user titles should leak through.
+        expect(screen.queryByText("Alice's Project Plan")).not.toBeInTheDocument();
+        // The empty-state ("No recent chats") must NOT appear either — the
+        // gate must show the spinner so we don't briefly imply user B has
+        // no chats while their data is still loading.
+        expect(screen.queryByText(/no recent chats/i)).not.toBeInTheDocument();
+    });
+
+    test("when data resolves for user B, only user B's titles render", async () => {
+        recentResult = {
+            data: [{ id: "b-1", name: "Bob's Sprint Review", updatedTime: new Date().toISOString() }],
+            isLoading: false,
+            isFetching: false,
+        };
+        await renderList();
+
+        expect(await screen.findByText("Bob's Sprint Review")).toBeInTheDocument();
+        expect(screen.queryByText("Alice's Project Plan")).not.toBeInTheDocument();
+    });
+});

--- a/client/webui/frontend/src/stories/hooks/useCacheUserId.test.tsx
+++ b/client/webui/frontend/src/stories/hooks/useCacheUserId.test.tsx
@@ -1,0 +1,78 @@
+/**
+ * Tests for useCacheUserId — the source of the user-scoped portion of every
+ * cache key. If this hook returns the wrong value, cache keys collapse and
+ * users could see another user's cached data.
+ */
+import React from "react";
+import { renderHook } from "@testing-library/react";
+import { describe, test, expect } from "vitest";
+
+import { AuthContext, type AuthContextValue } from "@/lib/contexts/AuthContext";
+import { useCacheUserId } from "@/lib/hooks/useCacheUserId";
+
+function wrapperWithUserInfo(userInfo: Record<string, unknown> | null) {
+    const value: AuthContextValue = {
+        isAuthenticated: true,
+        useAuthorization: true,
+        login: () => {},
+        logout: () => {},
+        userInfo,
+    };
+    return function Wrapper({ children }: { children: React.ReactNode }) {
+        return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>;
+    };
+}
+
+describe("useCacheUserId", () => {
+    test("returns username when present", () => {
+        const { result } = renderHook(() => useCacheUserId(), {
+            wrapper: wrapperWithUserInfo({ username: "alice", id: "alice-id" }),
+        });
+        expect(result.current).toBe("alice");
+    });
+
+    test("falls back to id when username is missing", () => {
+        const { result } = renderHook(() => useCacheUserId(), {
+            wrapper: wrapperWithUserInfo({ id: "user-42" }),
+        });
+        expect(result.current).toBe("user-42");
+    });
+
+    test("returns 'anonymous' when userInfo is null", () => {
+        const { result } = renderHook(() => useCacheUserId(), {
+            wrapper: wrapperWithUserInfo(null),
+        });
+        expect(result.current).toBe("anonymous");
+    });
+
+    test("returns 'anonymous' when both username and id are missing", () => {
+        const { result } = renderHook(() => useCacheUserId(), {
+            wrapper: wrapperWithUserInfo({ email: "x@y.z" }),
+        });
+        expect(result.current).toBe("anonymous");
+    });
+
+    test("non-string username falls through to id", () => {
+        const { result } = renderHook(() => useCacheUserId(), {
+            wrapper: wrapperWithUserInfo({ username: 12345, id: "fallback-id" }),
+        });
+        expect(result.current).toBe("fallback-id");
+    });
+
+    test("empty-string username falls through to id", () => {
+        const { result } = renderHook(() => useCacheUserId(), {
+            wrapper: wrapperWithUserInfo({ username: "", id: "fallback-id" }),
+        });
+        expect(result.current).toBe("fallback-id");
+    });
+
+    test("different users get different cache identifiers", () => {
+        const { result: a } = renderHook(() => useCacheUserId(), {
+            wrapper: wrapperWithUserInfo({ username: "alice" }),
+        });
+        const { result: b } = renderHook(() => useCacheUserId(), {
+            wrapper: wrapperWithUserInfo({ username: "bob" }),
+        });
+        expect(a.current).not.toBe(b.current);
+    });
+});

--- a/client/webui/frontend/src/stories/providers/AuthProvider.test.tsx
+++ b/client/webui/frontend/src/stories/providers/AuthProvider.test.tsx
@@ -8,12 +8,15 @@ import { describe, test, expect, beforeAll, beforeEach, afterEach, afterAll, vi 
 import { http, HttpResponse } from "msw";
 import { setupServer } from "msw/node";
 import * as matchers from "@testing-library/jest-dom/matchers";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 
 import { MockConfigProvider } from "@/stories/mocks/MockConfigProvider";
 import { CsrfContext, type CsrfContextValue } from "@/lib/contexts/CsrfContext";
 import { AuthContext } from "@/lib/contexts/AuthContext";
 import { AuthProvider } from "@/lib/providers/AuthProvider";
 import * as apiClientModule from "@/lib/api/client";
+import { sessionKeys } from "@/lib/api/sessions/keys";
+import { shareKeys } from "@/lib/api/share/keys";
 
 expect.extend(matchers);
 
@@ -52,20 +55,24 @@ function AuthConsumer() {
     );
 }
 
-// Wrapper with all required providers
-function TestWrapper({ children, useAuthorization = true }: { children: React.ReactNode; useAuthorization?: boolean }) {
+// Wrapper with all required providers. Accepts an optional shared QueryClient
+// so tests can pre-populate cache state and assert against it post-logout.
+function TestWrapper({ children, useAuthorization = true, queryClient }: { children: React.ReactNode; useAuthorization?: boolean; queryClient?: QueryClient }) {
+    const client = queryClient ?? new QueryClient({ defaultOptions: { queries: { retry: false } } });
     return (
-        <MockConfigProvider
-            mockValues={{
-                configUseAuthorization: useAuthorization,
-                configAuthLoginUrl: "http://localhost:3000/api/v1/auth/login",
-                webuiServerUrl: "http://localhost:3000",
-            }}
-        >
-            <MockCsrfProvider>
-                <AuthProvider>{children}</AuthProvider>
-            </MockCsrfProvider>
-        </MockConfigProvider>
+        <QueryClientProvider client={client}>
+            <MockConfigProvider
+                mockValues={{
+                    configUseAuthorization: useAuthorization,
+                    configAuthLoginUrl: "http://localhost:3000/api/v1/auth/login",
+                    webuiServerUrl: "http://localhost:3000",
+                }}
+            >
+                <MockCsrfProvider>
+                    <AuthProvider>{children}</AuthProvider>
+                </MockCsrfProvider>
+            </MockConfigProvider>
+        </QueryClientProvider>
     );
 }
 
@@ -192,6 +199,72 @@ describe("AuthProvider", () => {
             expect(localStorage.getItem("access_token")).toBeNull();
             expect(localStorage.getItem("sam_access_token")).toBeNull();
             expect(localStorage.getItem("refresh_token")).toBeNull();
+
+            Object.defineProperty(window, "location", {
+                value: originalLocation,
+                writable: true,
+                configurable: true,
+            });
+        });
+
+        test("evicts every cached query on logout so no prior-user data can leak", async () => {
+            const exp = Math.floor((Date.now() + 3600000) / 1000);
+            localStorage.setItem("sam_access_token", makeJwt(exp));
+            localStorage.setItem("access_token", makeJwt(exp));
+
+            server.use(
+                http.get("http://localhost:3000/api/v1/users/me", () => {
+                    return HttpResponse.json({
+                        username: "test-user",
+                        email: "test@example.com",
+                    });
+                }),
+                http.post("http://localhost:3000/api/v1/auth/logout", () => {
+                    return HttpResponse.json({ success: true });
+                })
+            );
+
+            // Pre-populate the QueryClient with data from "user A". After logout,
+            // none of these keys should remain in the cache.
+            const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+            const recentKey = sessionKeys.recent("alice", 10);
+            const sharedKey = shareKeys.sharedWithMe("alice");
+            queryClient.setQueryData(recentKey, [{ id: "sess-A", name: "User A's chat" }]);
+            queryClient.setQueryData(sharedKey, [{ shareId: "share-A" }]);
+            queryClient.setQueryData(["unrelated", "key"], { foo: "bar" });
+
+            const originalLocation = window.location;
+            Object.defineProperty(window, "location", {
+                value: { ...originalLocation, href: "" },
+                writable: true,
+                configurable: true,
+            });
+
+            render(
+                <TestWrapper queryClient={queryClient}>
+                    <AuthConsumer />
+                </TestWrapper>
+            );
+
+            await waitFor(() => {
+                expect(screen.getByTestId("authenticated").textContent).toBe("true");
+            });
+
+            // Sanity check: the seeded cache entries are present before logout.
+            expect(queryClient.getQueryData(recentKey)).toBeDefined();
+            expect(queryClient.getQueryData(sharedKey)).toBeDefined();
+            expect(queryClient.getQueryData(["unrelated", "key"])).toBeDefined();
+
+            const user = userEvent.setup();
+            await act(async () => {
+                await user.click(screen.getByTestId("logout-btn"));
+            });
+
+            // Every query — user-scoped or otherwise — must be evicted.
+            expect(queryClient.getQueryCache().getAll()).toHaveLength(0);
+            expect(queryClient.getQueryData(recentKey)).toBeUndefined();
+            expect(queryClient.getQueryData(sharedKey)).toBeUndefined();
+            expect(queryClient.getQueryData(["unrelated", "key"])).toBeUndefined();
 
             Object.defineProperty(window, "location", {
                 value: originalLocation,


### PR DESCRIPTION
This pull request introduces user-scoped React Query cache keys for session and share-related queries to prevent cached data from leaking between users, especially in multi-user or shared device scenarios. It also ensures cache eviction on logout and provides comprehensive tests to verify correct cache key behavior and user isolation.

**User-scoped caching and cache key changes:**

* Added a new `useCacheUserId` hook to provide a stable user identifier for cache key scoping; falls back to "anonymous" if user info is unavailable. (`client/webui/frontend/src/lib/hooks/useCacheUserId.ts`, [client/webui/frontend/src/lib/hooks/useCacheUserId.tsR1-R16](diffhunk://#diff-45b779f159e49d28496e25106ef9db2ef87f5a30e0827bd51a63bbd7f57f6688R1-R16))
* Updated `sessionKeys` and `shareKeys` to include `userId` in keys for recent sessions, infinite sessions, and "shared with me" queries, ensuring cache entries are unique per user. (`client/webui/frontend/src/lib/api/sessions/keys.ts`, [[1]](diffhunk://#diff-7c52f94b18328cff11b686352c90453ee4ab9faa43f92ed78ea1744b1f12e6d8R4-R13); `client/webui/frontend/src/lib/api/share/keys.ts`, [[2]](diffhunk://#diff-97a24bd2de6fe9222000eba931b9d9db873965a60322373499672689a8fabd85L12-R12)
* Modified hooks (`useRecentSessions`, `useInfiniteSessions`, `useSharedWithMe`) to use the user-scoped keys, and updated all usages accordingly. (`client/webui/frontend/src/lib/api/sessions/hooks.ts`, [[1]](diffhunk://#diff-e8f0e163ef3c81ae44aaf3bfb5b3437515d37ae7c7ab3c3a1581ecfadaf01d8aR11-R33) [[2]](diffhunk://#diff-e8f0e163ef3c81ae44aaf3bfb5b3437515d37ae7c7ab3c3a1581ecfadaf01d8aR45) [[3]](diffhunk://#diff-e8f0e163ef3c81ae44aaf3bfb5b3437515d37ae7c7ab3c3a1581ecfadaf01d8aL54-R57); `client/webui/frontend/src/lib/api/share/hooks.ts`, [[4]](diffhunk://#diff-44b376c6160147d202cf98c12146eec19c6b719d9e2b001ac1ff341198c82632R4) [[5]](diffhunk://#diff-44b376c6160147d202cf98c12146eec19c6b719d9e2b001ac1ff341198c82632R31-R33)

**Cache eviction and UI safety:**

* On logout, all cached queries are synchronously removed to prevent any possibility of rendering another user's stale data before a reload. (`client/webui/frontend/src/lib/providers/AuthProvider.tsx`, [[1]](diffhunk://#diff-8b359133dc616535b6c6ac8f33cbfe43fc5ac561c6c7ecff9692c7adec44e13eR2) [[2]](diffhunk://#diff-8b359133dc616535b6c6ac8f33cbfe43fc5ac561c6c7ecff9692c7adec44e13eR16) [[3]](diffhunk://#diff-8b359133dc616535b6c6ac8f33cbfe43fc5ac561c6c7ecff9692c7adec44e13eR107-R112)
* The recent chats list now ensures that it only renders session data once the correct user's data has loaded, preventing flashes of stale content. (`client/webui/frontend/src/lib/components/chat/RecentChatsList.tsx`, [[1]](diffhunk://#diff-28c1c4da4cb1ea22fb19c0637010a82dfbcea46ac4e34aa06cc4f0191d5bdd00L102-R103) [[2]](diffhunk://#diff-28c1c4da4cb1ea22fb19c0637010a82dfbcea46ac4e34aa06cc4f0191d5bdd00L183-R189)

**Testing and validation:**

* Added integration tests to verify that session queries refetch and use separate cache slots when the authenticated user changes, and that cache keys are correctly user-scoped. (`client/webui/frontend/src/stories/api/sessionHooks.test.tsx`, [client/webui/frontend/src/stories/api/sessionHooks.test.tsxR1-R121](diffhunk://#diff-1c75e7ec17b14d0a4f907695ee6e8602d642562ae04d2cb100db45d0d0a03a49R1-R121))
* Added unit tests for `sessionKeys` and updated tests for `shareKeys` to validate the new key structure and user isolation. (`client/webui/frontend/src/stories/api/sessionKeys.test.ts`, [[1]](diffhunk://#diff-b0f79a6ce0e0a2c579e1c0790317540394bb8d9c2111ca92b4e5555e6382572cR1-R56); `client/webui/frontend/src/stories/api/shareKeys.test.ts`, [[2]](diffhunk://#diff-ebd4a735092dd2b120a524a729b4bb02356e88944dee4521dd8e884bf29f519eL34-R35)

These changes collectively ensure robust user data isolation in the frontend cache, preventing cross-user data exposure and improving multi-user safety.