### PR TITLE
docs(DATAGO-135351): updating error and log reference

### DIFF
--- a/docs/docs/documentation/enterprise/production-kubernetes.md
+++ b/docs/docs/documentation/enterprise/production-kubernetes.md
@@ -1069,7 +1069,7 @@ Configure external PostgreSQL database and object storage. For production, set `
 |-----|------|---------|-------------|
 | `samDoctor.enabled` | bool | `true` | Enable sam-doctor pre-flight validation |
 | `samDoctor.failOnError` | bool | `true` | Block install/upgrade on validation failure |
-| `samDoctor.timeoutSeconds` | int | `120` | Hook job timeout in seconds |
+| `samDoctor.timeoutSeconds` | int | `180` | Hook job timeout in seconds |
 | `samDoctor.tlsDnsName` | string | `""` | DNS name for TLS certificate validation. Defaults to `sam.dnsName` if not set. |
 
 ### Bundled Components - Persistence Layer

--- a/docs/docs/documentation/enterprise/quickstart-kubernetes.md
+++ b/docs/docs/documentation/enterprise/quickstart-kubernetes.md
@@ -86,7 +86,7 @@ helm install sam /path/to/charts/solace-agent-mesh-<version>.tgz \
 
 The chart defaults are optimized for quickstart evaluation. No values file is needed beyond the credentials. After installation completes, the terminal displays post-install instructions including the port-forward command and the URL to access the Console UI.
 
-Note: By default, Helm pre-install checks are run. If they fail, you will see an `INSTALLATION FAILED` error. See [Helm pre-install check failed](#helm-pre-install-check-failed) for how to view the logs.
+Note: By default, Helm pre-install checks are run. If they fail, you should see an installation error. See [Helm pre-install check failed](#helm-pre-install-check-failed) for how to view the logs.
 
 **What gets deployed** (chart defaults):
 

--- a/docs/docs/partials/helm-pre-install-check.mdx
+++ b/docs/docs/partials/helm-pre-install-check.mdx
@@ -2,13 +2,13 @@ When `samDoctor.enabled=true` (the default), Agent Mesh runs a pre-install hook 
 
 ```
 Error: INSTALLATION FAILED: failed pre-install: 1 error occurred:
-    * job <release>-sam-doctor failed: ...
+    * job <release>-<chart-name>-sam-doctor failed: ...
 ```
 
 To see the diagnostic report, view the job's logs (the job name appears in the helm error above):
 
 ```bash
-kubectl logs job/<release>-sam-doctor -n <namespace>
+kubectl logs job/<release>-<chart-name>-sam-doctor -n <namespace>
 ```
 
 The report lists each check with a `PASS`, `WARN`, `FAIL`, or `SKIP` status and a reason for any failure.

--- a/docs/docs/partials/helm-pre-install-check.mdx
+++ b/docs/docs/partials/helm-pre-install-check.mdx
@@ -1,11 +1,14 @@
-When `samDoctor.enabled=true` (the default), Agent Mesh runs a pre-install hook Job before any workload pods are created. By default, a failing check blocks `helm install` and `helm upgrade`. To see the diagnostic report:
+When `samDoctor.enabled=true` (the default), Agent Mesh runs a pre-install hook Job before any workload pods are created. By default, a failing check blocks `helm install` and `helm upgrade` with an error like:
+
+```
+Error: INSTALLATION FAILED: failed pre-install: 1 error occurred:
+    * job <release>-sam-doctor failed: ...
+```
+
+To see the diagnostic report, view the job's logs (the job name appears in the helm error above):
 
 ```bash
-# Find the hook job (name includes your Helm release name):
-kubectl get jobs -n <namespace> | grep sam-doctor
-
-# View the diagnostic report using the actual job name:
-kubectl logs job/<job-name> -n <namespace>
+kubectl logs job/<release>-sam-doctor -n <namespace>
 ```
 
 The report lists each check with a `PASS`, `WARN`, `FAIL`, or `SKIP` status and a reason for any failure.


### PR DESCRIPTION
### What is the purpose of this change?

Updating error and log reference to be more accurate.

### How was this change implemented?

This pull request updates documentation to clarify the behavior of Helm pre-install checks and improves instructions for troubleshooting installation failures. It also adjusts a configuration default for the pre-install validation job. The most important changes are:

**Documentation improvements for Helm pre-install checks:**

* Clarified that Helm pre-install failures will result in an installation error, and updated instructions on how to view logs for troubleshooting. [[1]](diffhunk://#diff-b1c286280279767e6634dd8bf67704854a448e4ea191f6c1f3ef9811234ceb8bL89-R89) [[2]](diffhunk://#diff-f2f09a2065cb061d48b81c429d7d50045256de55a1e083f92da55764c72f55aeL1-R11)
* Improved the example error message and provided more direct instructions for retrieving the diagnostic report from the pre-install hook job logs.

**Configuration default update:**

* Increased the default `samDoctor.timeoutSeconds` from 120 to 180 seconds in the configuration documentation to allow more time for pre-install validation jobs.

### How was this change tested?

- [x] Manual testing: [describe scenarios]
- [ ] Unit tests: [new/modified tests]
- [ ] Integration tests: [if applicable]
- [ ] Known limitations: [what wasn't tested]

### Is there anything the reviewers should focus on/be aware of?

<img width="1023" height="718" alt="image" src="https://github.com/user-attachments/assets/421cf1e2-b058-4717-be5c-e8b55f59b60c" />
