### PR TITLE
docs: document samDeployment.agentDeployer.kubeApiHost knob

### DIFF
--- a/docs/docs/documentation/deploying/proxy_configuration.md
+++ b/docs/docs/documentation/deploying/proxy_configuration.md
@@ -84,6 +84,8 @@ services:
 
 :::info Enterprise Feature
 For Kubernetes proxy configuration with Agent Mesh Enterprise, configure proxy environment variables in your Helm values. See [Production Kubernetes Installation](../enterprise/production-kubernetes.md) for deployment guidance.
+
+When `HTTP_PROXY`/`HTTPS_PROXY` is set, the chart automatically routes the `sam-agent-deployer`'s in-cluster Kubernetes API calls around the proxy (via the [`samDeployment.agentDeployer.kubeApiHost`](../enterprise/production-kubernetes.md#values-reference) value), so agent deployments work out of the box without special `NO_PROXY` overrides.
 :::
 
 ## Certificate Bundle Merging

--- a/docs/docs/documentation/enterprise/airgap-kubernetes.md
+++ b/docs/docs/documentation/enterprise/airgap-kubernetes.md
@@ -173,6 +173,10 @@ This configuration is sufficient for **evaluation**. Embedded broker and persist
 
 For **production** air-gapped deployments, also configure external components. See [Step 3: Helm Chart Configuration](./production-kubernetes.md#step-3-helm-chart-configuration) in the Production guide.
 
+:::tip Forward Proxy
+If your air-gapped network uses a forward proxy, see [Proxy Configuration → Kubernetes](../deploying/proxy_configuration.md#kubernetes) for setup.
+:::
+
 ## Step 5: Custom CA Certificates (If Required)
 
 If your environment uses custom or self-signed CA certificates for internal infrastructure (Solace broker, OIDC providers, LLM services), configure this before the Helm install. Pods make outbound calls to these endpoints at startup and the CA bundle must be in place first.

--- a/docs/docs/documentation/enterprise/production-kubernetes.md
+++ b/docs/docs/documentation/enterprise/production-kubernetes.md
@@ -1030,6 +1030,7 @@ Configure external PostgreSQL database and object storage. For production, set `
 | `samDeployment.agentDeployer.image.pullPolicy` | string | `"IfNotPresent"` | Agent deployer pull policy |
 | `samDeployment.agentDeployer.version` | string | `"k8s-1.500.0"` | Agent deployer version identifier |
 | `samDeployment.agentDeployer.chartVersion` | string | `"1.500.0"` | Agent chart version |
+| `samDeployment.agentDeployer.kubeApiHost` | string | `"kubernetes.default.svc"` | Kubernetes API host the agent-deployer's `helm` client dials. Applied only when `HTTP_PROXY`/`HTTPS_PROXY` is set, so the chart's `.svc` `NO_PROXY` rule bypasses the proxy. Set to `""` to use the kubelet-injected cluster IP (required if your API server cert lacks a `kubernetes.default.svc` SAN). |
 | `samDeployment.dbInit.image.registry` | string | `""` | Database init container image registry override |
 | `samDeployment.dbInit.image.repository` | string | `"postgres"` | Database init container image |
 | `samDeployment.dbInit.image.tag` | string | `"18.0-trixie"` | Database init container tag |


### PR DESCRIPTION
## Summary

Documents the new `samDeployment.agentDeployer.kubeApiHost` Helm chart value introduced in [SolaceDev/sam-kubernetes#200](https://github.com/SolaceDev/sam-kubernetes/pull/200).

The chart change adds an automatic in-cluster API bypass for the `sam-agent-deployer` pod when `HTTP_PROXY`/`HTTPS_PROXY` is set, fixing agent deployments behind a forward proxy. This PR ensures the new value is discoverable in the docs.

## Changes

- **`production-kubernetes.md`** — adds the new `kubeApiHost` row to the `samDeployment.agentDeployer.*` values reference table.
- **`proxy_configuration.md`** — one-sentence note in the existing Kubernetes section pointing customers at the new value, so a customer hitting forward-proxy issues lands on the right answer when reading the canonical proxy doc.

3 lines added across 2 files. No new sections, no restructuring.

## Test plan

- [x] Renders cleanly (markdown table syntax + Docusaurus link form match the surrounding pages)
- [x] Cross-links resolve (`production-kubernetes.md#values-reference` exists; relative path is correct)