### PR TITLE
fix(DATAGO-135081): update libpng16 version to 1.6.48-1+deb13u5 in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -72,7 +72,7 @@ RUN echo "deb http://deb.debian.org/debian unstable main" > /etc/apt/sources.lis
     git \
     libc6=2.41-12+deb13u2 \
     libtasn1-6/unstable \
-    libpng16-16t64=1.6.48-1+deb13u4 \
+    libpng16-16t64=1.6.48-1+deb13u5 \
     libsqlite3-0=3.46.1-7+deb13u1 \
     libssl3t64=3.5.5-1~deb13u2 \
     libvpx9=1.15.0-2.1+deb13u1 \
@@ -169,7 +169,7 @@ RUN echo "deb http://deb.debian.org/debian unstable main" > /etc/apt/sources.lis
     libatomic1 \
     libc6=2.41-12+deb13u2 \
     libtasn1-6/unstable \
-    libpng16-16t64=1.6.48-1+deb13u4 \
+    libpng16-16t64=1.6.48-1+deb13u5 \
     libsqlite3-0=3.46.1-7+deb13u1 \
     libssl3t64=3.5.5-1~deb13u2 \
     libvpx9=1.15.0-2.1+deb13u1 \


### PR DESCRIPTION
### What is the purpose of this change?

Bumps the pinned `libpng16` package to the latest patched version (`1.6.48-1+deb13u5`) to pick up a security or bug fix released in that revision, ensuring the Docker image is not running a vulnerable or outdated version of the library.

### How was this change implemented?

- fix(DATAGO-135081): update libpng16 version to 1.6.48-1+deb13u5 in Dockerfile

The version pin for `libpng16-16t64` was updated from `1.6.48-1+deb13u4` to `1.6.48-1+deb13u5` in both Dockerfile build stages (the base/builder stage and the final runtime stage).

### Key Design Decisions _(optional - delete if not applicable)_

Both stages that install `libpng16` must be kept in sync to ensure the builder and runtime environments use the same patched version, avoiding inconsistencies between build and production behaviour.

### How was this change tested?

- [ ] Manual testing: Docker image built and verified that the correct `libpng16` version is installed
- [ ] Unit tests: No code logic changes; not applicable
- [ ] Integration tests: Not applicable
- [ ] Known limitations: No functional testing of libpng behaviour beyond confirming the correct package version is present

### Is there anything the reviewers should focus on/be aware of?

Confirm that `1.6.48-1+deb13u5` is available in the Debian repository and that both Dockerfile stages have been updated consistently. No application code is affected.