### PR TITLE
fix: log errors in silent exception handlers (5 catch blocks across 4 files)

### DIFF
--- a/evaluation/summary_builder.py
+++ b/evaluation/summary_builder.py
@@ -211,6 +211,7 @@ class TestCaseService:
         try:
             return load_test_case(test_case_id)
         except Exception:
+            log.warning("Failed to load test case '%s'", test_case_id, exc_info=True)
             return None
 
     @staticmethod

--- a/src/solace_agent_mesh/gateway/http_sse/routers/sessions.py
+++ b/src/solace_agent_mesh/gateway/http_sse/routers/sessions.py
@@ -1305,6 +1305,7 @@ def _get_model_context_limit(
             info = get_model_info(name)
             return info.get("max_input_tokens")
         except Exception:
+            log.warning("Failed to lookup model info for '%s'", name, exc_info=True)
             return None
 
     result = _try_lookup(model_name)

--- a/src/solace_agent_mesh/gateway/http_sse/routers/share.py
+++ b/src/solace_agent_mesh/gateway/http_sse/routers/share.py
@@ -67,6 +67,7 @@ def get_optional_user_id(request: Request) -> Optional[str]:
             return request.state.user.get('id')
         return None
     except Exception:
+        log.warning("Failed to get user ID from request", exc_info=True)
         return None
 
 
@@ -83,6 +84,7 @@ def get_optional_user_email(request: Request) -> Optional[str]:
             return request.state.user.get('email')
         return None
     except Exception:
+        log.warning("Failed to get user email from request", exc_info=True)
         return None
 
 

--- a/src/solace_agent_mesh/gateway/http_sse/services/task_logger_service.py
+++ b/src/solace_agent_mesh/gateway/http_sse/services/task_logger_service.py
@@ -339,6 +339,7 @@ class TaskLoggerService:
                 if message:
                     return a2a.get_text_from_message(message)
         except Exception:
+            log.warning("Failed to extract message text from A2A event", exc_info=True)
             return None
         return None
 


### PR DESCRIPTION
## Problem

5 `except Exception` blocks across 4 files silently swallow errors with zero diagnostic output. When these fail, operators have no way to know what went wrong:

| File | Location | What fails silently |
|------|----------|---------------------|
| `summary_builder.py` | `load_test_case` | Test case loading fails |
| `sessions.py` | `_try_lookup` | Model info lookup fails |
| `share.py` | `get_optional_user_id` | User ID extraction fails |
| `share.py` | `get_optional_user_email` | User email extraction fails |
| `task_logger_service.py` | `_get_request_text` | A2A event text extraction fails |

## Fix

Each catch now logs at `log.warning()` with `exc_info=True`, using the existing `log = logging.getLogger(__name__)` pattern already established in each file.

## Changes

- 4 files changed, 5 lines added
- No behavioral changes — all functions still return `None` on failure as before
