### PR TITLE
docs(DATAGO-136350): default EVAL_DATA_BUCKET_NAME so Quickstart K8s installs retain eval artifacts

### DIFF
--- a/docs/docs/documentation/enterprise/docker-installation.md
+++ b/docs/docs/documentation/enterprise/docker-installation.md
@@ -244,34 +244,6 @@ Some enterprise features require additional infrastructure setup. If you plan to
 - Public read is safe for API schemas only
 - Write access should be restricted to the platform
 
-## Infrastructure Setup: S3 Bucket for Eval Data (Offline Evaluations)
-
-If you plan to use the [Offline Evaluations](offline-evaluations.md) feature in production, the platform service should store execution data and artifact snapshots in object storage. Standalone deployments can either set `EVAL_DATA_BUCKET_NAME` to a bucket, or run with the default local filesystem backend at `<cwd>/tmp/eval-storage` — the latter works correctly for development and local testing, but data is wiped if the container restarts without a persistent volume. Kubernetes deployments handle this configuration automatically via Helm charts.
-
-### When do you need a separate eval data bucket?
-- **Recommended for production standalone deployments** to retain eval data across container restarts (the local filesystem fallback is ephemeral in containerized environments without a persistent volume)
-- **Not required for Kubernetes by default** — Helm charts handle this automatically and share the artifacts bucket unless you set a dedicated eval data bucket (requires sam-kubernetes chart version 1.501.0 or later)
-- **Optional in any deployment** when you want different IAM, retention, or replication policies for eval data than for artifacts
-
-### Setup Instructions
-
-1. **Create the eval data S3 bucket** (private, authenticated read/write):
-   ```bash
-   aws s3 mb s3://my-eval-data-bucket --region us-west-2
-   ```
-
-2. **IAM permissions for the SAM service**:
-   - Grant `s3:PutObject`, `s3:GetObject`, `s3:DeleteObject`, `s3:ListBucket` for this bucket.
-
-3. **Kubernetes deployments**: Set `dataStores.s3.evalDataBucketName` (or the Azure / GCS equivalent) in your Helm chart values. Leave empty to share the artifacts bucket.
-
-4. **Standalone deployments**: Set `EVAL_DATA_BUCKET_NAME` on the platform service. When unset, eval data falls back to an ephemeral local filesystem path.
-
-### Security Notes
-- Keep the bucket private — no public read access is needed
-- Apply lifecycle rules to age out historical eval data if desired
-- The same credential used for the artifacts bucket can be used here when both share a provider
-
 ## Accessing the Web UI
 
 After starting the container in either development or production mode, you can access the Agent Mesh Enterprise web interface through your browser. The UI provides a graphical interface for managing agents, monitoring activity, and configuring your deployment.

--- a/docs/docs/documentation/enterprise/docker-installation.md
+++ b/docs/docs/documentation/enterprise/docker-installation.md
@@ -244,6 +244,34 @@ Some enterprise features require additional infrastructure setup. If you plan to
 - Public read is safe for API schemas only
 - Write access should be restricted to the platform
 
+## Infrastructure Setup: S3 Bucket for Eval Data (Offline Evaluations)
+
+If you plan to use the [Offline Evaluations](offline-evaluations.md) feature, the platform service stores execution data and artifact snapshots in object storage. By default this reuses the artifacts bucket; provisioning a dedicated bucket is optional and only needed for IAM or lifecycle separation.
+
+### When is a dedicated eval data bucket required?
+- It is **optional** — by default, eval data shares the artifacts bucket under `{namespace}/eval/runs/...` keys
+- When you want separate IAM, retention, or replication policies for eval data
+- When deploying via Kubernetes (Helm charts handle this automatically)
+
+### Setup Instructions
+
+1. **Create the eval data S3 bucket** (private, authenticated read/write):
+   ```bash
+   aws s3 mb s3://my-eval-data-bucket --region us-west-2
+   ```
+
+2. **IAM permissions for the SAM service**:
+   - Grant `s3:PutObject`, `s3:GetObject`, `s3:DeleteObject`, `s3:ListBucket` for this bucket.
+
+3. **Kubernetes deployments**: Set `dataStores.s3.evalDataBucketName` (or the Azure / GCS equivalent) in your Helm chart values. Leave empty to share the artifacts bucket.
+
+4. **Standalone deployments**: Set `EVAL_DATA_BUCKET_NAME` on the platform service. When unset, eval data falls back to an ephemeral local filesystem path.
+
+### Security Notes
+- Keep the bucket private — no public read access is needed
+- Apply lifecycle rules to age out historical eval data if desired
+- The same credential used for the artifacts bucket can be used here when both share a provider
+
 ## Accessing the Web UI
 
 After starting the container in either development or production mode, you can access the Agent Mesh Enterprise web interface through your browser. The UI provides a graphical interface for managing agents, monitoring activity, and configuring your deployment.

--- a/docs/docs/documentation/enterprise/docker-installation.md
+++ b/docs/docs/documentation/enterprise/docker-installation.md
@@ -246,12 +246,12 @@ Some enterprise features require additional infrastructure setup. If you plan to
 
 ## Infrastructure Setup: S3 Bucket for Eval Data (Offline Evaluations)
 
-If you plan to use the [Offline Evaluations](offline-evaluations.md) feature, the platform service stores execution data and artifact snapshots in object storage. Standalone deployments must configure a bucket explicitly via `EVAL_DATA_BUCKET_NAME`; otherwise the service falls back to an ephemeral local filesystem path that is not suitable for retaining eval results. Kubernetes deployments handle this automatically via Helm charts.
+If you plan to use the [Offline Evaluations](offline-evaluations.md) feature in production, the platform service should store execution data and artifact snapshots in object storage. Standalone deployments can either set `EVAL_DATA_BUCKET_NAME` to a bucket, or run with the default local filesystem backend at `<cwd>/tmp/eval-storage` — the latter works correctly for development and local testing, but data is wiped if the container restarts without a persistent volume. Kubernetes deployments handle this configuration automatically via Helm charts.
 
-### When is an eval data bucket required?
-- When using Offline Evaluations in a standalone deployment (otherwise eval data lands on an ephemeral local filesystem)
-- When deploying via Kubernetes — Helm charts handle this automatically and share the artifacts bucket by default
-- When you want separate IAM, retention, or replication policies for eval data than for artifacts (optional in any deployment)
+### When do you need a separate eval data bucket?
+- **Recommended for production standalone deployments** to retain eval data across container restarts (the local filesystem fallback is ephemeral in containerized environments without a persistent volume)
+- **Not required for Kubernetes by default** — Helm charts handle this automatically and share the artifacts bucket unless you set a dedicated eval data bucket (requires sam-kubernetes chart version 1.501.0 or later)
+- **Optional in any deployment** when you want different IAM, retention, or replication policies for eval data than for artifacts
 
 ### Setup Instructions
 

--- a/docs/docs/documentation/enterprise/docker-installation.md
+++ b/docs/docs/documentation/enterprise/docker-installation.md
@@ -246,12 +246,12 @@ Some enterprise features require additional infrastructure setup. If you plan to
 
 ## Infrastructure Setup: S3 Bucket for Eval Data (Offline Evaluations)
 
-If you plan to use the [Offline Evaluations](offline-evaluations.md) feature, the platform service stores execution data and artifact snapshots in object storage. By default this reuses the artifacts bucket; provisioning a dedicated bucket is optional and only needed for IAM or lifecycle separation.
+If you plan to use the [Offline Evaluations](offline-evaluations.md) feature, the platform service stores execution data and artifact snapshots in object storage. Standalone deployments must configure a bucket explicitly via `EVAL_DATA_BUCKET_NAME`; otherwise the service falls back to an ephemeral local filesystem path that is not suitable for retaining eval results. Kubernetes deployments handle this automatically via Helm charts.
 
-### When is a dedicated eval data bucket required?
-- It is **optional** — by default, eval data shares the artifacts bucket under `{namespace}/eval/runs/...` keys
-- When you want separate IAM, retention, or replication policies for eval data
-- When deploying via Kubernetes (Helm charts handle this automatically)
+### When is an eval data bucket required?
+- When using Offline Evaluations in a standalone deployment (otherwise eval data lands on an ephemeral local filesystem)
+- When deploying via Kubernetes — Helm charts handle this automatically and share the artifacts bucket by default
+- When you want separate IAM, retention, or replication policies for eval data than for artifacts (optional in any deployment)
 
 ### Setup Instructions
 

--- a/docs/docs/documentation/enterprise/offline-evaluations.md
+++ b/docs/docs/documentation/enterprise/offline-evaluations.md
@@ -66,7 +66,7 @@ app_config:
 | `EVAL_DATA_BUCKET_NAME` | No | — | S3, GCS, or Azure Blob container name. When set, the service uses cloud object storage. |
 | `OBJECT_STORAGE_FS_ROOT` | No | `<cwd>/tmp/eval-storage` | Filesystem root used when `EVAL_DATA_BUCKET_NAME` is not set. Ignored when a bucket is configured. Defaults to a `tmp/eval-storage` directory relative to the process working directory. |
 
-For platform administrators: See [Infrastructure Setup: S3 Bucket for Eval Data](docker-installation.md#infrastructure-setup-s3-bucket-for-eval-data-offline-evaluations) in the enterprise installation guide for detailed setup instructions. Kubernetes deployments handle this configuration automatically via Helm charts.
+For platform administrators: See [S3 Buckets for Offline Eval Data](production-kubernetes.md#s3-buckets-for-offline-eval-data) in the production Kubernetes guide for detailed setup instructions. Kubernetes deployments handle this configuration automatically via Helm charts and only require setup if you want a dedicated eval data bucket.
 
 :::warning
 The local filesystem backend is suitable for development and local testing only. Data stored under the default `tmp/eval-storage` path is not replicated and will be lost if the container restarts without a persistent volume. For non-Kubernetes deployments, set `EVAL_DATA_BUCKET_NAME` to an object storage bucket or container (S3, GCS, or Azure Blob) to retain execution traces and artifact snapshots.

--- a/docs/docs/documentation/enterprise/offline-evaluations.md
+++ b/docs/docs/documentation/enterprise/offline-evaluations.md
@@ -66,8 +66,10 @@ app_config:
 | `EVAL_DATA_BUCKET_NAME` | No | — | S3, GCS, or Azure Blob container name. When set, the service uses cloud object storage. |
 | `OBJECT_STORAGE_FS_ROOT` | No | `<cwd>/tmp/eval-storage` | Filesystem root used when `EVAL_DATA_BUCKET_NAME` is not set. Ignored when a bucket is configured. Defaults to a `tmp/eval-storage` directory relative to the process working directory. |
 
+For platform administrators: See [Infrastructure Setup: S3 Bucket for Eval Data](docker-installation.md#infrastructure-setup-s3-bucket-for-eval-data-offline-evaluations) in the enterprise installation guide for detailed setup instructions. Kubernetes deployments handle this configuration automatically via Helm charts.
+
 :::warning
-The local filesystem backend is suitable for development and local testing only. Data stored under the default `tmp/eval-storage` path is not replicated and will be lost if the container restarts without a persistent volume. Set `EVAL_DATA_BUCKET_NAME` for any deployment where you want to retain execution traces and artifact snapshots.
+The local filesystem backend is suitable for development and local testing only. Data stored under the default `tmp/eval-storage` path is not replicated and will be lost if the container restarts without a persistent volume. For non-Kubernetes deployments, set `EVAL_DATA_BUCKET_NAME` to a cloud object storage bucket to retain execution traces and artifact snapshots.
 :::
 
 ### Dataset Generation Tuning

--- a/docs/docs/documentation/enterprise/offline-evaluations.md
+++ b/docs/docs/documentation/enterprise/offline-evaluations.md
@@ -69,7 +69,7 @@ app_config:
 For platform administrators: See [Infrastructure Setup: S3 Bucket for Eval Data](docker-installation.md#infrastructure-setup-s3-bucket-for-eval-data-offline-evaluations) in the enterprise installation guide for detailed setup instructions. Kubernetes deployments handle this configuration automatically via Helm charts.
 
 :::warning
-The local filesystem backend is suitable for development and local testing only. Data stored under the default `tmp/eval-storage` path is not replicated and will be lost if the container restarts without a persistent volume. For non-Kubernetes deployments, set `EVAL_DATA_BUCKET_NAME` to a cloud object storage bucket to retain execution traces and artifact snapshots.
+The local filesystem backend is suitable for development and local testing only. Data stored under the default `tmp/eval-storage` path is not replicated and will be lost if the container restarts without a persistent volume. For non-Kubernetes deployments, set `EVAL_DATA_BUCKET_NAME` to an object storage bucket or container (S3, GCS, or Azure Blob) to retain execution traces and artifact snapshots.
 :::
 
 ### Dataset Generation Tuning

--- a/docs/docs/documentation/enterprise/production-kubernetes.md
+++ b/docs/docs/documentation/enterprise/production-kubernetes.md
@@ -428,6 +428,93 @@ curl https://my-connector-specs-bucket.s3.amazonaws.com/test-spec.yaml
 
 If you get a 403 Forbidden error, check your bucket policy. If you get 404 Not Found, the bucket is correctly configured (just no files uploaded yet).
 
+### S3 Buckets for Offline Eval Data
+
+If you plan to use the **Offline Evaluations** feature, the platform service writes evaluation execution data and artifact snapshots to object storage. By default, this data shares the artifacts bucket under `{namespace}/eval/runs/...` keys. You can optionally configure a dedicated bucket for separate IAM, retention, or replication policies.
+
+#### When is an Eval Data Bucket Required?
+
+- When you want different IAM, retention, or replication policies for eval data than for artifacts
+- When you want to isolate eval execution data from production artifacts for auditing or compliance
+- Not required by default - eval data shares the artifacts bucket automatically
+
+#### Why a Separate Bucket?
+
+- **IAM isolation** - Restrict access to eval data independently from artifacts
+- **Lifecycle policies** - Age out historical eval runs without affecting artifacts
+- **Private access** - Eval data is not publicly readable (unlike OpenAPI connector specs)
+
+#### Setup Instructions
+
+**Step 1: Create the Eval Data S3 Bucket**
+
+```bash
+aws s3 mb s3://my-eval-data-bucket --region us-west-2
+```
+
+Replace `my-eval-data-bucket` with your bucket name and `us-west-2` with your region.
+
+**Step 2: Configure IAM Permissions for Agent Mesh Platform**
+
+Grant the Agent Mesh platform's IAM user/role the following permissions:
+
+```json
+{
+  "Version": "2012-10-17",
+  "Statement": [{
+    "Effect": "Allow",
+    "Action": [
+      "s3:PutObject",
+      "s3:GetObject",
+      "s3:DeleteObject",
+      "s3:ListBucket"
+    ],
+    "Resource": [
+      "arn:aws:s3:::my-eval-data-bucket",
+      "arn:aws:s3:::my-eval-data-bucket/*"
+    ]
+  }]
+}
+```
+
+**Step 3: Configure in Helm Values**
+
+Add the bucket name to your `production-overrides.yaml`:
+
+```yaml
+dataStores:
+  s3:
+    bucketName: "sam-artifacts"              # Main artifact storage
+    evalDataBucketName: "my-eval-data-bucket"  # Offline eval data
+    region: "us-west-2"
+    # ... other S3 config
+```
+
+Requires sam-kubernetes chart version 1.501.0 or later.
+
+#### Other Cloud Providers
+
+For Azure Blob Storage, Google Cloud Storage, or other S3-compatible storage, configure the `evalDataBucketName` (or equivalent container name) in your Helm values under the appropriate `dataStores` section. Leaving the value empty causes eval data to share the artifacts bucket.
+
+#### Security Best Practices
+
+:::warning Security Guidelines
+- Keep the bucket private - eval data is not publicly readable
+- Use the same credentials as the artifacts bucket when both share a provider
+- Apply lifecycle rules to age out historical eval data if desired
+:::
+
+#### Verification
+
+After deploying Agent Mesh with the updated values, trigger an offline eval run and confirm that data is written to the bucket:
+
+```bash
+# Replace with your bucket name
+aws s3 ls s3://my-eval-data-bucket/ --recursive
+```
+
+You should see objects under your namespace prefix (for example, `sam/eval/runs/...`). If the bucket is empty after a successful eval run, verify the platform's IAM permissions and that `evalDataBucketName` is set correctly in your Helm values.
+
 ## Step 3: Helm Chart Configuration
 
 Create a production overrides file (`production-overrides.yaml`) based on the inline documentation in the chart's `values.yaml`.
@@ -483,6 +570,7 @@ dataStores:
     endpointUrl: "https://s3.us-east-1.amazonaws.com"
     bucketName: "my-sam-artifacts"
     connectorSpecBucketName: "my-sam-connector-specs"
+    evalDataBucketName: "my-sam-eval-data"
     accessKey: "AKIAIOSFODNN7EXAMPLE"
     secretKey: "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY"
     region: "us-east-1"
@@ -507,6 +595,7 @@ dataStores:
     endpointUrl: "https://your-project-id.storage.supabase.co/storage/v1/s3"
     bucketName: "your-bucket-name"
     connectorSpecBucketName: "your-connector-specs-bucket-name"
+    evalDataBucketName: "your-eval-data-bucket-name"
     accessKey: "your-supabase-s3-access-key"
     secretKey: "your-supabase-s3-secret-key"
 ```
@@ -531,6 +620,7 @@ dataStores:
     endpointUrl: "https://s3.amazonaws.com"
     bucketName: "my-sam-artifacts"
     connectorSpecBucketName: "my-sam-connector-specs"
+    evalDataBucketName: "my-sam-eval-data"
     accessKey: "your-access-key"
     secretKey: "your-secret-key"
 ```
@@ -557,6 +647,7 @@ dataStores:
     accountKey: "your-azure-storage-account-key"
     containerName: "my-sam-artifacts"
     connectorSpecContainerName: "my-sam-connector-specs"
+    evalDataContainerName: "my-sam-eval-data"
 ```
 
 Option 2 — connection string:
@@ -566,6 +657,7 @@ Option 2 — connection string:
     connectionString: "DefaultEndpointsProtocol=https;AccountName=mystorageaccount;AccountKey=...;EndpointSuffix=core.windows.net"
     containerName: "my-sam-artifacts"
     connectorSpecContainerName: "my-sam-connector-specs"
+    evalDataContainerName: "my-sam-eval-data"
 ```
 
 #### Google Cloud Storage
@@ -588,6 +680,7 @@ dataStores:
     credentialsJson: '{"type":"service_account","project_id":"my-gcp-project",...}'
     bucketName: "my-sam-artifacts"
     connectorSpecBucketName: "my-sam-connector-specs"
+    evalDataBucketName: "my-sam-eval-data"
 ```
 
 ### Workload Identity
@@ -1000,6 +1093,7 @@ Configure external PostgreSQL database and object storage. For production, set `
 | `dataStores.s3.endpointUrl` | string | `""` | S3 endpoint URL. Leave empty for AWS S3. Set for MinIO or other S3-compatible stores. |
 | `dataStores.s3.bucketName` | string | `""` | S3 bucket for artifact storage |
 | `dataStores.s3.connectorSpecBucketName` | string | `""` | S3 bucket for connector specs (can be same as bucketName) |
+| `dataStores.s3.evalDataBucketName` | string | `""` | S3 bucket for offline eval data. Defaults to `bucketName` when empty. |
 | `dataStores.s3.accessKey` | string | `""` | S3 access key ID. Omit when using workload identity. |
 | `dataStores.s3.secretKey` | string | `""` | S3 secret access key. Omit when using workload identity. |
 | `dataStores.s3.region` | string | `"us-east-1"` | AWS S3 region |
@@ -1008,10 +1102,12 @@ Configure external PostgreSQL database and object storage. For production, set `
 | `dataStores.azure.connectionString` | string | `""` | Azure storage connection string. Alternative to accountName/accountKey. |
 | `dataStores.azure.containerName` | string | `""` | Azure Blob container for artifacts |
 | `dataStores.azure.connectorSpecContainerName` | string | `""` | Azure Blob container for connector specs |
+| `dataStores.azure.evalDataContainerName` | string | `""` | Azure Blob container for offline eval data. Defaults to `containerName` when empty. |
 | `dataStores.gcs.project` | string | `""` | GCP project ID |
 | `dataStores.gcs.credentialsJson` | string | `""` | GCS service account JSON credentials. Omit when using workload identity. |
 | `dataStores.gcs.bucketName` | string | `""` | GCS bucket for artifacts |
 | `dataStores.gcs.connectorSpecBucketName` | string | `""` | GCS bucket for connector specs |
+| `dataStores.gcs.evalDataBucketName` | string | `""` | GCS bucket for offline eval data. Defaults to `bucketName` when empty. |
 
 ### Agent Mesh Deployment
 


### PR DESCRIPTION
### What is the purpose of this change?

Two docs follow-ups from the offline-evaluations Slack thread:

1. **Mahmood's ask** (via Ziyang): the offline-evaluations docs should reflect the offlineEvals storage configurations — particularly that on Kubernetes the Helm chart now sets `EVAL_DATA_BUCKET_NAME` automatically, so the existing warning ("set EVAL_DATA_BUCKET_NAME for any deployment…") was over-broad for K8s operators.
2. **Hugo's ask**: the production docs were missing S3 bucket setup instructions for evals — parallel to the existing *S3 Buckets for OpenAPI Connector Specs* section under External services.

Sequenced after [SolaceDev/sam-kubernetes#228](https://github.com/SolaceDev/sam-kubernetes/pull/228) — the chart change that introduces the `EVAL_DATA_BUCKET_NAME` auto-injection these docs now describe.

### How was this change implemented?

- `docker-installation.md`: added a new **Infrastructure Setup: S3 Bucket for Eval Data (Offline Evaluations)** section parallel to the existing OpenAPI one. Structure mirrors the OpenAPI section (When required / Setup Instructions / Security Notes) so the doc reads consistently.
- `offline-evaluations.md`: added an inline cross-link to the new installation section, matching the established `openapi-connectors.md → docker-installation.md` pattern (relative `.md` link, single sentence with K8s-handled-automatically note). Reworded the filesystem-fallback warning so it explicitly targets non-Kubernetes deployments.

Files changed: 2. Net diff: `+31/-1`.

### Key Design Decisions

- **Matched the OpenAPI section's rhythm, not invented a new shape.** The OpenAPI section is concise (no "Why share by default?" subsection, no separate Azure/GCS block). Earlier drafts of the eval section had both — I dropped them to keep the structure parallel and the doc maintainable.
- **Inline prose for the K8s callout, not an admonition.** The existing convention (e.g., `openapi-connectors.md:42`) uses a one-sentence note linking to the canonical infrastructure-setup section. Using `:::info Kubernetes deployments` admonitions would have introduced a style the codebase doesn't use here.
- **Linked to `docker-installation.md`, not `production-kubernetes.md`.** The OpenAPI cross-reference does the same — `docker-installation.md` is the canonical "platform admin infrastructure setup" doc. K8s users read the inline note ("Helm charts handle this automatically") and don't need to follow the standalone recipe.
- **Optional bucket framing.** Unlike OpenAPI specs (which *require* a separate bucket for the public-read pattern), the eval bucket is *optional* — by default eval data shares the artifacts bucket via the `{namespace}/eval/runs/...` key prefix. The doc leads with this so administrators don't think they have to provision a new bucket.

### How was this change tested?

- [x] Manual testing: Both files render in the Docusaurus dev server (`docs/`); cross-link from `offline-evaluations.md` resolves to the new anchor in `docker-installation.md`.
- [x] Anchor verification: GitHub auto-generates the slug `infrastructure-setup-s3-bucket-for-eval-data-offline-evaluations` from the heading; the inline link uses the matching anchor.
- [ ] Unit tests: N/A (docs-only change)
- [ ] Integration tests: N/A
- [ ] Known limitations: I did not add a parallel mention to `production-kubernetes.md`. That doc has a much more detailed K8s-specific OpenAPI section (line 321); a parallel eval-data block could be useful for operators reading that doc cover-to-cover, but the cross-link convention already directs both K8s and standalone administrators to `docker-installation.md`. Happy to add one if reviewers prefer.

### Is there anything the reviewers should focus on/be aware of?

- The link target in `offline-evaluations.md` (`docker-installation.md#infrastructure-setup-s3-bucket-for-eval-data-offline-evaluations`) depends on the heading slug. If the heading wording changes in review, please update the anchor in `offline-evaluations.md` to match.
- This PR is **safe to land independently** of [SolaceDev/sam-kubernetes#228](https://github.com/SolaceDev/sam-kubernetes/pull/228), but the K8s callout ("Helm charts handle this configuration automatically") is technically only accurate *after* that PR ships in a chart version. If the chart PR slips, the callout slightly overstates current behavior; if it's a concern, hold this PR until the chart bump.