### PR TITLE
refactor(DATAGO-134095): migrate newNavigation flag to features.yaml

### DIFF
--- a/client/webui/frontend/src/AppLayout.tsx
+++ b/client/webui/frontend/src/AppLayout.tsx
@@ -9,7 +9,7 @@ import { ModelWarningBanner } from "@/lib/components/models/ModelWarningBanner";
 import { SettingsDialog } from "@/lib/components/settings/SettingsDialog";
 import { ChatProvider } from "@/lib/providers";
 import { useBooleanFlagDetails } from "@openfeature/react-sdk";
-import { useAuthContext, useBeforeUnload, useConfigContext, useChatContext, useNavigationItems, useLocalStorage, useMoveSession } from "@/lib/hooks";
+import { useAuthContext, useBeforeUnload, useConfigContext, useChatContext, useNavigationItems, useLocalStorage, useMoveSession, useIsNewNavigationEnabled } from "@/lib/hooks";
 import { useNotificationSSE } from "@/lib/hooks/useNotificationSSE";
 import { useModelConfigStatus } from "@/lib/api/models";
 
@@ -70,7 +70,7 @@ function AppLayoutContent() {
     }, []);
 
     const topNavItems = getTopNavigationItems(configFeatureEnablement);
-    const useNewNav = configFeatureEnablement?.newNavigation ?? false;
+    const useNewNav = useIsNewNavigationEnabled();
     const projectsEnabled = configFeatureEnablement?.projects ?? false;
     const logoutEnabled = configFeatureEnablement?.logout ?? false;
 

--- a/client/webui/frontend/src/lib/components/pages/ChatPage.tsx
+++ b/client/webui/frontend/src/lib/components/pages/ChatPage.tsx
@@ -6,7 +6,7 @@ import { PanelLeftIcon, Loader2, GitFork } from "lucide-react";
 import type { ImperativePanelHandle } from "react-resizable-panels";
 
 import { Header } from "@/lib/components/header";
-import { useChatContext, useConfigContext, useIsAutoTitleGenerationEnabled, useTaskContext, useTitleAnimation, useIsChatSharingEnabled, useTurnDividerAnimation } from "@/lib/hooks";
+import { useChatContext, useIsAutoTitleGenerationEnabled, useIsNewNavigationEnabled, useTaskContext, useTitleAnimation, useIsChatSharingEnabled, useTurnDividerAnimation } from "@/lib/hooks";
 import { SLIDE_OUT_DURATION_MS, FADE_OUT_DURATION_MS } from "@/lib/hooks/useTurnDividerAnimation";
 import { useProjectContext } from "@/lib/providers";
 import type { CollaborativeUser } from "@/lib/types/collaboration";
@@ -47,8 +47,7 @@ export function ChatPage() {
     const queryClient = useQueryClient();
     const { activeProject } = useProjectContext();
     const autoTitleGenerationEnabled = useIsAutoTitleGenerationEnabled();
-    const { configFeatureEnablement } = useConfigContext();
-    const useNewNav = configFeatureEnablement?.newNavigation ?? false;
+    const useNewNav = useIsNewNavigationEnabled();
     const chatSharingEnabled = useIsChatSharingEnabled();
     const location = useLocation();
     const navigate = useNavigate();

--- a/client/webui/frontend/src/lib/components/pages/RecentChatsPage.tsx
+++ b/client/webui/frontend/src/lib/components/pages/RecentChatsPage.tsx
@@ -6,7 +6,7 @@ import { useQueryClient } from "@tanstack/react-query";
 
 import { useInfiniteSessions, useMarkSessionViewed, useRenameSessionWithAI, sessionKeys } from "@/lib/api/sessions";
 import { useSharedWithMe } from "@/lib/api/share";
-import { useChatContext, useConfigContext, useIsAutoTitleGenerationEnabled, useTitleGeneration, useTitleAnimation, useIsChatSharingEnabled } from "@/lib/hooks";
+import { useChatContext, useConfigContext, useIsAutoTitleGenerationEnabled, useIsNewNavigationEnabled, useTitleGeneration, useTitleAnimation, useIsChatSharingEnabled } from "@/lib/hooks";
 import type { Session } from "@/lib/types";
 import { formatRelativeTime, formatTimestamp, hasUnseenUpdates } from "@/lib/utils";
 import { ProjectBadge, SessionSearch, SessionActionMenu, ChatSessionDeleteDialog, sessionCardStyles, sessionTitleStyles } from "@/lib/components/chat";
@@ -97,6 +97,7 @@ export const RecentChatsPage: React.FC = () => {
     const { persistenceEnabled, configFeatureEnablement } = useConfigContext();
     const { generateTitle } = useTitleGeneration();
     const chatSharingEnabled = useIsChatSharingEnabled();
+    const newNavigationEnabled = useIsNewNavigationEnabled();
     const inputRef = useRef<HTMLInputElement>(null);
     const [isShareDialogOpen, setIsShareDialogOpen] = useState(false);
     const [sessionToShare, setSessionToShare] = useState<Session | null>(null);
@@ -322,8 +323,8 @@ export const RecentChatsPage: React.FC = () => {
         return sessionWithProject?.projectId || null;
     }, [selectedProject, sessions]);
 
-    // Feature flag gate: redirect to /chat if newNavigation is not enabled
-    if (!configFeatureEnablement?.newNavigation) {
+    // Feature flag gate: redirect to /chat if new_navigation is not enabled
+    if (!newNavigationEnabled) {
         return <Navigate to="/chat" replace />;
     }
 

--- a/client/webui/frontend/src/lib/components/pages/SharedChatViewPage.tsx
+++ b/client/webui/frontend/src/lib/components/pages/SharedChatViewPage.tsx
@@ -19,13 +19,12 @@ import { ChatMessage, SessionSidePanel } from "@/lib/components/chat";
 import { SharedChatProvider } from "@/lib/providers/SharedChatProvider";
 import { SharedSidePanel } from "@/lib/components/share/SharedSidePanel";
 import { useSharedSession, formatDateYMD } from "@/lib/hooks/useSharedSession";
-import { useConfigContext } from "@/lib/hooks";
+import { useIsNewNavigationEnabled } from "@/lib/hooks";
 export function SharedChatViewPage() {
     const shared = useSharedSession();
     const location = useLocation();
     const navigate = useNavigate();
-    const { configFeatureEnablement } = useConfigContext();
-    const useNewNav = configFeatureEnablement?.newNavigation ?? false;
+    const useNewNav = useIsNewNavigationEnabled();
     const [isSessionSidePanelCollapsed, setIsSessionSidePanelCollapsed] = useState(true);
 
     // Open sessions panel if navigated with state

--- a/client/webui/frontend/src/lib/hooks/index.ts
+++ b/client/webui/frontend/src/lib/hooks/index.ts
@@ -39,6 +39,7 @@ export * from "./useIsAutoTitleGenerationEnabled";
 export * from "./useIsProjectSharingEnabled";
 export * from "./useIsProjectIndexingEnabled";
 export * from "./useIsMentionsEnabled";
+export * from "./useIsNewNavigationEnabled";
 export * from "./useSSEContext";
 export * from "./useIndexingSSE";
 export * from "./useNavigationItems";

--- a/client/webui/frontend/src/lib/hooks/useIsNewNavigationEnabled.ts
+++ b/client/webui/frontend/src/lib/hooks/useIsNewNavigationEnabled.ts
@@ -1,0 +1,5 @@
+import { useBooleanFlagValue } from "@openfeature/react-sdk";
+
+export function useIsNewNavigationEnabled(): boolean {
+    return useBooleanFlagValue("new_navigation", false);
+}

--- a/client/webui/frontend/src/stories/chat/RecentChatsPage.stories.tsx
+++ b/client/webui/frontend/src/stories/chat/RecentChatsPage.stories.tsx
@@ -25,7 +25,7 @@ const meta = {
         layout: "fullscreen",
         msw: { handlers },
         configContext: {
-            configFeatureEnablement: { newNavigation: true },
+            configFeatureEnablement: { new_navigation: true },
             persistenceEnabled: true,
         },
         chatContext: { sessionId: "session-1" },

--- a/client/webui/frontend/src/stories/chat/RecentChatsPage.test.tsx
+++ b/client/webui/frontend/src/stories/chat/RecentChatsPage.test.tsx
@@ -62,9 +62,10 @@ async function loadPage() {
             }),
             useConfigContext: () => ({
                 persistenceEnabled: true,
-                configFeatureEnablement: { newNavigation: newNav, scheduler: schedulerEnabled, chatSharing },
+                configFeatureEnablement: { scheduler: schedulerEnabled, chatSharing },
             }),
             useIsAutoTitleGenerationEnabled: () => false,
+            useIsNewNavigationEnabled: () => newNav,
             useTitleGeneration: () => ({ generateTitle: vi.fn() }),
             useTitleAnimation: (name: string) => ({ text: name, isAnimating: false, isGenerating: false }),
             useIsChatSharingEnabled: () => chatSharing,

--- a/client/webui/frontend/src/stories/chat/SharedChatViewPage.test.tsx
+++ b/client/webui/frontend/src/stories/chat/SharedChatViewPage.test.tsx
@@ -37,7 +37,7 @@ async function loadPage() {
     }));
 
     vi.doMock("@/lib/hooks", () => ({
-        useConfigContext: () => ({ configFeatureEnablement: { newNavigation: newNavigationFlag } }),
+        useIsNewNavigationEnabled: () => newNavigationFlag,
     }));
 
     const mod = await import("@/lib/components/pages/SharedChatViewPage");

--- a/src/solace_agent_mesh/common/features/features.yaml
+++ b/src/solace_agent_mesh/common/features/features.yaml
@@ -145,3 +145,12 @@ features:
       evaluations against deployed SAM agents with per-request model
       overrides. When disabled, model override metadata is ignored and
       the resolver is not initialized.
+
+  - key: new_navigation
+    name: New Navigation
+    release_phase: experimental
+    default: false
+    jira: DATAGO-133974
+    description: >
+      Enable the new navigation experience in the frontend, including
+      the collapsible navigation sidebar.


### PR DESCRIPTION
### What is the purpose of this change?

Move the `newNavigation` feature flag off the legacy `configFeatureEnablement` config-passthrough path and onto the OpenFeature `features.yaml` registry, matching the pattern already used by `mentions`, `auto_title_generation`, and the enterprise repo's `new_navigation` flag. After this change, the flag is toggleable via `SAM_FEATURE_NEW_NAVIGATION` and surfaced through `/api/v1/config/features` like every other modern SAM flag.

### How was this change implemented?

- **Backend registry** — `src/solace_agent_mesh/common/features/features.yaml` gains a `new_navigation` entry (snake_case, `experimental`, `default: false`, DATAGO-133974) so it merges into the OpenFeature registry at startup. Enterprise's existing `new_navigation` definition continues to win the merge (same default), so behaviour there is unchanged.
- **Frontend wrapper hook** — new `useIsNewNavigationEnabled()` in `client/webui/frontend/src/lib/hooks/`, calling `useBooleanFlagValue("new_navigation", false)`. Re-exported from the hooks barrel.
- **Consumers swapped** — `AppLayout.tsx`, `ChatPage.tsx`, `SharedChatViewPage.tsx`, and `RecentChatsPage.tsx` replace `configFeatureEnablement?.newNavigation ?? false` with the hook. Dropped the now-unused `useConfigContext` destructure/import where `newNavigation` was its only use.
- **Stories/tests** — `SharedChatViewPage.test.tsx` and `RecentChatsPage.test.tsx` mock `useIsNewNavigationEnabled` directly. `RecentChatsPage.stories.tsx` keeps using the `StoryProvider`'s `configFeatureEnablement` -> `OpenFeatureTestProvider` pipe but with the new snake_case key (`new_navigation`).

### Key Design Decisions _(optional - delete if not applicable)_

- Added the flag to **community** features.yaml even though enterprise already defines it. Community now reads the flag too, and the merge order (community first, enterprise overrides) means the enterprise definition still wins for enterprise deployments. A follow-up can remove the enterprise duplicate.
- Default kept `false` (experimental) to match the enterprise definition — no behavioural change.
- Did not touch `templates/webui.yaml` or `preset/agents/basic/webui.yaml` — neither tracked template referenced `newNavigation`.

### How was this change tested?

- [x] Manual testing: ran `tsc --noEmit` on the frontend — no new type errors. Verified grep that no `configFeatureEnablement?.newNavigation` reads remain in `client/webui/frontend/src/`.
- [x] Unit tests: existing `RecentChatsPage.test.tsx` and `SharedChatViewPage.test.tsx` updated to mock the new hook; suite still asserts both flag-on and flag-off behaviour.
- [ ] Integration tests: not run locally; CI should cover.
- [ ] Known limitations: did not perform a live runtime check against `/api/v1/config/features` or the cluster — reviewer should sanity-check on test once deployed.

### Is there anything the reviewers should focus on/be aware of?

- Toggling the flag on the `sam-enterprise-test` cluster going forward should use `SAM_FEATURE_NEW_NAVIGATION=true` (env var) instead of the previous `frontend_feature_enablement.newNavigation: true` ConfigMap patch. The ConfigMap path is no longer wired up.
- `RecentChatsPage` still keeps `useConfigContext` because it reads `scheduler` and `persistenceEnabled` — only the `newNavigation` read was migrated.
- StoryProvider behaviour relied on: it forwards `configFeatureEnablement` directly into `OpenFeatureTestProvider`'s `flagValueMap`, so stories that want the new nav on must now use the snake_case key.