### PR TITLE
fix(DATAGO-134531): bump npm to 11.13.0 to fix brace-expansion CVE-<>

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -193,7 +193,7 @@ RUN echo "deb http://deb.debian.org/debian unstable main" > /etc/apt/sources.lis
     rm -rf /var/lib/apt/lists/* /etc/apt/sources.list.d/unstable.list /etc/apt/preferences.d/99pin-libtasn1
 
 # Node 25.5.0 ships with npm 11.8.0; upgrade to pick up security fixes in bundled dependencies
-RUN node /usr/local/lib/node_modules/npm/bin/npm-cli.js install -g npm@11.11.1
+RUN node /usr/local/lib/node_modules/npm/bin/npm-cli.js install -g npm@11.13.0
 
 # Install playwright temporarily just for browser installation (cached layer)
 # This is separate from the full venv to keep this layer cached


### PR DESCRIPTION
### What is the purpose of this change?

Fixes CVE-2026-33750 (high severity) in brace-expansion@5.0.4 found in the SAM container image.

### How was this change implemented?

 Bumped npm from 11.11.1 to 11.13.0 in Dockerfile. npm 11.11.1 was released before brace-expansion@5.0.5 existed and locks to the vulnerable version. npm 11.13.0 resolves to 5.0.5.

### Key Design Decisions _(optional - delete if not applicable)_

    Why did you choose this approach over alternatives?

### How was this change tested?

- [ ] Manual testing: [describe scenarios]
- [ ] Unit tests: [new/modified tests]
- [ ] Integration tests: [if applicable]
- [ ] Known limitations: [what wasn't tested]

### Is there anything the reviewers should focus on/be aware of?

    Special attention areas, potential risks, or open questions
