### PR TITLE
docs(DATAGO-131495): fix broken links and leftover conflict marker in…

### DIFF
--- a/docs/docs/documentation/enterprise/offline-evaluations.md
+++ b/docs/docs/documentation/enterprise/offline-evaluations.md
@@ -35,9 +35,9 @@ Use offline evaluations when you want to measure and track agent quality over ti
 
 Before using this feature, verify that you have:
 
-- Agent Mesh Enterprise installed and running. For installation instructions, see [Installing Agent Mesh Enterprise](installation.md).
+- Agent Mesh Enterprise installed and running. For installation instructions, see [Installing Agent Mesh Enterprise](quickstart-kubernetes.md).
 - At least one agent deployed and reachable through the event broker.
-- The Platform Service running with a database configured. SQLite works for development; use PostgreSQL for production. For database configuration guidance, see [Installing Agent Mesh Enterprise](installation.md).
+- The Platform Service running with a database configured. SQLite works for development; use PostgreSQL for production. For database configuration guidance, see [Installing Agent Mesh Enterprise](quickstart-kubernetes.md).
 - Object storage configured if you want to persist execution data and artifact snapshots beyond the local filesystem. See [Storage Configuration](#storage-configuration) below.
 
 ## Storage Configuration
@@ -346,6 +346,6 @@ An active (`pending` or `running`) run is blocking deletion. Cancel all active r
 ## Related Topics
 
 - [Evaluating Agents](../developing/evaluations.md) — CLI-based evaluation workflow for Community and Enterprise deployments.
-- [Installing Agent Mesh Enterprise](installation.md) — Installation and database configuration.
+- [Installing Agent Mesh Enterprise](quickstart-kubernetes.md) — Installation and database configuration.
 - [Setting Up RBAC](rbac-setup-guide.md) — Configure the `sam:evaluations:read`, `sam:evaluations:write`, and `sam:evaluations:execute` permission scopes to control who can access the Evaluations UI.
 - [Model Configurations](../installing-and-configuring/model_configurations.md) — Create and manage the model configurations you assign to experiments and LLM-as-a-judge evaluators.


### PR DESCRIPTION
This pull request updates documentation to reference the correct installation guide for Agent Mesh Enterprise, ensuring users are directed to the `quickstart-kubernetes.md` guide instead of the outdated `installation.md`. This change improves clarity and accuracy for installation and configuration instructions.

Documentation updates:

* Updated references in the prerequisites and related topics sections of `offline-evaluations.md` to point to `quickstart-kubernetes.md` for installation and database configuration guidance, replacing the previous `installation.md` links. [[1]](diffhunk://#diff-bca4deeb81986cdb1cdb4add13a40cd77608c5566d05d79abc3c6ad61347ae0aL38-R40) [[2]](diffhunk://#diff-bca4deeb81986cdb1cdb4add13a40cd77608c5566d05d79abc3c6ad61347ae0aL349-R349)