### PR TITLE
docs(DATAGO-132137): rename "Components" to "Core Concepts" and reposition in sidebar

### DIFF
--- a/docs/docs/documentation/components/_category_.json
+++ b/docs/docs/documentation/components/_category_.json
@@ -1,6 +1,6 @@
 {
-  "position": 200,
-  "label": "Components",
+  "position": 340,
+  "label": "Core Concepts",
   "collapsible": true,
   "collapsed": true
 }

--- a/docs/docs/documentation/components/cli.md
+++ b/docs/docs/documentation/components/cli.md
@@ -4,6 +4,8 @@ sidebar_position: 280
 toc_max_heading_level: 4
 ---
 
+{/* TODO(DATAGO-132137 / SAM Docs IA Phase 6): Extract this page into a top-level "Reference" section as "CLI Reference". See KA: SAM Docs Information Architecture §3.3. */}
+
 # Agent Mesh CLI
 
 Agent Mesh comes with a comprehensive CLI tool that you can use to create, and run an instance of Agent Mesh, which is referred to as an Agent Mesh application. Agent Mesh CLI also allows you to add agents and gateways, manage plugins, help you debug, and much more.

--- a/docs/docs/documentation/components/speech.md
+++ b/docs/docs/documentation/components/speech.md
@@ -1,5 +1,7 @@
 import NetworkAccessRequiredSingleFeature from '@site/docs/partials/network-access-required.mdx';
 
+{/* TODO(DATAGO-132137 / SAM Docs IA Phase 4): Move this page to the "Developing with Agent Mesh" section as "Adding Speech Integration". See KA: SAM Docs Information Architecture §3. */}
+
 # Speech Integration
 
 :::warning Experimental Feature

--- a/docs/docs/documentation/enterprise/_category_.json
+++ b/docs/docs/documentation/enterprise/_category_.json
@@ -1,5 +1,5 @@
 {
-  "position": 700,
+  "position": 320,
   "label": "Agent Mesh Enterprise",
   "collapsible": true,
   "collapsed": true


### PR DESCRIPTION
### What is the purpose of this change?

This change aims to improve the documentation structure for Solace Agent Mesh by renaming the "Components" section to "Core Concepts" and repositioning it in the sidebar. 

### How was this change implemented?

The update involved modifying the `_category_.json` file within the documentation folder to change the label from "Components" to "Core Concepts" and adjusting its sidebar position. Additionally, files within the "components" directory were reviewed to add TODO comments for future documentation phases, specifically noting changes to come in Phases 4 and 6. 

### How was this change tested?

- [x] Manual testing: Ensured the sidebar reflects the new structure and labels.
- [ ] Unit tests: N/A
- [ ] Integration tests: N/A
- [ ] Known limitations: No content changes were made, and further adjustments are planned for future phases.

### Is there anything the reviewers should focus on/be aware of?