### PR TITLE
feat(DATAGO-134667): promote offline_evals to beta and default true

### DIFF
--- a/src/solace_agent_mesh/common/features/features.yaml
+++ b/src/solace_agent_mesh/common/features/features.yaml
@@ -137,8 +137,8 @@ features:
 
   - key: offline_evals
     name: Offline Enterprise Evaluations
-    release_phase: experimental
-    default: false
+    release_phase: beta
+    default: true
     jira: DATAGO-104642
     description: >
       Enable the offline enterprise evaluation framework. Allows running


### PR DESCRIPTION
### What is the purpose of this change?

Promotes the `offline_evals` feature flag from `experimental` to `beta` and flips its default from `false` to `true` ahead of shipping the offline evaluations MVP. The feature is now broadly available for users, with follow-up work continuing under the same flag until it can be retired.

### How was this change implemented?

Single edit to `src/solace_agent_mesh/common/features/features.yaml`:

- `release_phase: experimental` → `release_phase: beta`
- `default: false` → `default: true`

The flag continues to gate `model_override` resolution in `src/solace_agent_mesh/agent/protocol/event_handlers.py` (line ~1162); the gating behavior itself is unchanged — only the baseline state is flipped.

### Key Design Decisions

- **`beta` over `early_access`**: per the SAM Feature Flags Guide, `beta` is "broadly available; complete but may have open issues" — the right fit for an MVP that is shipping to all users with follow-up work planned. `early_access` would imply a closed group of testers, which is no longer the case.
- **Default flip rather than env-var override**: making the change in `features.yaml` ensures every deployment (community, enterprise, Solace Chat) picks up the new baseline without each environment needing a `SAM_FEATURE_OFFLINE_EVALS=true` override. Operators can still flip it off per-environment if needed.

### How was this change tested?

- [x] Unit tests: `tests/unit/agent/protocol/test_event_handlers_model_override.py` (15 passed locally). These tests explicitly set the flag via `mock_flags(offline_evals=True/False)` for every case, so they remain stable across the default change.
- [ ] Manual testing: not required — YAML-only change with no behavioral logic shift beyond the flag's default.
- [ ] Integration tests: existing integration coverage continues to apply unchanged.
- [ ] Known limitations: deployments that previously relied on the `experimental`/`false` baseline (e.g. environments that did not set `SAM_FEATURE_OFFLINE_EVALS`) will now have the feature on by default. Operators wanting it off must set `SAM_FEATURE_OFFLINE_EVALS=false`.

### Is there anything the reviewers should focus on/be aware of?

- **Merge order**: a companion PR in `solace-agent-mesh-enterprise` removes a duplicate `offline_evals` definition from the enterprise `features.yaml`. **This community PR must merge first** — once enterprise drops its duplicate, enterprise inherits whatever community declares. If enterprise lands first, it would temporarily revert to community's old `experimental`/`false`.
- Verify the phase choice (`beta`) is still appropriate at review time given any updates to MVP shipping plans.

---

_Generated by Claude Code._
