### PR TITLE
fix(DATAGO-122712): Enhance mention detection and add tests for multi-word queries

### DIFF
--- a/client/webui/frontend/src/lib/components/chat/MentionsCommand.tsx
+++ b/client/webui/frontend/src/lib/components/chat/MentionsCommand.tsx
@@ -107,7 +107,7 @@ export const MentionsCommand: React.FC<MentionsCommandProps> = ({ isOpen, onClos
         const fetchPeople = async () => {
             setIsLoading(true);
             try {
-                const data: PeopleSearchResponse = await api.webui.get(`/api/v1/people/search?q=${encodeURIComponent(searchQuery)}&limit=10`);
+                const data: PeopleSearchResponse = await api.webui.get(`/api/v1/people/search?q=${encodeURIComponent(searchQuery.trim())}&limit=10`);
                 setPeople(data.data || []);
             } catch (error) {
                 console.error("Failed to fetch people:", error);

--- a/client/webui/frontend/src/lib/utils/mentionUtils.test.ts
+++ b/client/webui/frontend/src/lib/utils/mentionUtils.test.ts
@@ -1,0 +1,93 @@
+import { describe, it, expect } from "vitest";
+import { detectMentionTrigger } from "./mentionUtils";
+
+describe("detectMentionTrigger", () => {
+    it("returns the query when @ is at the start of the input", () => {
+        const text = "@john";
+        expect(detectMentionTrigger(text, text.length)).toBe("john");
+    });
+
+    it("returns an empty query when only @ has been typed", () => {
+        const text = "@";
+        expect(detectMentionTrigger(text, text.length)).toBe("");
+    });
+
+    it("returns the query when @ is preceded by a space", () => {
+        const text = "hello @john";
+        expect(detectMentionTrigger(text, text.length)).toBe("john");
+    });
+
+    it("returns null when there's no @ before the cursor", () => {
+        const text = "hello world";
+        expect(detectMentionTrigger(text, text.length)).toBeNull();
+    });
+
+    it("returns null when @ is part of a word (e.g. an email)", () => {
+        const text = "foo@bar.com";
+        expect(detectMentionTrigger(text, text.length)).toBeNull();
+    });
+
+    it("returns null when @ is part of an existing internal mention @[...](...)", () => {
+        const text = "hello @[John Doe](john@example.com) ";
+        expect(detectMentionTrigger(text, text.length)).toBeNull();
+    });
+
+    it("allows multi-word queries with a single space", () => {
+        const text = "@john du";
+        expect(detectMentionTrigger(text, text.length)).toBe("john du");
+    });
+
+    it("does not allow more than one space after query", () => {
+        const text = "@john  ";
+        expect(detectMentionTrigger(text, text.length)).toBeNull();
+    });
+
+    it("allows multi-word queries with multiple spaces", () => {
+        const text = "@john du doe";
+        expect(detectMentionTrigger(text, text.length)).toBe("john du doe");
+    });
+
+    it("normalizes non-breaking spaces (U+00A0) to regular spaces", () => {
+        // Contenteditable elements often substitute regular spaces with NBSP.
+        const text = "@john\u00A0du";
+        expect(detectMentionTrigger(text, text.length)).toBe("john du");
+    });
+
+    it("treats two consecutive non-breaking spaces as the end of the mention", () => {
+        const text = "@john\u00A0\u00A0";
+        expect(detectMentionTrigger(text, text.length)).toBeNull();
+    });
+
+    it("returns the query with a trailing space", () => {
+        const text = "@john ";
+        expect(detectMentionTrigger(text, text.length)).toBe("john ");
+    });
+
+    it("returns null when the query starts with a space", () => {
+        const text = "@ foo";
+        expect(detectMentionTrigger(text, text.length)).toBeNull();
+    });
+
+    it("returns null when the query contains a newline", () => {
+        const text = "@john\nmore text";
+        expect(detectMentionTrigger(text, text.length)).toBeNull();
+    });
+
+    it("returns null when the query exceeds 50 characters", () => {
+        const longQuery = "a".repeat(51);
+        const text = `@${longQuery}`;
+        expect(detectMentionTrigger(text, text.length)).toBeNull();
+    });
+
+    it("returns the query when it is exactly 50 characters", () => {
+        const query = "a".repeat(50);
+        const text = `@${query}`;
+        expect(detectMentionTrigger(text, text.length)).toBe(query);
+    });
+
+    it("uses cursor position to scope the query, ignoring text after the cursor", () => {
+        const text = "@john and more";
+        // Cursor right after "@john"
+        expect(detectMentionTrigger(text, 5)).toBe("john");
+    });
+});

--- a/client/webui/frontend/src/lib/utils/mentionUtils.ts
+++ b/client/webui/frontend/src/lib/utils/mentionUtils.ts
@@ -47,8 +47,6 @@ export function detectMentionTrigger(text: string, cursorPosition: number): stri
     // spaces ( ) — normalize them so our space-handling logic and the
     // returned query (which is sent to the backend search) use plain spaces.
     const textBeforeCursor = text.substring(0, cursorPosition).replaceAll("\u00A0", " ");
-    console.log("text", text, "cursorPosition", cursorPosition, "textBeforeCursor", textBeforeCursor);
-
 
     // Find the last "@" before cursor
     const lastAtIndex = textBeforeCursor.lastIndexOf("@");

--- a/client/webui/frontend/src/lib/utils/mentionUtils.ts
+++ b/client/webui/frontend/src/lib/utils/mentionUtils.ts
@@ -30,13 +30,25 @@ export function formatInternalMention(person: Person): string {
     return `@[${person.displayName}](${person.id})`;
 }
 
+/** Maximum length of a mention query before the dropdown auto-closes. */
+const MAX_MENTION_QUERY_LENGTH = 50;
+
 /**
  * Detects if cursor is in a mention trigger position
- * Returns the query string after "@" or null if not in mention mode
- * Updated to handle internal format - doesn't trigger inside @[...](...)
+ * Returns the query string after "@" or null if not in mention mode.
+ *
+ * Multi-word queries are supported (e.g. "michael du" for "Michael Du Plessis").
+ * The dropdown closes when the query contains a newline, starts with whitespace,
+ * contains two consecutive spaces, or exceeds {@link MAX_MENTION_QUERY_LENGTH} characters.
+ * Doesn't trigger inside an existing internal mention `@[...](...)`.
  */
 export function detectMentionTrigger(text: string, cursorPosition: number): string | null {
-    const textBeforeCursor = text.substring(0, cursorPosition);
+    // contenteditable elements often substitute regular spaces with non-breaking
+    // spaces ( ) — normalize them so our space-handling logic and the
+    // returned query (which is sent to the backend search) use plain spaces.
+    const textBeforeCursor = text.substring(0, cursorPosition).replaceAll("\u00A0", " ");
+    console.log("text", text, "cursorPosition", cursorPosition, "textBeforeCursor", textBeforeCursor);
+
 
     // Find the last "@" before cursor
     const lastAtIndex = textBeforeCursor.lastIndexOf("@");
@@ -54,8 +66,17 @@ export function detectMentionTrigger(text: string, cursorPosition: number): stri
     // Extract query after "@"
     const query = textBeforeCursor.substring(lastAtIndex + 1);
 
-    // Check if query contains spaces or newlines (mention should be contiguous)
-    if (query.includes(" ") || query.includes("\n")) return null;
+    // Newlines always close the mention dropdown.
+    if (query.includes("\n")) return null;
+
+    // Don't trigger when the query begins with whitespace (e.g. "@ foo").
+    if (query.startsWith(" ")) return null;
+
+    // Two consecutive spaces signal the end of the mention
+    if (query.includes("  ")) return null;
+
+    // Bound the query so a forgotten dropdown doesn't search across long sentences.
+    if (query.length > MAX_MENTION_QUERY_LENGTH) return null;
 
     return query;
 }

--- a/client/webui/frontend/src/stories/chat/MentionsCommand.test.tsx
+++ b/client/webui/frontend/src/stories/chat/MentionsCommand.test.tsx
@@ -143,4 +143,22 @@ describe("MentionsCommand", () => {
         // No crash and the item is still present
         expect(btn).toBeInTheDocument();
     });
+
+    test("renders search results for a multi-word query and URL-encodes the space", async () => {
+        const multiWordPerson: Person = {
+            id: "michael.du.plessis@example.com",
+            displayName: "Michael Du Plessis",
+            workEmail: "michael.du.plessis@example.com",
+            jobTitle: "Engineer",
+        };
+        mockFetch.mockClear();
+        mockFetch.mockResolvedValue(makeFetchResponse({ data: [multiWordPerson] }));
+        renderMentions({ searchQuery: "michael du" });
+
+        await screen.findByText("Michael Du Plessis");
+
+        const calledUrl = mockFetch.mock.calls.find(call => typeof call[0] === "string" && call[0].includes("/api/v1/people/search"))?.[0] as string | undefined;
+        expect(calledUrl).toBeDefined();
+        expect(calledUrl).toContain("q=michael%20du");
+    });
 });


### PR DESCRIPTION
### What is the purpose of this change?

The mention detection logic previously only supported single-word queries, meaning users couldn't search for people by their full name (e.g. "Michael Du Plessis"). This change enables multi-word mention queries so users can type a first and last name after the `@` trigger and still get relevant search results.

### How was this change implemented?

- fix: enhance mention detection and add tests for multi-word queries
  - Updated `detectMentionTrigger` in `mentionUtils.ts` to allow spaces within a mention query, replacing the previous rule that closed the dropdown on any space. The dropdown now only closes on double-spaces, leading whitespace, newlines, or queries exceeding 50 characters.
  - Non-breaking spaces (commonly inserted by `contenteditable` elements) are now normalized to regular spaces before detection and search, ensuring consistent behaviour.
  - The search query is trimmed before being sent to the API in `MentionsCommand.tsx` to avoid trailing-space issues in requests.

### Key Design Decisions _(optional - delete if not applicable)_

Double-space was chosen as the signal to close the mention dropdown rather than a single space, as a single space is now needed to support multi-word name searches. A maximum query length of 50 characters is enforced to prevent the dropdown from staying open across unintended long sentences.

### How was this change tested?

- [ ] Manual testing: Typing a multi-word query after `@` in the chat input to verify search results appear and the correct URL-encoded query is sent to the backend.
- [ ] Unit tests: New test file `mentionUtils.test.ts` added with comprehensive coverage of `detectMentionTrigger`, including edge cases for multi-word queries, non-breaking spaces, double-spaces, newlines, leading whitespace, length limits, and cursor position scoping. Existing `MentionsCommand.test.tsx` extended with a multi-word query test verifying URL encoding.
- [ ] Known limitations: A `console.log` debug statement was left in `mentionUtils.ts` and should be removed before merge.

### Is there anything the reviewers should focus on/be aware of?

A `console.log` debug statement in `mentionUtils.ts` needs to be removed. Reviewers should also verify the double-space-to-close behaviour feels natural in practice, as it is a behaviour change from the previous single-space rule.