### PR TITLE
feat(DATAGO-134503): Experiment runs shows agent generated artifacts

### DIFF
--- a/client/webui/frontend/src/lib/components/chat/artifact/ArtifactDetails.tsx
+++ b/client/webui/frontend/src/lib/components/chat/artifact/ArtifactDetails.tsx
@@ -1,9 +1,9 @@
-import React, { useMemo } from "react";
+import React, { useContext, useMemo } from "react";
 
 import { Download, Info, Trash } from "lucide-react";
 
 import { Button, Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/lib/components/ui";
-import { useChatContext } from "@/lib/hooks";
+import { ChatContext } from "@/lib/contexts/ChatContext";
 import { formatRelativeTime } from "@/lib/utils/format";
 import type { ArtifactInfo } from "@/lib/types";
 
@@ -23,8 +23,13 @@ interface ArtifactDetailsProps {
 }
 
 export const ArtifactDetails: React.FC<ArtifactDetailsProps> = ({ artifactInfo, isPreview = false, isExpanded = false, onDelete, onDownload, setIsExpanded, badge }) => {
-    const { previewedArtifactAvailableVersions, currentPreviewedVersionNumber, navigateArtifactVersion } = useChatContext();
-    const versions = useMemo(() => previewedArtifactAvailableVersions ?? [], [previewedArtifactAvailableVersions]);
+    // Use the chat context optionally — when ArtifactDetails is rendered outside a
+    // ChatProvider (e.g. eval experiment results) the version-selector simply
+    // hides itself instead of throwing.
+    const ctx = useContext(ChatContext);
+    const versions = useMemo(() => ctx?.previewedArtifactAvailableVersions ?? [], [ctx?.previewedArtifactAvailableVersions]);
+    const currentPreviewedVersionNumber = ctx?.currentPreviewedVersionNumber;
+    const navigateArtifactVersion = ctx?.navigateArtifactVersion;
 
     return (
         <div className="flex flex-row justify-between gap-1">
@@ -41,7 +46,7 @@ export const ArtifactDetails: React.FC<ArtifactDetailsProps> = ({ artifactInfo, 
                     </div>
                 </div>
 
-                {isPreview && versions.length > 1 && (
+                {isPreview && versions.length > 1 && navigateArtifactVersion && (
                     <div className="align-right">
                         <Select
                             value={currentPreviewedVersionNumber?.toString()}

--- a/client/webui/frontend/src/lib/components/chat/index.ts
+++ b/client/webui/frontend/src/lib/components/chat/index.ts
@@ -23,3 +23,18 @@ export { InlineProgressUpdates } from "./InlineProgressUpdates";
 export { ContextUsageIndicator } from "./ContextUsageIndicator";
 export * from "./file";
 export * from "./selection";
+
+// Artifact bar (chat-style file row) — pure flat-props component, safe to use
+// outside a chat session (no context dependency). Other artifact components
+// in `./artifact/*` rely on `useChatContext` so are intentionally not re-exported.
+export { ArtifactBar, type ArtifactBarProps } from "./artifact/ArtifactBar";
+
+// Artifact details row (filename + last-modified subtitle + info/download/delete
+// action buttons). Optional version-selector hides when no ChatProvider is
+// available, so it works inside other contexts (e.g. eval experiment results).
+export { ArtifactDetails } from "./artifact/ArtifactDetails";
+
+// Universal content preview renderer + helpers — pure components, safe to
+// reuse anywhere a caller can supply the blob/text content directly.
+export { ContentRenderer } from "./preview/ContentRenderer";
+export { getRenderType, canPreviewArtifact, decodeBase64Content, encodeBase64Content, getFileContent } from "./preview/previewUtils";

--- a/client/webui/frontend/src/lib/components/ui/index.ts
+++ b/client/webui/frontend/src/lib/components/ui/index.ts
@@ -12,6 +12,7 @@ export { ComboBox, type ComboBoxItem } from "./combobox";
 export { Form, FormControl, FormField, FormItem, FormLabel, FormInputLabel } from "./form";
 export { Spinner } from "./spinner";
 export * from "./dialog";
+export { Sheet, SheetClose, SheetContent, SheetDescription, SheetFooter, SheetHeader, SheetTitle, SheetTrigger } from "./sheet";
 export { ResizablePanelGroup, ResizablePanel, ResizableHandle } from "./resizable";
 export { Switch } from "./switch";
 export { Progress } from "./progress";

--- a/client/webui/frontend/src/stories/chat/ArtifactDetails.test.tsx
+++ b/client/webui/frontend/src/stories/chat/ArtifactDetails.test.tsx
@@ -1,0 +1,93 @@
+/// <reference types="@testing-library/jest-dom" />
+import React from "react";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { describe, test, expect, vi } from "vitest";
+import * as matchers from "@testing-library/jest-dom/matchers";
+
+import { ArtifactDetails } from "@/lib/components/chat/artifact/ArtifactDetails";
+import { ChatContext, type ChatContextValue } from "@/lib/contexts/ChatContext";
+import type { ArtifactInfo } from "@/lib/types";
+
+expect.extend(matchers);
+
+const baseArtifact: ArtifactInfo = {
+    filename: "report.pdf",
+    mime_type: "application/pdf",
+    size: 1024,
+    last_modified: "2024-01-01T00:00:00.000Z",
+    uri: "artifact://report.pdf",
+};
+
+function withChatContext(value: Partial<ChatContextValue>, children: React.ReactNode) {
+    return <ChatContext.Provider value={value as ChatContextValue}>{children}</ChatContext.Provider>;
+}
+
+describe("ArtifactDetails outside a ChatProvider", () => {
+    test("renders filename without throwing when no ChatContext is present", () => {
+        render(<ArtifactDetails artifactInfo={baseArtifact} isPreview />);
+        expect(screen.getByText("report.pdf")).toBeInTheDocument();
+    });
+
+    test("hides version selector when no ChatContext is present even with isPreview=true", () => {
+        render(<ArtifactDetails artifactInfo={baseArtifact} isPreview />);
+        expect(screen.queryByText("Version")).not.toBeInTheDocument();
+    });
+
+    test("invokes onDownload when download button is clicked", () => {
+        const onDownload = vi.fn();
+        render(<ArtifactDetails artifactInfo={baseArtifact} onDownload={onDownload} isPreview />);
+        fireEvent.click(screen.getByRole("button", { name: /download/i }));
+        expect(onDownload).toHaveBeenCalledWith(baseArtifact);
+    });
+
+    test("invokes onDelete when delete button is clicked", () => {
+        const onDelete = vi.fn();
+        render(<ArtifactDetails artifactInfo={baseArtifact} onDelete={onDelete} isPreview />);
+        fireEvent.click(screen.getByRole("button", { name: /delete/i }));
+        expect(onDelete).toHaveBeenCalledTimes(1);
+    });
+});
+
+describe("ArtifactDetails inside a ChatProvider", () => {
+    test("hides version selector when only one version is available", () => {
+        render(
+            withChatContext(
+                {
+                    previewedArtifactAvailableVersions: [1],
+                    currentPreviewedVersionNumber: 1,
+                    navigateArtifactVersion: vi.fn(),
+                },
+                <ArtifactDetails artifactInfo={baseArtifact} isPreview />
+            )
+        );
+        expect(screen.queryByRole("combobox")).not.toBeInTheDocument();
+    });
+
+    test("renders version selector when multiple versions are available and isPreview=true", () => {
+        render(
+            withChatContext(
+                {
+                    previewedArtifactAvailableVersions: [1, 2, 3],
+                    currentPreviewedVersionNumber: 2,
+                    navigateArtifactVersion: vi.fn(),
+                },
+                <ArtifactDetails artifactInfo={baseArtifact} isPreview />
+            )
+        );
+        expect(screen.getByRole("combobox")).toBeInTheDocument();
+    });
+
+    test("hides version selector when isPreview=false even with multiple versions", () => {
+        render(
+            withChatContext(
+                {
+                    previewedArtifactAvailableVersions: [1, 2, 3],
+                    currentPreviewedVersionNumber: 2,
+                    navigateArtifactVersion: vi.fn(),
+                },
+                <ArtifactDetails artifactInfo={baseArtifact} />
+            )
+        );
+        expect(screen.queryByRole("combobox")).not.toBeInTheDocument();
+    });
+});

--- a/src/solace_agent_mesh/services/platform/services/model_config_service.py
+++ b/src/solace_agent_mesh/services/platform/services/model_config_service.py
@@ -320,6 +320,25 @@ class ModelConfigService:
             return self._to_raw_litellm_config(db_config)
         return self._to_response(db_config)
 
+    def get_for_snapshot(
+        self, db: Session, alias_or_id: str
+    ) -> Tuple[Optional[Dict], Optional[ModelConfigurationResponse]]:
+        """Single-fetch dual projection for callers that need both shapes.
+
+        Returns ``(raw_litellm_dict, response)`` for the same row. Used by eval
+        snapshotting which captures both the live LiteLlm config (for the
+        actual eval invocation) and the redacted response shape (for the
+        persisted point-in-time snapshot). Performs one DB read instead of
+        two, so callers don't need to reach into ``_to_raw_litellm_config`` /
+        ``_to_response`` / ``repository`` to keep the single-read property.
+
+        Returns ``(None, None)`` if no row matches.
+        """
+        db_config = self.repository.get_by_alias_or_id(db, alias_or_id)
+        if not db_config:
+            return None, None
+        return self._to_raw_litellm_config(db_config), self._to_response(db_config)
+
     def create(
         self, db: Session, request: ModelConfigurationCreateRequest, created_by: str
     ) -> ModelConfigurationResponse:


### PR DESCRIPTION
### What is the purpose of this change?

Lets library consumers reuse the chat artifact preview UI outside of a chat session — specifically, the SAM Enterprise eval-experiment results page, which renders saved artifacts but has no `ChatProvider` ancestor. Today, importing `ArtifactDetails` and `ContentRenderer` from `@SolaceLabs/solace-agent-mesh-ui` either isn't possible (not exported) or throws at runtime (`useChatContext` is required).

### How was this change implemented?

- **`ArtifactDetails.tsx`** — switched from `useChatContext()` (throws when no provider) to `useContext(ChatContext)` (returns `undefined` when absent). The version-selector now hides instead of throwing when there's no chat session, and a `&& navigateArtifactVersion` render gate keeps TS strict mode happy. **Behavior inside a `ChatProvider` is unchanged** — same context values, same render output.
- **`chat/index.ts`** — explicit re-exports of `ArtifactBar`, `ArtifactDetails`, `ContentRenderer`, and the preview helpers (`getRenderType`, `canPreviewArtifact`, `decodeBase64Content`, `encodeBase64Content`, `getFileContent`). Sibling artifact components that still depend on `useChatContext` are intentionally not re-exported (called out in a comment).
- **`ui/index.ts`** — re-exports the `Sheet` primitive family (`Sheet`, `SheetClose`, `SheetContent`, …) so consumers can build slide-out side-panels.

### Key Design Decisions _(optional - delete if not applicable)_

Considered moving `ArtifactDetails` to a context-agnostic location with an explicit `versions` prop, but that would break the existing in-chat call site (`ArtifactPanel.tsx`) and force a prop-drilling refactor. Optional context consumption is a smaller, safer change with no behavior delta for current consumers.

Considered adopting `FileMessage`'s `readOnly` prop + `hasContext` guard pattern. Skipped because `ArtifactDetails` doesn't render differently for read-only state — the simpler optional-context check is a better fit here.

### How was this change tested?

- [x] Manual testing: type-checked enterprise frontend (`tsc --noEmit -p tsconfig.app.json`) against a freshly-rebuilt local tgz of this branch — clean.
- [x] Unit tests: new `src/stories/chat/ArtifactDetails.test.tsx` (7 tests) covering both with-`ChatProvider` and without-`ChatProvider` render paths, version-selector visibility, and action-button callbacks.
- [x] Full unit suite: `npx vitest run --project=unit` — 87 files / 921 tests pass.
- [x] Lint: `npx eslint` clean on changed files.
- [x] Type-check: `npx tsc --noEmit -p tsconfig.app.json` clean.
- [ ] Storybook test: not added — no existing storybook story for `ArtifactPanel` to attach to, and `ArtifactDetails` already has full unit coverage. Worth adding a play-function story in a follow-up.

### Is there anything the reviewers should focus on/be aware of?

- **Bundle size**: `ContentRenderer` statically imports all 10 renderers (PDF, Mermaid, Office, Markdown, etc.). Tree-shaking should drop unused ones for consumers using named imports — verified no `import * as Chat` exists in the enterprise repo. If your downstream uses wildcard imports, the chat barrel is now wider.
- **Runtime peer-deps**: `ContentRenderer`'s renderers carry implicit peer-dep requirements (PDF.js worker, Mermaid runtime, etc.). The current consumer (enterprise eval results) already wires these up; broader consumers may need to.