### PR TITLE
fix(DATAGO-136560): - [prod] investigatge solace-chat slowness

### DIFF
--- a/.github/workflows/test-and-sonarqube.yml
+++ b/.github/workflows/test-and-sonarqube.yml
@@ -89,7 +89,6 @@ jobs:
       fail-fast: false
       matrix:
         python-version:
-          - ${{ inputs.min-python-version }}
           - ${{ inputs.max-python-version }}
     steps:
       - name: Checkout

--- a/.github/workflows/test-and-sonarqube.yml
+++ b/.github/workflows/test-and-sonarqube.yml
@@ -357,9 +357,6 @@ jobs:
       - name: SonarQube Scan
         uses: sonarsource/sonarqube-scan-action@fd88b7d7ccbaefd23d8f36f73b59db7a3d246602 # v6.0.0
         if: ${{ fromJSON(inputs.run_sonarqube_analysis) }}
-        with:
-          args: >
-            -Dsonar.scanner.javaOpts=-Xss16m -Xmx3g
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
           SONAR_HOST_URL: ${{ secrets.SONAR_HOST_URL }}

--- a/.github/workflows/test-and-sonarqube.yml
+++ b/.github/workflows/test-and-sonarqube.yml
@@ -357,10 +357,12 @@ jobs:
       - name: SonarQube Scan
         uses: sonarsource/sonarqube-scan-action@fd88b7d7ccbaefd23d8f36f73b59db7a3d246602 # v6.0.0
         if: ${{ fromJSON(inputs.run_sonarqube_analysis) }}
+        with:
+          args: >
+            -Dsonar.scanner.javaOpts=-Xss16m -Xmx3g
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
           SONAR_HOST_URL: ${{ secrets.SONAR_HOST_URL }}
-          SONAR_SCANNER_OPTS: "-Xss16m -Xmx3g"
 
       - name: SonarQube Quality Gate
         if: ${{ fromJSON(inputs.run_quality_gate) }}

--- a/.github/workflows/test-and-sonarqube.yml
+++ b/.github/workflows/test-and-sonarqube.yml
@@ -360,6 +360,7 @@ jobs:
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
           SONAR_HOST_URL: ${{ secrets.SONAR_HOST_URL }}
+          SONAR_SCANNER_OPTS: "-Xss16m -Xmx3g"
 
       - name: SonarQube Quality Gate
         if: ${{ fromJSON(inputs.run_quality_gate) }}

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,6 +1,8 @@
 # SonarQube Configuration for Solace Agent Mesh
 # This file configures SonarQube analysis for both Python backend and TypeScript/React UI
 
+sonar.scanner.javaOpts=-Xss16m -Xmx3g
+
 sonar.projectKey=SolaceLabs_solace-agent-mesh
 sonar.projectName=solace-agent-mesh
 

--- a/src/solace_agent_mesh/gateway/http_sse/dependencies.py
+++ b/src/solace_agent_mesh/gateway/http_sse/dependencies.py
@@ -479,12 +479,19 @@ def get_db(request: Request) -> Generator[Session, None, None]:
         
         # Check if this is a transient connection error
         if _is_connection_error(e):
+            # Attribute the error to its originating endpoint when possible.
+            # Wrapped defensively: any failure to read request attributes must
+            # not mask the underlying connection error.
+            try:
+                request_info = f"{request.method} {request.url.path}"
+            except Exception:
+                request_info = "unknown request"
+
             log.warning(
-                    "Database connection error during commit on %s %s "
-                    "(connection may have been closed by server): %s",
-                    request.method,
-                    request.url.path,
-                    str(e),
+                "Database connection error during commit on %s "
+                "(connection may have been closed by server): %s",
+                request_info,
+                str(e),
             )
             # Re-raise as a service unavailable error for transient connection issues
             raise HTTPException(

--- a/src/solace_agent_mesh/gateway/http_sse/dependencies.py
+++ b/src/solace_agent_mesh/gateway/http_sse/dependencies.py
@@ -15,7 +15,6 @@ from typing import TYPE_CHECKING, Any, Optional
 from fastapi import Depends, HTTPException, Request, status, Path, Query
 from sqlalchemy import create_engine
 from sqlalchemy.orm import Session, sessionmaker
-
 from ...common.agent_registry import AgentRegistry
 from ...common.middleware.config_resolver import ConfigResolver
 from ...common.services.identity_service import BaseIdentityService
@@ -100,10 +99,25 @@ def init_database(database_url: str):
                 # "idle in transaction" for more than 60 seconds to prevent deadlocks
                 # statement_timeout (120s): Prevent any single statement from running more than
                 # 2 minutes.
+                # TCP keepalives: let the OS detect dead/half-closed sockets within ~25s
+                # (idle=10s, then 3 probes 5s apart) instead of waiting on the kernel's
+                # default TCP retransmit timeout (30s-15min). Without this, when Postgres
+                # or the network silently closes a connection, pool_pre_ping's SELECT 1
+                # blocks on recv() until TCP gives up — freezing the worker's event loop
+                # for that entire wait. With keepalives, pre-ping fails fast and the pool
+                # invalidates the dead slot transparently.
                 engine_kwargs["connect_args"] = {
+                    "keepalives": 1,
+                    "keepalives_idle": 10,
+                    "keepalives_interval": 5,
+                    "keepalives_count": 3,
                     "options": "-c idle_in_transaction_session_timeout=60000 -c statement_timeout=120000"
                 }
-                log.info(f"Configuring {dialect_name} database with connection pooling and transaction timeouts (idle_in_transaction=60s, statement=120s)")
+                log.info(
+                        f"Configuring {dialect_name} database with connection pooling, "
+                        f"transaction timeouts (idle_in_transaction=60s, statement=120s), "
+                        f"and TCP keepalives (idle=10s, interval=5s, count=3)"
+                    )
             else:
                 log.info(f"Configuring {dialect_name} database with connection pooling")
 
@@ -446,7 +460,7 @@ def short_lived_session():
             pass
 
 
-def get_db() -> Generator[Session, None, None]:
+def get_db(request: Request) -> Generator[Session, None, None]:
     if SessionLocal is None:
         raise HTTPException(
             status_code=status.HTTP_501_NOT_IMPLEMENTED,
@@ -466,8 +480,11 @@ def get_db() -> Generator[Session, None, None]:
         # Check if this is a transient connection error
         if _is_connection_error(e):
             log.warning(
-                "Database connection error during commit (connection may have been closed by server): %s",
-                str(e)
+                    "Database connection error during commit on %s %s "
+                    "(connection may have been closed by server): %s",
+                    request.method,
+                    request.url.path,
+                    str(e),
             )
             # Re-raise as a service unavailable error for transient connection issues
             raise HTTPException(

--- a/tests/unit/gateway/http_sse/test_dependencies.py
+++ b/tests/unit/gateway/http_sse/test_dependencies.py
@@ -12,7 +12,7 @@ Tests cover:
 """
 
 import contextlib
-from unittest.mock import AsyncMock, Mock, patch
+from unittest.mock import AsyncMock, Mock, PropertyMock, patch
 
 import pytest
 from fastapi import HTTPException, Request
@@ -504,6 +504,63 @@ class TestDatabaseDependencies:
 
         mock_db_session.rollback.assert_called_once()
         mock_db_session.close.assert_called_once()
+
+    def test_get_db_connection_error_logs_request_info(
+        self, mock_db_session, mock_request, caplog
+    ):
+        """503 path logs the originating request's method and URL path."""
+
+        # Mimics SQLAlchemy disconnection: _is_connection_error() returns True
+        # when an exception exposes connection_invalidated=True.
+        class FakeDisconnect(Exception):
+            connection_invalidated = True
+
+        mock_db_session.commit.side_effect = FakeDisconnect("connection lost")
+        dependencies.SessionLocal = Mock(return_value=mock_db_session)
+
+        mock_request.method = "POST"
+        mock_request.url.path = "/api/v1/widgets"
+
+        with caplog.at_level("WARNING", logger="solace_agent_mesh.gateway.http_sse.dependencies"):
+            with pytest.raises(HTTPException) as exc_info:
+                gen = get_db(mock_request)
+                next(gen)
+                with contextlib.suppress(StopIteration):
+                    next(gen)
+
+        assert exc_info.value.status_code == 503
+        assert "POST /api/v1/widgets" in caplog.text
+        mock_db_session.rollback.assert_called_once()
+
+    def test_get_db_connection_error_falls_back_to_unknown_request(
+        self, mock_db_session, caplog
+    ):
+        """If reading request attributes raises, log falls back to 'unknown request'."""
+
+        class FakeDisconnect(Exception):
+            connection_invalidated = True
+
+        mock_db_session.commit.side_effect = FakeDisconnect("connection lost")
+        dependencies.SessionLocal = Mock(return_value=mock_db_session)
+
+        # Build a Request whose .url.path raises during f-string formatting,
+        # forcing the except branch in get_db to use the fallback string.
+        bad_request = Mock(spec=Request)
+        bad_request.method = "GET"
+        bad_url = Mock()
+        type(bad_url).path = PropertyMock(side_effect=RuntimeError("scope unavailable"))
+        bad_request.url = bad_url
+
+        with caplog.at_level("WARNING", logger="solace_agent_mesh.gateway.http_sse.dependencies"):
+            with pytest.raises(HTTPException) as exc_info:
+                gen = get_db(bad_request)
+                next(gen)
+                with contextlib.suppress(StopIteration):
+                    next(gen)
+
+        assert exc_info.value.status_code == 503
+        assert "unknown request" in caplog.text
+        mock_db_session.rollback.assert_called_once()
 
     def test_get_db_optional_with_database(self, mock_db_session):
         """Test optional database dependency when configured."""

--- a/tests/unit/gateway/http_sse/test_dependencies.py
+++ b/tests/unit/gateway/http_sse/test_dependencies.py
@@ -443,13 +443,28 @@ class TestUserIdExtraction:
 class TestDatabaseDependencies:
     """Tests for database-related dependencies."""
 
-    def test_get_db_success(self, mock_db_session):
+    @pytest.fixture
+    def mock_request(self):
+        """Minimal Request mock for direct invocation of get_db in unit tests.
+
+        get_db() is declared as get_db(request: Request) so it can log the
+        originating endpoint on connection-error 503s. FastAPI auto-injects
+        Request at runtime; in unit tests we provide a mock exposing the
+        attributes the error path reads (method, url.path).
+        """
+        request = Mock(spec=Request)
+        request.method = "GET"
+        request.url = Mock()
+        request.url.path = "/test"
+        return request
+
+    def test_get_db_success(self, mock_db_session, mock_request):
         """Test getting database session when configured."""
         mock_session_maker = Mock(return_value=mock_db_session)
         dependencies.SessionLocal = mock_session_maker
 
         # Use generator
-        gen = get_db()
+        gen = get_db(mock_request)
         _ = next(gen)
 
         assert mock_db_session is not None
@@ -461,23 +476,23 @@ class TestDatabaseDependencies:
         mock_db_session.commit.assert_called_once()
         mock_db_session.close.assert_called_once()
 
-    def test_get_db_not_configured(self):
+    def test_get_db_not_configured(self, mock_request):
         """Test error when database is not configured."""
         dependencies.SessionLocal = None
 
         with pytest.raises(HTTPException) as exc_info:
-            gen = get_db()
+            gen = get_db(mock_request)
             next(gen)
 
         assert exc_info.value.status_code == 501
         assert "database configuration" in exc_info.value.detail.lower()
 
-    def test_get_db_rollback_on_error(self, mock_db_session):
+    def test_get_db_rollback_on_error(self, mock_db_session, mock_request):
         """Test database rollback on exception."""
         mock_session_maker = Mock(return_value=mock_db_session)
         dependencies.SessionLocal = mock_session_maker
 
-        gen = get_db()
+        gen = get_db(mock_request)
         _ = next(gen)
 
         # Simulate an error


### PR DESCRIPTION
### What is the purpose of this change?

```
  The webui gateway has been experiencing recurring incidents where sam.db.duration{collection=sessions, op=query} 
  pegs the 5-second histogram cap, accompanied by HTTP 503s with    psycopg2.OperationalError: SSL connection has 
  been closed unexpectedly. Investigation showed two compounding problems:
                                                                                                                                                                                             
  1. Connections die silently in the pool. Some handlers hold a DB transaction open across slow await calls (LLM, A2A 
     messaging, file processing). When those waits exceed  idle_in_transaction_session_timeout (60s), or under other 
     infrastructure-level conditions, the server-side connection is terminated. The client kernel doesn't know — without TCP          
     keepalives, the half-closed socket sits in the pool looking healthy.    
                                                                                                                   
  2. pool_pre_ping then hangs for the OS's TCP retransmit timeout (30 seconds to multiple minutes) when it tries to 
      SELECT 1 on the dead socket. Because SAM uses sync psycopg2 inside async def handlers, that hang blocks the
      worker's event loop, freezing every other in-flight request.

  3. The 503 logs don't include the endpoint URL, so we can't tell which handlers originate the failures — making targeted
      refactoring impossible.  
```

### How was this change implemented?

```
  - init_database() — added four TCP keepalive keys to the PostgreSQL connect_args (keepalives=1, keepalives_idle=10, 
   keepalives_interval=5, keepalives_count=3). Configures the OS to detect dead/half-closed sockets within ~25 seconds 
   via TCP probes. Once the kernel knows the socket is dead, pool_pre_ping's SELECT 1 fails in microseconds (up to 25s in  
   unfortunate scenario connection got infected microsecond before - highly unlikely) and  SQLAlchemy invalidates the   
   pool slot transparently — eliminating the cascading worker freeze.
  - get_db() — added request: Request to the signature and expanded the existing connection-error log line to include 
    request.method and request.url.path. FastAPI auto-injects Request for dependency functions, so no callsite changes 
   are needed — every existing Depends(get_db) keeps working unmodified. Future 503s from this code path now carry
   the originating endpoint, turning anonymous SSL traces into a greppable, faceted list of offending URLs.
```

### Key Design Decisions _(optional - delete if not applicable)_



### How was this change tested?

- [x] Manual testing: [describe scenarios]
  spin SAM locally with postgress enabled - ensure app behaves normally
- [ ] Unit tests: [new/modified tests]
- [ ] Integration tests: [if applicable]
- [ ] Known limitations: [what wasn't tested]

### Is there anything the reviewers should focus on/be aware of?

    Special attention areas, potential risks, or open questions
