### PR TITLE
chore(DATAGO-135298) :- doc - Support to Skip TLS verification for MCP tools/connectors

### DIFF
--- a/docs/docs/documentation/developing/tutorials/mcp-integration.md
+++ b/docs/docs/documentation/developing/tutorials/mcp-integration.md
@@ -278,6 +278,20 @@ tools:
 The `ssl_config` option only applies to remote connections (`sse` and `streamable-http`). It has no effect on `stdio` connections which run as local processes.
 :::
 
+#### Disable SSL Verification Globally
+
+You can also disable SSL verification globally for all remote MCP connections by setting the `SAM_MCP_CONNECTOR_TLS_VERIFY` environment variable to `false`. This applies to every `sse` and `streamable-http` MCP connection in the agent and overrides the per-connection `ssl_config.verify` setting.
+
+```sh
+export SAM_MCP_CONNECTOR_TLS_VERIFY=false
+```
+
+When the variable is unset, empty, or set to any value other than `false`, SSL verification remains enabled. The check is case-insensitive, so `false`, `False`, and `FALSE` all disable verification.
+
+:::warning[Security Risk]
+Use `SAM_MCP_CONNECTOR_TLS_VERIFY=false` only in development environments with self-signed certificates. Never disable SSL verification in production. For production deployments that need to trust a private CA, set the `REQUESTS_CA_BUNDLE` and `SSL_CERT_FILE` environment variables to point to your CA certificate bundle instead. For more information, see [Proxy Configuration](../../deploying/proxy_configuration.md).
+:::
+
 ## Running Your MCP-Enabled Agent
 
 1. **Create the working directory** (for filesystem example):

--- a/docs/docs/documentation/developing/tutorials/mcp-integration.md
+++ b/docs/docs/documentation/developing/tutorials/mcp-integration.md
@@ -278,18 +278,18 @@ tools:
 The `ssl_config` option only applies to remote connections (`sse` and `streamable-http`). It has no effect on `stdio` connections which run as local processes.
 :::
 
-#### Disable SSL Verification Globally
+#### Disable TLS Verification Globally
 
-You can also disable SSL verification globally for all remote MCP connections by setting the `SAM_MCP_CONNECTOR_TLS_VERIFY` environment variable to `false`. This applies to every `sse` and `streamable-http` MCP connection in the agent and overrides the per-connection `ssl_config.verify` setting.
+You can also disable TLS verification globally for all remote MCP connections by setting the `SAM_MCP_CONNECTOR_TLS_VERIFY` environment variable to `false`. This applies to every `sse` and `streamable-http` MCP connection in the agent and overrides the per-connection `ssl_config.verify` setting.
 
 ```sh
 export SAM_MCP_CONNECTOR_TLS_VERIFY=false
 ```
 
-When the variable is unset, empty, or set to any value other than `false`, SSL verification remains enabled. The check is case-insensitive, so `false`, `False`, and `FALSE` all disable verification.
+When the variable is unset, empty, or set to any value other than `false`, TLS verification remains enabled. The check is case-insensitive, so `false`, `False`, and `FALSE` all disable verification.
 
 :::warning[Security Risk]
-Use `SAM_MCP_CONNECTOR_TLS_VERIFY=false` only in development environments with self-signed certificates. Never disable SSL verification in production. For production deployments that need to trust a private CA, set the `REQUESTS_CA_BUNDLE` and `SSL_CERT_FILE` environment variables to point to your CA certificate bundle instead. For more information, see [Proxy Configuration](../../deploying/proxy_configuration.md).
+Use `SAM_MCP_CONNECTOR_TLS_VERIFY=false` only in development environments with self-signed certificates. Never disable TLS verification in production. For production deployments that need to trust a private CA, set the `REQUESTS_CA_BUNDLE` and `SSL_CERT_FILE` environment variables to point to your CA certificate bundle instead. For more information, see [Proxy Configuration](../../deploying/proxy_configuration.md).
 :::
 
 ## Running Your MCP-Enabled Agent

--- a/docs/docs/documentation/developing/tutorials/mcp-integration.md
+++ b/docs/docs/documentation/developing/tutorials/mcp-integration.md
@@ -247,7 +247,7 @@ For remote MCP connections (SSE and Streamable HTTP), you can configure SSL/TLS 
 #### Disable SSL Verification (Development Only)
 
 :::warning[Security Risk]
-Disabling SSL verification should only be used in development environments. Never disable SSL verification in production.
+Disabling TLS verification should only be used in development environments. Never disable TLS verification in production.
 :::
 
 ```yaml


### PR DESCRIPTION
### What is the purpose of this change?

  Docs for TLS disable on mcp connectors

