### PR TITLE
fix(DATAGO-134667): strip max_input_tokens from per-request override

### DIFF
--- a/src/solace_agent_mesh/agent/adk/models/lite_llm.py
+++ b/src/solace_agent_mesh/agent/adk/models/lite_llm.py
@@ -979,7 +979,7 @@ Functions:
 -----------------------------------------------------------
 """
 
-_NON_COMPLETION_KEYS = frozenset({"cache_strategy", "thinking", "type"})
+_NON_COMPLETION_KEYS = frozenset({"cache_strategy", "thinking", "type", "max_input_tokens"})
 """Config keys used during initialization but not valid as litellm.completion() kwargs."""
 
 VALID_CACHE_STRATEGIES = ["none", "5m", "1h"]

--- a/tests/unit/agent/adk/models/test_lite_llm_sanitize.py
+++ b/tests/unit/agent/adk/models/test_lite_llm_sanitize.py
@@ -20,12 +20,14 @@ class TestSanitizeForCompletion:
             "cache_strategy": "5m",
             "thinking": {"budget_tokens": 10000},
             "type": "custom",
+            "max_input_tokens": 200000,
         }
         result = LiteLlm._sanitize_for_completion(config)
 
         assert "cache_strategy" not in result
         assert "thinking" not in result
         assert "type" not in result
+        assert "max_input_tokens" not in result
 
         assert result["model"] == "openai/gpt-4o"
         assert result["api_key"] == "sk-test"
@@ -106,6 +108,7 @@ class TestOverrideSanitization:
                 "type": "custom",
                 "oauth_client_id": "id",
                 "oauth_audience": "https://api.example.com",
+                "max_input_tokens": 200000,
             }
 
             llm = LiteLlm(model="openai/gpt-4o")
@@ -138,6 +141,7 @@ class TestOverrideSanitization:
             assert "type" not in completion_args
             assert "oauth_client_id" not in completion_args
             assert "oauth_audience" not in completion_args
+            assert "max_input_tokens" not in completion_args
 
             assert completion_args["model"] == "openai/gpt-4o-override"
             assert completion_args["api_key"] == "sk-override"


### PR DESCRIPTION
### What is the purpose of this change?

When the SAM evaluations engine submits a task with a `model_override`, the orchestrator resolves the alias against the model_configurations table and feeds the resulting config through `LiteLlm.generate_content_async`'s override path. If the resolved row had a configured context window (`max_input_tokens`), that key leaked into the `litellm.completion()` call and Vertex AI rejected every request with:

> `Extra inputs are not permitted` (model field `max_input_tokens`)

Symptom in `test-sam-enterprise`: the orchestrator only failed in eval runs (chat path doesn't use model_override), and only against models that had `max_input_tokens` set on their DB row (e.g. `vertex-claude-4-sonnet`). The error surfaced to the user as the generic "The LLM service rejected the request..." message after LiteLLM exhausted its 3 retries.

### How was this change implemented?

`src/solace_agent_mesh/agent/adk/models/lite_llm.py`
- Added `"max_input_tokens"` to the `_NON_COMPLETION_KEYS` frozenset used by `_sanitize_for_completion`.

The constructor path already pops `max_input_tokens` explicitly in `configure_model` (it's stored on `self._max_input_tokens` and is not a litellm.completion kwarg), so the frozenset addition is harmless redundancy there. The override path in `generate_content_async` was the only caller that ran a resolved config through `_sanitize_for_completion` without first extracting `max_input_tokens`, which is what caused the leak.

`tests/unit/agent/adk/models/test_lite_llm_sanitize.py`
- Extended `TestSanitizeForCompletion::test_removes_non_completion_keys` to include `max_input_tokens` in the input config and assert it's removed.
- Extended `TestOverrideSanitization::test_override_keys_stripped_before_acompletion` (the end-to-end override test) to put `max_input_tokens` in the mocked override config and assert it is not present in the final `acompletion` kwargs.

### Key Design Decisions

Adding `max_input_tokens` to the shared `_NON_COMPLETION_KEYS` frozenset rather than duplicating the explicit `pop()` in the override path. The frozenset is the single source of truth for "config keys that look like completion kwargs but aren't", and `_sanitize_for_completion` is already invoked on every config that flows to `litellm.completion()`. Future non-completion keys should be added there, not handled per-call-site.

A predecessor fix added `max_input_tokens` to a separate sanitize set in the LLM Judge eval scorer, which fixed the scorer path but didn't cover the orchestrator runtime path that uses `lite_llm.py`'s frozenset. This change closes that second path.

### How was this change tested?

- [x] Unit tests: extended `test_lite_llm_sanitize.py` to cover `max_input_tokens` in both the direct sanitize test and the end-to-end override test. All 6 tests pass.
- [ ] Manual testing: not yet run end-to-end against `test-sam-enterprise`. The diagnosis was confirmed via Datadog — the "Resolved model override alias ..." log line in `event_handlers.py` fires at the same timestamps as the `BadRequestError`, and every failing trace references `Received Model Group=vertex-claude-4-sonnet` (the only model in that env with `max_input_tokens` set).
- [ ] Integration tests: existing override integration coverage is unchanged; no new integration test added since the unit test exercises the full override path through `generate_content_async`.

### Is there anything the reviewers should focus on/be aware of?

- Confirm the choice of fixing this at `_NON_COMPLETION_KEYS` rather than at the override-path call site. The trade-off: this also strips `max_input_tokens` from any per-request override before it reaches `litellm.completion()`, but `max_input_tokens` is not a valid completion kwarg, and applying an override-time context window would also need to update `self._max_input_tokens` (currently only set in `configure_model`). That's out of scope here — this PR only stops the leak.
- The Vertex AI rejection cascades through three LiteLLM retries (~90s) before the orchestrator gives up, so the original error surface was a generic "LLM service rejected the request" rather than the underlying validation message.

Generated by Claude Code