### PR TITLE
chore(DATAGO-134889): removing crypto.randomUUID usage

### DIFF
--- a/client/webui/frontend/.claude/CLAUDE.md
+++ b/client/webui/frontend/.claude/CLAUDE.md
@@ -22,7 +22,7 @@ React 19, TanStack Query v5, Tailwind v4, Radix UI, Vitest, Playwright
 
 ## Utilities
 
-- For UUIDs, use `uuidv4({})` from `uuid` — never `crypto.randomUUID()` (breaks in HTTP contexts)
+- For UUIDs, use `uuidv4({})` from `uuid` — never `crypto.randomUUID()`, which is undefined outside secure contexts (HTTPS/localhost) and throws when the app is served over plain HTTP
 
 ## Tests
 

--- a/client/webui/frontend/.claude/CLAUDE.md
+++ b/client/webui/frontend/.claude/CLAUDE.md
@@ -20,6 +20,10 @@ React 19, TanStack Query v5, Tailwind v4, Radix UI, Vitest, Playwright
 - Use `cn()` for class merging — never template literals
 - Use Tailwind v4 `(--var)` syntax — not bracket `[var(--var)]`
 
+## Utilities
+
+- For UUIDs, use `uuidv4({})` from `uuid` — never `crypto.randomUUID()` (breaks in HTTP contexts)
+
 ## Tests
 
 ```sh

--- a/client/webui/frontend/src/lib/components/research/ResearchPlanVerification.tsx
+++ b/client/webui/frontend/src/lib/components/research/ResearchPlanVerification.tsx
@@ -1,12 +1,12 @@
 import { useCallback, useState, useSyncExternalStore } from "react";
 import { Brain, CircleDashed, Loader2, Pencil, Plus, Trash2, Play } from "lucide-react";
-import { v4 as uuidv4 } from "uuid";
 
 import { useSubmitPlanResponse } from "@/lib/api";
 import { Button } from "@/lib/components/ui/button";
 import { Input } from "@/lib/components/ui/input";
 import { useChatContext } from "@/lib/hooks";
 import type { DataPart } from "@/lib/types";
+import { uuid } from "@/lib/utils/uuid";
 
 import { getRespondedPlansSnapshot, markPlanResponded, subscribeRespondedPlans } from "./respondedPlansStore";
 
@@ -38,7 +38,7 @@ interface EditableStep {
     value: string;
 }
 
-const makeStepId = () => uuidv4({});
+const makeStepId = () => uuid();
 
 const toEditableSteps = (steps: string[]): EditableStep[] => steps.map(value => ({ id: makeStepId(), value }));
 

--- a/client/webui/frontend/src/lib/components/research/ResearchPlanVerification.tsx
+++ b/client/webui/frontend/src/lib/components/research/ResearchPlanVerification.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useState, useSyncExternalStore } from "react";
 import { Brain, CircleDashed, Loader2, Pencil, Plus, Trash2, Play } from "lucide-react";
+import { v4 as uuidv4 } from "uuid";
 
 import { useSubmitPlanResponse } from "@/lib/api";
 import { Button } from "@/lib/components/ui/button";
@@ -37,7 +38,7 @@ interface EditableStep {
     value: string;
 }
 
-const makeStepId = () => (typeof crypto !== "undefined" && "randomUUID" in crypto ? crypto.randomUUID() : `step-${Math.random().toString(36).slice(2)}-${Date.now()}`);
+const makeStepId = () => uuidv4({});
 
 const toEditableSteps = (steps: string[]): EditableStep[] => steps.map(value => ({ id: makeStepId(), value }));
 

--- a/client/webui/frontend/src/lib/providers/ChatProvider.tsx
+++ b/client/webui/frontend/src/lib/providers/ChatProvider.tsx
@@ -1,6 +1,5 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import React, { useState, useCallback, useEffect, useRef, type FormEvent, type ReactNode } from "react";
-import { v4 as uuidv4 } from "uuid";
 import { useBooleanFlagDetails } from "@openfeature/react-sdk";
 
 import { api } from "@/lib/api";
@@ -11,7 +10,7 @@ import { useAutoGenerateTitle } from "@/lib/hooks/useAutoGenerateTitle";
 import { useProjectContext, registerProjectDeletedCallback } from "@/lib/providers";
 import { processChatEvent, serializeChatMessage, deserializeChatMessages } from "@/lib/providers/chat";
 import type { ChatEffect } from "@/lib/providers/chat";
-import { getErrorMessage, fileToBase64, migrateTask, CURRENT_SCHEMA_VERSION, getApiBearerToken, internalToDisplayText, extractRagDataFromTasks } from "@/lib/utils";
+import { getErrorMessage, fileToBase64, migrateTask, CURRENT_SCHEMA_VERSION, getApiBearerToken, internalToDisplayText, extractRagDataFromTasks, uuid } from "@/lib/utils";
 import { ConfirmationDialog } from "@/lib/components/common/ConfirmationDialog";
 
 import type {
@@ -33,11 +32,6 @@ import type {
     RAGSearchResult,
     ArtifactInfo,
 } from "@/lib/types";
-
-// Wrapper to force uuid to use crypto.getRandomValues() fallback instead of crypto.randomUUID()
-// This ensures compatibility with non-secure (HTTP) contexts where crypto.randomUUID() is unavailable
-// Note: may be able to remove this workaround with next version of uuid
-const v4 = () => uuidv4({});
 
 const INLINE_FILE_SIZE_LIMIT_BYTES = 1 * 1024 * 1024; // 1 MB
 
@@ -892,7 +886,7 @@ export const ChatProvider: React.FC<ChatProviderProps> = ({ children }) => {
                     api.webui
                         .post(`/api/v1/tasks/${currentTaskId}:cancel`, {
                             jsonrpc: "2.0",
-                            id: `req-${v4()}`,
+                            id: `req-${uuid()}`,
                             method: "tasks/cancel",
                             params: { id: currentTaskId },
                         })
@@ -1012,7 +1006,7 @@ export const ChatProvider: React.FC<ChatProviderProps> = ({ children }) => {
                     try {
                         await api.webui.post(`/api/v1/tasks/${currentTaskId}:cancel`, {
                             jsonrpc: "2.0",
-                            id: `req-${v4()}`,
+                            id: `req-${uuid()}`,
                             method: "tasks/cancel",
                             params: { id: currentTaskId },
                         });
@@ -1246,7 +1240,7 @@ export const ChatProvider: React.FC<ChatProviderProps> = ({ children }) => {
         try {
             const cancelRequest: CancelTaskRequest = {
                 jsonrpc: "2.0",
-                id: `req-${v4()}`,
+                id: `req-${uuid()}`,
                 method: "tasks/cancel",
                 params: { id: currentTaskId },
             };
@@ -1370,7 +1364,7 @@ export const ChatProvider: React.FC<ChatProviderProps> = ({ children }) => {
                 contextQuote: contextQuote || undefined,
                 contextQuoteSourceId: contextQuoteSourceId || undefined,
                 metadata: {
-                    messageId: `msg-${v4()}`,
+                    messageId: `msg-${uuid()}`,
                     sessionId: overrideSessionId || sessionId,
                     lastProcessedEventSequence: 0,
                 },
@@ -1498,7 +1492,7 @@ export const ChatProvider: React.FC<ChatProviderProps> = ({ children }) => {
                 const a2aMessage: Message = {
                     role: "user",
                     parts: messageParts,
-                    messageId: `msg-${v4()}`,
+                    messageId: `msg-${uuid()}`,
                     kind: "message",
                     contextId: effectiveSessionId,
                     metadata: messageMetadata,
@@ -1509,7 +1503,7 @@ export const ChatProvider: React.FC<ChatProviderProps> = ({ children }) => {
                 // 4. Construct the SendStreamingMessageRequest
                 const sendMessageRequest: SendStreamingMessageRequest = {
                     jsonrpc: "2.0",
-                    id: `req-${v4()}`,
+                    id: `req-${uuid()}`,
                     method: "message/stream",
                     params: {
                         message: a2aMessage,

--- a/client/webui/frontend/src/lib/providers/SSEProvider.tsx
+++ b/client/webui/frontend/src/lib/providers/SSEProvider.tsx
@@ -1,9 +1,9 @@
 import React, { type ReactNode, useState, useRef, useEffect, useCallback } from "react";
-import { v4 as uuidv4 } from "uuid";
 
 import { SSEContext, type SSEContextValue } from "@/lib/contexts/SSEContext";
 import { useSessionStorage } from "@/lib/hooks";
 import { getApiBearerToken } from "@/lib/utils/api";
+import { uuid } from "@/lib/utils/uuid";
 import { api } from "@/lib/api";
 import type { SSEConnectionState, SSESubscriptionOptions, SSESubscriptionReturn, SSETask } from "@/lib/types";
 
@@ -228,7 +228,7 @@ export const SSEProvider = ({ children }: SSEProviderProps) => {
 
     const subscribe = useCallback(
         (endpoint: string, handlers: { onMessage?: (e: MessageEvent) => void; onError?: (e: Event) => void }, onStateChange: (state: SSEConnectionState) => void, eventType: string = "message"): (() => void) => {
-            const subscriberId = uuidv4({});
+            const subscriberId = uuid();
 
             let entry = connectionsRef.current.get(endpoint);
 

--- a/client/webui/frontend/src/lib/providers/SSEProvider.tsx
+++ b/client/webui/frontend/src/lib/providers/SSEProvider.tsx
@@ -1,4 +1,5 @@
 import React, { type ReactNode, useState, useRef, useEffect, useCallback } from "react";
+import { v4 as uuidv4 } from "uuid";
 
 import { SSEContext, type SSEContextValue } from "@/lib/contexts/SSEContext";
 import { useSessionStorage } from "@/lib/hooks";
@@ -227,7 +228,7 @@ export const SSEProvider = ({ children }: SSEProviderProps) => {
 
     const subscribe = useCallback(
         (endpoint: string, handlers: { onMessage?: (e: MessageEvent) => void; onError?: (e: Event) => void }, onStateChange: (state: SSEConnectionState) => void, eventType: string = "message"): (() => void) => {
-            const subscriberId = crypto.randomUUID();
+            const subscriberId = uuidv4({});
 
             let entry = connectionsRef.current.get(endpoint);
 

--- a/client/webui/frontend/src/lib/providers/chat/processChatEvent.ts
+++ b/client/webui/frontend/src/lib/providers/chat/processChatEvent.ts
@@ -1,12 +1,8 @@
-import { v4 as uuidv4 } from "uuid";
-
 import { filterRenderableDataParts, checkHasVisibleContent, isCompactionNotificationBubble } from "@/lib/utils/messageProcessing";
+import { uuid } from "@/lib/utils/uuid";
 import { markPlanResponded } from "@/lib/components/research/respondedPlansStore";
 
 import type { DataPart, FileAttachment, SendStreamingMessageSuccessResponse, JSONRPCErrorResponse, TaskStatusUpdateEvent, ArtifactPart, PartFE, MessageFE, RAGSearchResult, ProgressUpdate, ArtifactInfo, Part } from "@/lib/types";
-
-// Force uuid to use crypto.getRandomValues() fallback for non-secure (HTTP) contexts
-const v4 = () => uuidv4({});
 
 // ============ Data Part Payloads ============
 
@@ -236,7 +232,7 @@ export function processChatEvent(input: ChatEventInput): ChatEventOutput {
             isError: true,
             isComplete: true,
             metadata: {
-                messageId: `msg-${v4()}`,
+                messageId: `msg-${uuid()}`,
                 lastProcessedEventSequence: eventSequence,
             },
         });
@@ -417,7 +413,7 @@ export function processChatEvent(input: ChatEventInput): ChatEventOutput {
                                     },
                                     isUser: false,
                                     isComplete: true,
-                                    metadata: { messageId: `auth-${v4()}` },
+                                    metadata: { messageId: `auth-${uuid()}` },
                                 };
                                 messages = [...messages, authMessage];
                             }
@@ -500,7 +496,7 @@ export function processChatEvent(input: ChatEventInput): ChatEventOutput {
     const isTaskFailed = result.kind === "task" && result.status?.state === "failed";
 
     // --- Update messages with content ---
-    const responseMessageId = rpcResponse.id?.toString() ?? `msg-${v4()}`;
+    const responseMessageId = rpcResponse.id?.toString() ?? `msg-${uuid()}`;
     const responseContextId = "result" in rpcResponse && rpcResponse.result && "contextId" in rpcResponse.result ? (rpcResponse.result as unknown as { contextId?: string }).contextId : undefined;
 
     messages = applyContentToMessages(messages, newContentParts, {
@@ -551,7 +547,7 @@ export function processChatEvent(input: ChatEventInput): ChatEventOutput {
                     isUser: false,
                     isComplete: true,
                     metadata: {
-                        messageId: rpcResponse.id?.toString() || `msg-${v4()}`,
+                        messageId: rpcResponse.id?.toString() || `msg-${uuid()}`,
                         sessionId: (result as unknown as { contextId?: string }).contextId || sessionId,
                         lastProcessedEventSequence: eventSequence,
                     },
@@ -656,7 +652,7 @@ function appendProgressUpdate(
             isComplete: false,
             progressUpdates: [update],
             metadata: {
-                messageId: `msg-${v4()}`,
+                messageId: `msg-${uuid()}`,
                 lastProcessedEventSequence: eventSequence,
             },
             ...extraFields,

--- a/client/webui/frontend/src/lib/providers/chat/serializeChatMessage.ts
+++ b/client/webui/frontend/src/lib/providers/chat/serializeChatMessage.ts
@@ -1,8 +1,6 @@
-import { v4 as uuidv4 } from "uuid";
+import { uuid } from "@/lib/utils/uuid";
 
 import type { MessageFE, ArtifactPart, TextPart } from "@/lib/types";
-
-const v4 = () => uuidv4({});
 
 /**
  * Serializes a MessageFE into the format expected by the backend chat-tasks API.
@@ -22,7 +20,7 @@ export function serializeChatMessage(message: MessageFE) {
     }
 
     return {
-        id: message.metadata?.messageId || `msg-${v4()}`,
+        id: message.metadata?.messageId || `msg-${uuid()}`,
         type: message.isUser ? "user" : "agent",
         text: combinedText,
         parts: message.parts,

--- a/client/webui/frontend/src/lib/utils/index.ts
+++ b/client/webui/frontend/src/lib/utils/index.ts
@@ -11,6 +11,7 @@ export * from "./textPreprocessor";
 export * from "./themeHtmlStyles";
 export * from "./guard";
 export * from "./url";
+export * from "./uuid";
 export * from "./sourceUrlHelpers";
 export * from "./mentionUtils";
 export * from "./agentUtils";

--- a/client/webui/frontend/src/lib/utils/uuid.ts
+++ b/client/webui/frontend/src/lib/utils/uuid.ts
@@ -1,0 +1,7 @@
+import { v4 as uuidv4 } from "uuid";
+
+// Forces uuid to use the crypto.getRandomValues() fallback instead of crypto.randomUUID().
+// crypto.randomUUID() is undefined outside secure contexts (HTTPS/localhost) and throws
+// when the app is served over plain HTTP, which is supported in some SAM deployments.
+// Passing any options (even {}) bypasses uuid's native.randomUUID() shortcut.
+export const uuid = (): string => uuidv4({});


### PR DESCRIPTION
### What is the purpose of this change?

    Removing `crypto.randomUUID` usage.

### How was this change implemented?

This pull request standardizes the generation of UUIDs across the frontend codebase by replacing the use of `crypto.randomUUID()` with `uuidv4({})` from the `uuid` library. This change improves compatibility in environments where `crypto.randomUUID()` may not be available, such as certain HTTP contexts. The update is reflected in both documentation and key utility functions.

**UUID Generation Standardization:**
- Updated the documentation in `client/webui/frontend/.claude/CLAUDE.md` to specify using `uuidv4({})` from the `uuid` package for UUIDs, explicitly discouraging the use of `crypto.randomUUID()` due to compatibility issues.
- Replaced all usages of `crypto.randomUUID()` with `uuidv4({})` in the `makeStepId` utility function within `ResearchPlanVerification.tsx`, ensuring consistent UUID generation for editable steps.
- Updated the `SSEProvider` component to use `uuidv4({})` for generating `subscriberId`s instead of `crypto.randomUUID()`.

**Dependency Management:**
- Added imports for `uuidv4` from the `uuid` library in both `ResearchPlanVerification.tsx` and `SSEProvider.tsx` to support the new UUID generation approach. [[1]](diffhunk://#diff-c25650a7f000608c521a44e1a5be92d34f4fc16664f4f02d81538564a0fab997R3) [[2]](diffhunk://#diff-9e8adb5d838a75132f370103cca527fc015198668b464d836f7c22ac324b9c98R2)

### How was this change tested?

- [x] Manual testing: [describe scenarios]
- [ ] Unit tests: [new/modified tests]
- [ ] Integration tests: [if applicable]
- [ ] Known limitations: [what wasn't tested]

### Is there anything the reviewers should focus on/be aware of?

Internals encountered this error - fixing to unblock some browsers.
