### PR TITLE
fix(agent): lazy-init DynamicModelProvider for per-request model_override

### DIFF
--- a/src/solace_agent_mesh/agent/adk/models/dynamic_model_provider.py
+++ b/src/solace_agent_mesh/agent/adk/models/dynamic_model_provider.py
@@ -143,10 +143,20 @@ class ModelConfigReceiverComponent(ComponentBase):
 
 class DynamicModelProvider:
 
-    def __init__(self, component: ComponentBase, litellm_instance: LiteLlm, model_id: str):
+    def __init__(
+        self,
+        component: ComponentBase,
+        litellm_instance: LiteLlm,
+        model_id: str,
+        skip_bootstrap: bool = False,
+    ):
         self._component = component
         self._litellm_instance = litellm_instance
         self._model_id = model_id
+        # When True, set up the broker subscription only — don't send a bootstrap
+        # request for ``model_id``. Used by the override-only path so the agent's
+        # static litellm model isn't replaced via the auto-update flow.
+        self._skip_bootstrap = skip_bootstrap
 
         # Internal SAC flow for subscribing to model config updates
         self._internal_app = None
@@ -176,13 +186,20 @@ class DynamicModelProvider:
         self._loop = asyncio.get_running_loop()
         await self.listen_for_model_config_change()
 
+        if self._skip_bootstrap:
+            # Override-only mode: subscription is up so resolve() works for any
+            # alias via the wildcard receiver, but we never request a bootstrap
+            # for this provider's own model_id. Skipping that avoids the
+            # auto-update path mutating the agent's static litellm instance.
+            return
+
         # Call request_model_config up to 3 times, once every 5 seconds, until initialized
         for i in range(_MAX_BOOTSTRAP_RETRIES):
             await self.request_model_config()
             await asyncio.sleep(_BOOTSTRAP_RETRY_INTERVAL_SECONDS)
             if self._initialized:
                 break
-        
+
         if not self._initialized:
             log.warning(
                 "%s Model configuration not received after multiple attempts. LiteLlm instance may not be configured.",

--- a/src/solace_agent_mesh/agent/protocol/event_handlers.py
+++ b/src/solace_agent_mesh/agent/protocol/event_handlers.py
@@ -1084,9 +1084,63 @@ def _send_error_response_and_nack(
     component.handle_error(exception, Event(EventType.MESSAGE, message))
 
 
+_LAZY_OVERRIDE_PROVIDER_SENTINEL = "__lazy_override_resolver__"
+
+
+async def _ensure_override_provider(component: "SamAgentComponent") -> Any:
+    """Lazy-init an override-only ``DynamicModelProvider`` on the component.
+
+    Agents whose YAML lacks a ``model_provider`` field don't start a model
+    listener at boot, so ``component._dynamic_model_provider`` is ``None`` and
+    per-request ``model_override`` resolution would fail with "model config
+    not available". Instead of forcing every agent's YAML to declare
+    ``model_provider``, we spin up an override-only provider on the first
+    override request: it shares the wildcard bootstrap subscription so
+    ``resolve()`` works for any alias/UUID, but skips the auto-update path
+    (``skip_bootstrap=True``) so the agent's static ``model:`` config is
+    never replaced.
+
+    Returns the provider, or ``None`` if the component has no litellm
+    instance to back the resolution flow.
+    """
+    if component._dynamic_model_provider is not None:
+        return component._dynamic_model_provider
+
+    if component._dynamic_model_provider_init_lock is None:
+        component._dynamic_model_provider_init_lock = asyncio.Lock()
+
+    async with component._dynamic_model_provider_init_lock:
+        if component._dynamic_model_provider is not None:
+            return component._dynamic_model_provider
+
+        litellm_instance = component.get_lite_llm_model()
+        if litellm_instance is None:
+            return None
+
+        # Inline import keeps event_handlers free of an agent->adk dependency
+        # at module load and matches the pattern used elsewhere in this file.
+        from ..adk.models.dynamic_model_provider import DynamicModelProvider
+
+        provider = DynamicModelProvider(
+            component,
+            litellm_instance,
+            _LAZY_OVERRIDE_PROVIDER_SENTINEL,
+            skip_bootstrap=True,
+        )
+        # Wait for the broker subscription to be live before returning so the
+        # immediately-following resolve() doesn't race the listener setup.
+        await provider.initialize()
+        component._dynamic_model_provider = provider
+        log.info(
+            "%s Lazy-initialised override-only DynamicModelProvider",
+            component.log_identifier,
+        )
+        return provider
+
+
 async def _resolve_model_override_metadata(
     task_metadata: Dict[str, Any],
-    dynamic_model_provider: Any,
+    component: "SamAgentComponent",
     log_identifier: str,
 ) -> Optional[str]:
     """Resolve model_override alias in task metadata to a raw LiteLLM config dict.
@@ -1126,6 +1180,10 @@ async def _resolve_model_override_metadata(
         return None
 
     model_id = model_override["model_id"]
+    dynamic_model_provider = component._dynamic_model_provider
+    if dynamic_model_provider is None:
+        dynamic_model_provider = await _ensure_override_provider(component)
+
     resolved = None
     if dynamic_model_provider:
         resolved = await dynamic_model_provider.resolve(model_id)
@@ -1231,7 +1289,7 @@ async def _handle_send_message_request(
 
     override_error = await _resolve_model_override_metadata(
         task_metadata,
-        component._dynamic_model_provider,
+        component,
         component.log_identifier,
     )
     if override_error:

--- a/src/solace_agent_mesh/common/sac/sam_component_base.py
+++ b/src/solace_agent_mesh/common/sac/sam_component_base.py
@@ -74,6 +74,9 @@ class SamComponentBase(ComponentBase, abc.ABC):
 
         # DynamicModelProvider ref for per-request model alias resolution
         self._dynamic_model_provider: Optional[DynamicModelProvider] = None
+        # Coordinates lazy-init of the override-only provider when an agent has
+        # no ``model_provider`` configured but receives a per-request override.
+        self._dynamic_model_provider_init_lock: Optional[asyncio.Lock] = None
 
         feature_flags.initialize()
 

--- a/tests/unit/agent/adk/models/test_dynamic_model_provider.py
+++ b/tests/unit/agent/adk/models/test_dynamic_model_provider.py
@@ -40,6 +40,7 @@ def _make_provider_no_init(component=None, litellm_instance=None, model_id="gene
     provider._component = component or _make_mock_component()
     provider._litellm_instance = litellm_instance or LiteLlm(model=None)
     provider._model_id = model_id
+    provider._skip_bootstrap = False
     provider._internal_app = None
     provider._broker_input = None
     provider._initialized = False
@@ -209,6 +210,22 @@ class TestDynamicModelProviderInitialize:
             await provider.initialize()
 
         assert call_count == 2
+
+    @pytest.mark.asyncio
+    async def test_initialize_skip_bootstrap_subscribes_only(self):
+        """skip_bootstrap=True must wire up the listener subscription but never
+        send a bootstrap request — that's what protects an agent's static
+        litellm config from being clobbered by the auto-update path when the
+        provider is lazy-initialised purely to handle per-request overrides."""
+        provider = _make_provider_no_init()
+        provider._skip_bootstrap = True
+        provider.listen_for_model_config_change = AsyncMock()
+        provider.request_model_config = AsyncMock()
+
+        await provider.initialize()
+
+        provider.listen_for_model_config_change.assert_awaited_once()
+        provider.request_model_config.assert_not_awaited()
 
 
 class TestDynamicModelProviderEnsureConfigListener:

--- a/tests/unit/agent/protocol/test_event_handlers_model_override.py
+++ b/tests/unit/agent/protocol/test_event_handlers_model_override.py
@@ -17,6 +17,21 @@ from solace_agent_mesh.agent.protocol.event_handlers import (
 )
 
 
+def _component(dmp=None, litellm=None):
+    """Build a stand-in component for the resolver.
+
+    The resolver reads ``_dynamic_model_provider`` and may call
+    ``get_lite_llm_model()`` for lazy-init. Tests that don't exercise lazy-init
+    can leave ``litellm`` unset.
+    """
+    component = MagicMock()
+    component._dynamic_model_provider = dmp
+    component._dynamic_model_provider_init_lock = None
+    component.get_lite_llm_model = MagicMock(return_value=litellm)
+    component.log_identifier = "[TestComponent]"
+    return component
+
+
 @pytest.fixture(autouse=True)
 def _reset_feature_flags():
     feature_flags._reset_for_testing()
@@ -35,7 +50,9 @@ class TestModelOverrideAliasResolution:
         metadata = {"model_override": {"model_id": "my-gpt4-alias"}}
 
         with mock_flags(offline_evals=True):
-            result = await _resolve_model_override_metadata(metadata, dmp, "[Test]")
+            result = await _resolve_model_override_metadata(
+                metadata, _component(dmp=dmp), "[Test]"
+            )
 
         assert result is None
         assert metadata["model_override"] == {"model": "openai/gpt-4o", "api_key": "sk-test"}
@@ -47,17 +64,22 @@ class TestModelOverrideAliasResolution:
         metadata = {"model_override": {"model_id": "unknown-alias"}}
 
         with mock_flags(offline_evals=True):
-            result = await _resolve_model_override_metadata(metadata, dmp, "[Test]")
+            result = await _resolve_model_override_metadata(
+                metadata, _component(dmp=dmp), "[Test]"
+            )
 
         assert isinstance(result, str)
         assert "unknown-alias" in result
 
     @pytest.mark.asyncio
-    async def test_no_provider_returns_error_reason(self):
+    async def test_no_provider_no_litellm_returns_error_reason(self):
+        """Component with neither a provider nor a litellm can't resolve."""
         metadata = {"model_override": {"model_id": "my-alias"}}
 
         with mock_flags(offline_evals=True):
-            result = await _resolve_model_override_metadata(metadata, None, "[Test]")
+            result = await _resolve_model_override_metadata(
+                metadata, _component(dmp=None, litellm=None), "[Test]"
+            )
 
         assert isinstance(result, str)
         assert "not available" in result
@@ -68,7 +90,9 @@ class TestModelOverrideAliasResolution:
         metadata = {"some_other_key": "value"}
 
         with mock_flags(offline_evals=True):
-            result = await _resolve_model_override_metadata(metadata, dmp, "[Test]")
+            result = await _resolve_model_override_metadata(
+                metadata, _component(dmp=dmp), "[Test]"
+            )
 
         assert result is None
         dmp.resolve.assert_not_awaited()
@@ -80,7 +104,9 @@ class TestModelOverrideAliasResolution:
         metadata = {"model_override": None}
 
         with mock_flags(offline_evals=True):
-            result = await _resolve_model_override_metadata(metadata, dmp, "[Test]")
+            result = await _resolve_model_override_metadata(
+                metadata, _component(dmp=dmp), "[Test]"
+            )
 
         assert result is None
         dmp.resolve.assert_not_awaited()
@@ -91,7 +117,7 @@ class TestModelOverrideAliasResolution:
 
         with mock_flags(offline_evals=True):
             result = await _resolve_model_override_metadata(
-                metadata, AsyncMock(), "[Test]"
+                metadata, _component(dmp=AsyncMock()), "[Test]"
             )
 
         assert result is None
@@ -104,7 +130,7 @@ class TestModelOverrideAliasResolution:
 
         with mock_flags(offline_evals=True):
             result = await _resolve_model_override_metadata(
-                metadata, AsyncMock(), "[Test]"
+                metadata, _component(dmp=AsyncMock()), "[Test]"
             )
 
         assert result is None
@@ -116,7 +142,7 @@ class TestModelOverrideAliasResolution:
 
         with mock_flags(offline_evals=True):
             result = await _resolve_model_override_metadata(
-                metadata, AsyncMock(), "[Test]"
+                metadata, _component(dmp=AsyncMock()), "[Test]"
             )
 
         assert result is None
@@ -128,7 +154,7 @@ class TestModelOverrideAliasResolution:
 
         with mock_flags(offline_evals=True):
             result = await _resolve_model_override_metadata(
-                metadata, AsyncMock(), "[Test]"
+                metadata, _component(dmp=AsyncMock()), "[Test]"
             )
 
         assert result is None
@@ -140,11 +166,68 @@ class TestModelOverrideAliasResolution:
 
         with mock_flags(offline_evals=True):
             result = await _resolve_model_override_metadata(
-                metadata, AsyncMock(), "[Test]"
+                metadata, _component(dmp=AsyncMock()), "[Test]"
             )
 
         assert result is None
         assert "model_override" not in metadata
+
+
+class TestLazyOverrideProviderInit:
+    """Lazy-init path: components without a model_provider configured can still
+    accept model_override by spinning up an override-only DynamicModelProvider
+    on demand. Without this, the orchestrator agent (which has model: but no
+    model_provider:) would reject every eval task with "model config not
+    available".
+    """
+
+    @pytest.mark.asyncio
+    async def test_lazy_init_when_provider_missing(self, monkeypatch):
+        from solace_agent_mesh.agent.protocol import event_handlers
+
+        litellm = MagicMock()
+        component = _component(dmp=None, litellm=litellm)
+
+        provider = AsyncMock()
+        provider.resolve.return_value = {"model": "openai/gpt-4o"}
+
+        # Patch the inline import target inside _ensure_override_provider so the
+        # constructor returns our pre-baked AsyncMock instead of creating a real
+        # provider (which would try to start an SAC flow).
+        provider_factory = MagicMock(return_value=provider)
+        import solace_agent_mesh.agent.adk.models.dynamic_model_provider as dmp_mod
+        monkeypatch.setattr(dmp_mod, "DynamicModelProvider", provider_factory)
+
+        metadata = {"model_override": {"model_id": "my-alias"}}
+
+        with mock_flags(offline_evals=True):
+            result = await event_handlers._resolve_model_override_metadata(
+                metadata, component, "[Test]"
+            )
+
+        assert result is None
+        # Constructed with skip_bootstrap=True so the agent's static litellm is
+        # never replaced via the auto-update flow.
+        assert provider_factory.called
+        assert provider_factory.call_args.kwargs.get("skip_bootstrap") is True
+        assert component._dynamic_model_provider is provider
+
+    @pytest.mark.asyncio
+    async def test_lazy_init_skipped_when_litellm_unavailable(self):
+        """Without a litellm instance there's nothing to back resolve(); the
+        request must be rejected with the same "not available" error rather
+        than constructing a dead provider."""
+        component = _component(dmp=None, litellm=None)
+        metadata = {"model_override": {"model_id": "my-alias"}}
+
+        with mock_flags(offline_evals=True):
+            result = await _resolve_model_override_metadata(
+                metadata, component, "[Test]"
+            )
+
+        assert isinstance(result, str)
+        assert "not available" in result
+        assert component._dynamic_model_provider is None
 
 
 class TestModelOverrideFeatureFlag:
@@ -156,7 +239,9 @@ class TestModelOverrideFeatureFlag:
         metadata = {"model_override": {"model_id": "my-alias"}}
 
         with mock_flags(offline_evals=False):
-            result = await _resolve_model_override_metadata(metadata, dmp, "[Test]")
+            result = await _resolve_model_override_metadata(
+                metadata, _component(dmp=dmp), "[Test]"
+            )
 
         assert result is None
         dmp.resolve.assert_not_awaited()
@@ -168,7 +253,7 @@ class TestModelOverrideFeatureFlag:
 
         with mock_flags(offline_evals=False):
             result = await _resolve_model_override_metadata(
-                metadata, AsyncMock(), "[Test]"
+                metadata, _component(dmp=AsyncMock()), "[Test]"
             )
 
         assert result is None
@@ -181,7 +266,9 @@ class TestModelOverrideFeatureFlag:
         metadata = {"model_override": {"model_id": "my-alias"}}
 
         with mock_flags(offline_evals=True):
-            result = await _resolve_model_override_metadata(metadata, dmp, "[Test]")
+            result = await _resolve_model_override_metadata(
+                metadata, _component(dmp=dmp), "[Test]"
+            )
 
         assert result is None
         dmp.resolve.assert_awaited_once_with("my-alias")


### PR DESCRIPTION
### What is the purpose of this change?

Per-request `model_override` (used by enterprise eval to swap an agent's
model on a per-task basis) was being rejected with `"model config not
available"` for any agent whose YAML doesn't declare a `model_provider`
field — including the bundled OrchestratorAgent in `custom_llm_agent_app`.
That broke eval runs against those agents end-to-end: every example
failed at the entry agent before the LLM was even called.

Concretely:
- `SamComponentBase.__init__` reads `model_provider` from the YAML; if
  absent, `self.model_provider = None`.
- `_async_setup_and_run` only starts the model listener when both
  `_lazy_model_mode` AND `model_provider` are truthy, so the orchestrator
  never starts one — `_dynamic_model_provider` stays `None`.
- `_resolve_model_override_metadata` then takes the `if not
  dynamic_model_provider` branch and returns `"model config not
  available"`, rejecting the task.

Forcing every existing and future agent's YAML/helm template to declare
`model_provider` is brittle ongoing maintenance, especially for built-in
mesh agents.

### How was this change implemented?

The override path now lazy-instantiates an override-only
`DynamicModelProvider` on the first per-request override, instead of
relying on a startup-time provider tied to a specific configured alias.

**`agent/adk/models/dynamic_model_provider.py`**
- New `skip_bootstrap` constructor flag. When `True`, `initialize()`
  wires up the broker subscription via `listen_for_model_config_change`
  and returns immediately — it does **not** call `request_model_config`.
- Skipping the bootstrap is what makes this safe: the wildcard
  subscription `configuration/model/response/*/{component_id}` already
  catches one-shot resolves for any alias/UUID via
  `complete_pending_resolve`, but never receives a topic that matches
  `self.model_provider.model_id`, so `update_litellm_model` /
  `remove_litellm_model` (the auto-update path) can never fire and
  clobber the agent's static `model:` config.

**`agent/protocol/event_handlers.py`**
- New `_ensure_override_provider(component)` helper: under an
  `asyncio.Lock` on the component, constructs a `DynamicModelProvider`
  with `skip_bootstrap=True` keyed on a sentinel `model_id`
  (`"__lazy_override_resolver__"`) that no real platform alias can match,
  awaits its `initialize()` so the subscription is live before returning,
  and stores it on `component._dynamic_model_provider`.
- `_resolve_model_override_metadata` now takes `component` instead of
  the bare provider; if no provider exists when an override comes in, it
  calls `_ensure_override_provider` and resolves through that. If the
  component has no litellm instance to back resolution, it falls back
  to the existing `"model config not available"` rejection rather than
  constructing a dead provider.

**`common/sac/sam_component_base.py`**
- Adds `_dynamic_model_provider_init_lock: Optional[asyncio.Lock] =
  None` so concurrent first-override requests don't race two providers
  into existence.

### Key Design Decisions

**Why a sentinel `model_id` instead of the override's own id?** The
receiver routes by `topic_model_id == self.model_provider.model_id` —
match → auto-update litellm; mismatch → complete a one-shot resolve
future. If we keyed the provider on the override's id, the platform's
bootstrap response (or any subsequent config-update broadcast for that
alias) would mutate the agent's static litellm permanently. A sentinel
guarantees the auto-update branch is unreachable while leaving one-shot
resolves fully functional.

**Why lazy-init rather than always-on at startup?** Always-on requires
either (a) every agent template declares `model_provider` — fragile and
easy to forget — or (b) starting a provider with no real alias for every
agent at boot, paying broker subscription cost even when overrides are
never used. Lazy-init pays only on demand and self-heals for new agents.

**Why `asyncio.Lock` rather than a thread lock?** The override path is
fully async; a thread lock would force `await` paths off the event loop
inside the critical section. `asyncio.Lock` keeps the await semantics
intact while still serialising init.

### How was this change tested?

- [x] Unit tests:
  - `tests/unit/agent/protocol/test_event_handlers_model_override.py` —
    existing 13 tests reworked to pass a mock component; 2 new tests
    cover `TestLazyOverrideProviderInit::test_lazy_init_when_provider_missing`
    (verifies `skip_bootstrap=True` and provider stored on component) and
    `test_lazy_init_skipped_when_litellm_unavailable` (rejection when
    component has no litellm).
  - `tests/unit/agent/adk/models/test_dynamic_model_provider.py` —
    fixture initializes `_skip_bootstrap=False`; new
    `test_initialize_skip_bootstrap_subscribes_only` confirms the listener
    is set up but `request_model_config` is never called.
- [x] Full unit suite: 5206 passed, 14 skipped, 6 xfailed (pre-existing).
- [ ] Manual end-to-end against test cluster — pending merge + community
  release + enterprise `manifest.json` bump.

### Is there anything the reviewers should focus on/be aware of?

- The lazy-init runs on the request thread the first time an override
  arrives. The SAC flow setup (queue creation + subscription) typically
  takes ~200 ms; subsequent overrides reuse the same provider. Worth a
  look from anyone who knows the SAC flow startup cost on the production
  brokers — if that latency is problematic, an alternative is to lazy-init
  earlier (e.g. on first chat request), but that wasn't necessary for the
  bug at hand.
- The enterprise eval broker currently sends the model **UUID** rather
  than its alias (`eval_run_service.py:312` prefers `modelConfigId`).
  Platform's `ModelConfigurationRepository.get_by_alias_or_id` accepts
  both, so this works — but it's a latent coupling worth noting if either
  side ever tightens its input handling.
- Sentinel string `"__lazy_override_resolver__"` is unlikely to collide
  with a real model alias, but if you'd prefer a UUID-shaped sentinel for
  belt-and-braces I can switch it.