### PR TITLE
docs(DATAGO-132135): create new "Get Started" section with quickstart entry points

### DIFF
--- a/docs/docs/documentation/developing/create-agents.md
+++ b/docs/docs/documentation/developing/create-agents.md
@@ -474,7 +474,7 @@ sam plugin build
 
 This command packages your agent code, configuration, and dependencies into a distributable wheel file. The wheel file is a standard Python package format that can be installed into any Python environment.
 
-Check into [your Agent Mesh project directory](../overview/try-agent-mesh.md), and add the plugin wheel with a given name:
+Check into [your Agent Mesh project directory](../get-started/docker-playground.md), and add the plugin wheel with a given name:
 
 ```bash
 sam plugin add my-first-weather-agent --plugin PATH/TO/weather-agent/dist/weather-agent.whl

--- a/docs/docs/documentation/get-started/_category_.json
+++ b/docs/docs/documentation/get-started/_category_.json
@@ -1,0 +1,6 @@
+{
+  "position": 105,
+  "label": "Get Started",
+  "collapsible": true,
+  "collapsed": false
+}

--- a/docs/docs/documentation/get-started/before-you-begin.md
+++ b/docs/docs/documentation/get-started/before-you-begin.md
@@ -1,0 +1,8 @@
+---
+title: Before You Begin
+sidebar_position: 1
+---
+
+# Before You Begin
+
+This page is a stub. It will cover the universal prerequisites for installing Solace Agent Mesh, including Solace event broker provisioning, LLM API keys, and Python version requirements.

--- a/docs/docs/documentation/get-started/docker-playground.md
+++ b/docs/docs/documentation/get-started/docker-playground.md
@@ -1,9 +1,9 @@
 ---
-title: Try Agent Mesh
-sidebar_position: 22
+title: Docker Playground
+sidebar_position: 2
 ---
 
-# Try Agent Mesh
+# Docker Playground
 
 Get started quickly with Agent Mesh using our pre-configured Docker image. This approach lets you explore the capabilities of Agent Mesh without setting up a complete project.
 

--- a/docs/docs/documentation/get-started/quick-start-with-pip-uv.md
+++ b/docs/docs/documentation/get-started/quick-start-with-pip-uv.md
@@ -1,0 +1,8 @@
+---
+title: Quick Start with pip / uv
+sidebar_position: 3
+---
+
+# Quick Start with pip / uv
+
+This page is a stub. It will cover a fast path to install and run Solace Agent Mesh locally using `pip` or `uv`.

--- a/docs/docs/documentation/installing-and-configuring/installation.md
+++ b/docs/docs/documentation/installing-and-configuring/installation.md
@@ -124,7 +124,7 @@ This command pulls the latest image (if not already present) and executes `solac
 
 If your host OS architecture is not `linux/amd64`, you need to add `--platform linux/amd64` when running the container.
 
-For more complex operations like building a project, you need to mount your project directory into the container. See the [Quick Start guide](../overview/try-agent-mesh.md) for examples.
+For more complex operations like building a project, you need to mount your project directory into the container. See the [Docker Playground](../get-started/docker-playground.md) for examples.
 :::
 
 :::warning Browser Requirement
@@ -163,7 +163,7 @@ solace-agent-mesh --help
 
 After successful installation, choose your next step based on your goals:
 
-**For Quick Exploration**: If you want to try SAM's capabilities immediately without project setup, use the [Docker quick start](../overview/try-agent-mesh.md) to explore SAM with minimal configuration.
+**For Quick Exploration**: If you want to try SAM's capabilities immediately without project setup, use the [Docker Playground](../get-started/docker-playground.md) to explore SAM with minimal configuration.
 
 **For Development Work**: If you're ready to build a complete project with full control over configuration, proceed directly to the [project setup guide](run-project.md).
 

--- a/docs/docs/documentation/overview/introduction.md
+++ b/docs/docs/documentation/overview/introduction.md
@@ -63,5 +63,5 @@ Whether you're building a proof-of-concept or planning a production deployment, 
 
 - [Getting Started](./overview.md): For an overview of Agent Mesh and what you can find in this documentation.
 - [Installation](../installing-and-configuring/installation.md): For installing and setting up Agent Mesh.
-- [Quick Start](./try-agent-mesh.md): For creating a project, building, and running Agent Mesh.
+- [Docker Playground](../get-started/docker-playground.md): For trying Agent Mesh quickly using a pre-configured Docker image.
 - [Component Overview](../components/components.md): Understanding the parts of Agent Mesh.

--- a/docs/docs/documentation/overview/overview.md
+++ b/docs/docs/documentation/overview/overview.md
@@ -23,7 +23,7 @@ To see how all the pieces fit together, you can explore the key building blocks 
 
 ## Getting Started Quickly
 
-The fastest way to experience Agent Mesh is through our pre-configured Docker setup that gets you up and running with a working system in minutes. This approach lets you explore the framework's capabilities immediately without any installation or complex configuration. To get started right away, see [Try Agent Mesh](./try-agent-mesh.md)
+The fastest way to experience Agent Mesh is through our pre-configured Docker setup that gets you up and running with a working system in minutes. This approach lets you explore the framework's capabilities immediately without any installation or complex configuration. To get started right away, see [Docker Playground](../get-started/docker-playground.md)
 
 Once you've explored the basic functionality and want to set up your own development environment, you'll need to install the CLI and framework tools. The installation process supports multiple approaches including pip, uv, and Docker, making it easy to integrate with your existing workflow. For complete setup instructions, see [Installation](../installing-and-configuring/installation.md)
 


### PR DESCRIPTION
### What is the purpose of this change?

This change aims to improve the onboarding process for new developers by introducing a "Getting Started" section with a Docker Playground. It also adds two new stub pages.

### How was this change implemented?

Reorganizing the documentation by creating a new "Get Started" section. Key files and components that were modified include:
- Addition of `before-you-begin.md` and `quick-start-with-pip-uv.md` stub pages.
- Renaming of `try-agent-mesh.md` to `docker-playground.md`.
- Updates to various documentation links to reflect these changes.

### How was this change tested?

- [x] Manual testing: Verified completeness and accessibility of new documentation sections and links.

### Is there anything the reviewers should focus on/be aware of?

- Any stub pages will be filled out in later tickets.
- The Overview section directs to the overview document when the section title is clicked, but there is no such document currently for the get-started section.