### PR TITLE
fix(DATAGO-132447): - Enable Support to Skip TLS verification for MCP tools/connectors

### DIFF
--- a/src/solace_agent_mesh/agent/adk/mcp_ssl_config.py
+++ b/src/solace_agent_mesh/agent/adk/mcp_ssl_config.py
@@ -13,6 +13,23 @@ import httpx
 
 log = logging.getLogger(__name__)
 
+# Environment variable that globally controls TLS verification for outbound
+# MCP HTTPS connections (SSE, Streamable HTTP). Default is verify=True; set
+# to "false" (case insensitive) to skip TLS verification. Intended for
+# development environments with self-signed certificates.
+ENV_MCP_TLS_VERIFY = "SAM_MCP_CONNECTOR_TLS_VERIFY"
+
+
+def is_tls_verify() -> bool:
+    """Resolve TLS verification setting from the environment.
+
+    Returns True (verify) by default and when SAM_MCP_CONNECTOR_TLS_VERIFY is
+    unset, empty, or any value other than "false". Returns False only when
+    the variable is explicitly set to "false" (case insensitive).
+    """
+    raw = os.getenv(ENV_MCP_TLS_VERIFY, "").strip().lower()
+    return raw != "false"
+
 
 @dataclass
 class SslConfig:

--- a/src/solace_agent_mesh/agent/adk/setup.py
+++ b/src/solace_agent_mesh/agent/adk/setup.py
@@ -48,7 +48,7 @@ from ..tools.executors import PythonToolLoader
 from ..tools.tool_definition import BuiltinTool
 from .app_llm_agent import AppLlmAgent
 from .embed_resolving_mcp_toolset import EmbedResolvingMCPToolset
-from .mcp_ssl_config import SslConfig
+from .mcp_ssl_config import SslConfig, is_tls_verify
 from .tool_result_processor import ToolResultProcessor
 from .tool_wrapper import ADKToolWrapper
 
@@ -481,6 +481,21 @@ async def _load_mcp_tool(component: "SamAgentComponent", tool_config: Dict) -> T
             component.log_identifier,
             ssl_verify,
             ssl_ca_bundle,
+        )
+
+    # Apply SAM_MCP_CONNECTOR_TLS_VERIFY override for HTTPS-based MCP
+    # connections (SSE, Streamable HTTP). Stdio connections do not use TLS so
+    # this override does not apply to them.
+    if connection_type in ("sse", "streamable-http") and not is_tls_verify():
+        if ssl_config is None:
+            ssl_config = SslConfig(verify=False)
+        else:
+            ssl_config.verify = False
+        log.warning(
+            "%s SSL verification disabled for MCP connection via "
+            "SAM_MCP_CONNECTOR_TLS_VERIFY=false. This should only be used in "
+            "development environments.",
+            component.log_identifier,
         )
 
     environment_variables = tool_config_model.environment_variables

--- a/tests/unit/agent/adk/test_mcp_ssl_config.py
+++ b/tests/unit/agent/adk/test_mcp_ssl_config.py
@@ -7,8 +7,10 @@ import httpx
 import pytest
 
 from solace_agent_mesh.agent.adk.mcp_ssl_config import (
+    ENV_MCP_TLS_VERIFY,
     SslConfig,
     create_ssl_httpx_client_factory,
+    is_tls_verify,
 )
 
 
@@ -152,3 +154,49 @@ class TestCreateSslHttpxClientFactory:
 
         assert client._auth is not None
         assert isinstance(client._auth, httpx.BasicAuth)
+
+
+class TestGetEnvTlsVerify:
+    """Tests for the SAM_MCP_CONNECTOR_TLS_VERIFY env var resolver."""
+
+    @pytest.fixture(autouse=True)
+    def _clear_env(self, monkeypatch):
+        monkeypatch.delenv(ENV_MCP_TLS_VERIFY, raising=False)
+
+    def test_default_is_true_when_unset(self):
+        assert is_tls_verify() is True
+
+    def test_empty_value_is_true(self, monkeypatch):
+        monkeypatch.setenv(ENV_MCP_TLS_VERIFY, "")
+        assert is_tls_verify() is True
+
+    def test_whitespace_value_is_true(self, monkeypatch):
+        monkeypatch.setenv(ENV_MCP_TLS_VERIFY, "   ")
+        assert is_tls_verify() is True
+
+    def test_true_value(self, monkeypatch):
+        monkeypatch.setenv(ENV_MCP_TLS_VERIFY, "true")
+        assert is_tls_verify() is True
+
+    def test_false_value(self, monkeypatch):
+        monkeypatch.setenv(ENV_MCP_TLS_VERIFY, "false")
+        assert is_tls_verify() is False
+
+    def test_false_is_case_insensitive(self, monkeypatch):
+        monkeypatch.setenv(ENV_MCP_TLS_VERIFY, "FALSE")
+        assert is_tls_verify() is False
+
+        monkeypatch.setenv(ENV_MCP_TLS_VERIFY, "False")
+        assert is_tls_verify() is False
+
+    def test_false_with_surrounding_whitespace(self, monkeypatch):
+        monkeypatch.setenv(ENV_MCP_TLS_VERIFY, "  false  ")
+        assert is_tls_verify() is False
+
+    def test_unrecognized_value_defaults_to_true(self, monkeypatch):
+        # Anything other than "false" is treated as verify=True (safe default).
+        monkeypatch.setenv(ENV_MCP_TLS_VERIFY, "0")
+        assert is_tls_verify() is True
+
+        monkeypatch.setenv(ENV_MCP_TLS_VERIFY, "no")
+        assert is_tls_verify() is True

--- a/tests/unit/agent/adk/test_mcp_tls_verify_env.py
+++ b/tests/unit/agent/adk/test_mcp_tls_verify_env.py
@@ -1,0 +1,147 @@
+"""Tests for SAM_MCP_CONNECTOR_TLS_VERIFY env var override in MCP loader."""
+
+from unittest.mock import Mock
+
+import pytest
+
+from solace_agent_mesh.agent.adk.embed_resolving_mcp_toolset import (
+    EmbedResolvingMCPToolset,
+)
+from solace_agent_mesh.agent.adk.mcp_ssl_config import ENV_MCP_TLS_VERIFY
+from solace_agent_mesh.agent.adk.setup import _load_mcp_tool
+from solace_agent_mesh.agent.adk.ssl_mcp_session_manager import (
+    SslConfigurableMCPSessionManager,
+)
+
+
+@pytest.fixture
+def component():
+    component = Mock()
+    component.log_identifier = "[TestAgent]"
+    return component
+
+
+@pytest.fixture(autouse=True)
+def _clear_env(monkeypatch):
+    monkeypatch.delenv(ENV_MCP_TLS_VERIFY, raising=False)
+
+
+def _sse_tool_config():
+    return {
+        "tool_type": "mcp",
+        "connection_params": {
+            "type": "sse",
+            "url": "https://example.test/sse",
+        },
+    }
+
+
+def _streamable_http_tool_config():
+    return {
+        "tool_type": "mcp",
+        "connection_params": {
+            "type": "streamable-http",
+            "url": "https://example.test/mcp",
+        },
+    }
+
+
+def _stdio_tool_config():
+    return {
+        "tool_type": "mcp",
+        "connection_params": {
+            "type": "stdio",
+            "command": "npx",
+            "args": ["-y", "@modelcontextprotocol/server-filesystem", "/tmp"],
+        },
+    }
+
+
+@pytest.mark.asyncio
+async def test_sse_with_env_var_unset_does_not_disable_verify(component):
+    tools, _, _, _ = await _load_mcp_tool(component, _sse_tool_config())
+
+    toolset = tools[0]
+    assert isinstance(toolset, EmbedResolvingMCPToolset)
+    # No ssl_config in YAML and no env override → no SslConfigurableMCPSessionManager.
+    assert not isinstance(
+        toolset._mcp_session_manager, SslConfigurableMCPSessionManager
+    )
+
+
+@pytest.mark.asyncio
+async def test_sse_with_env_var_false_disables_verify(component, monkeypatch):
+    monkeypatch.setenv(ENV_MCP_TLS_VERIFY, "false")
+
+    tools, _, _, _ = await _load_mcp_tool(component, _sse_tool_config())
+
+    toolset = tools[0]
+    assert isinstance(
+        toolset._mcp_session_manager, SslConfigurableMCPSessionManager
+    )
+    assert toolset._mcp_session_manager._ssl_config.verify is False
+
+
+@pytest.mark.asyncio
+async def test_streamable_http_with_env_var_false_disables_verify(
+    component, monkeypatch
+):
+    monkeypatch.setenv(ENV_MCP_TLS_VERIFY, "FALSE")
+
+    tools, _, _, _ = await _load_mcp_tool(
+        component, _streamable_http_tool_config()
+    )
+
+    toolset = tools[0]
+    assert isinstance(
+        toolset._mcp_session_manager, SslConfigurableMCPSessionManager
+    )
+    assert toolset._mcp_session_manager._ssl_config.verify is False
+
+
+@pytest.mark.asyncio
+async def test_env_var_overrides_config_level_verify_true(component, monkeypatch):
+    monkeypatch.setenv(ENV_MCP_TLS_VERIFY, "false")
+
+    tool_config = _sse_tool_config()
+    tool_config["connection_params"]["ssl_config"] = {"verify": True}
+
+    tools, _, _, _ = await _load_mcp_tool(component, tool_config)
+
+    toolset = tools[0]
+    assert isinstance(
+        toolset._mcp_session_manager, SslConfigurableMCPSessionManager
+    )
+    # Env var must override the explicit verify=True from config.
+    assert toolset._mcp_session_manager._ssl_config.verify is False
+
+
+@pytest.mark.asyncio
+async def test_env_var_true_does_not_disable_config_verify_true(
+    component, monkeypatch
+):
+    monkeypatch.setenv(ENV_MCP_TLS_VERIFY, "true")
+
+    tool_config = _sse_tool_config()
+    tool_config["connection_params"]["ssl_config"] = {"verify": True}
+
+    tools, _, _, _ = await _load_mcp_tool(component, tool_config)
+
+    toolset = tools[0]
+    assert isinstance(
+        toolset._mcp_session_manager, SslConfigurableMCPSessionManager
+    )
+    assert toolset._mcp_session_manager._ssl_config.verify is True
+
+
+@pytest.mark.asyncio
+async def test_stdio_ignores_env_var(component, monkeypatch):
+    monkeypatch.setenv(ENV_MCP_TLS_VERIFY, "false")
+
+    tools, _, _, _ = await _load_mcp_tool(component, _stdio_tool_config())
+
+    toolset = tools[0]
+    # Stdio has no TLS, so the env var must not force an SSL session manager.
+    assert not isinstance(
+        toolset._mcp_session_manager, SslConfigurableMCPSessionManager
+    )


### PR DESCRIPTION
### What is the purpose of this change?

 - add env var flag to skip tls validation for outbound mcp com 

### How was this change implemented?

    - as per jira, new env var to target/disable mcp tls check

### Key Design Decisions _(optional - delete if not applicable)_

    Why did you choose this approach over alternatives?

### How was this change tested?

- [x] Manual testing: [describe scenarios]
- [x] Unit tests: [new/modified tests]
- [ ] Integration tests: [if applicable]
- [ ] Known limitations: [what wasn't tested]

### Is there anything the reviewers should focus on/be aware of?

    Special attention areas, potential risks, or open questions
