### PR TITLE
docs(DATAGO-132141): add stubs for Reference, Help, and Developer Productivity sections

### DIFF
--- a/docs/docs/documentation/developer-productivity/_category_.json
+++ b/docs/docs/documentation/developer-productivity/_category_.json
@@ -1,0 +1,10 @@
+{
+  "position": 900,
+  "label": "Developer Productivity",
+  "collapsible": true,
+  "collapsed": true,
+  "link": {
+    "type": "doc",
+    "id": "documentation/developer-productivity/developer-productivity"
+  }
+}

--- a/docs/docs/documentation/developer-productivity/developer-productivity.md
+++ b/docs/docs/documentation/developer-productivity/developer-productivity.md
@@ -1,0 +1,8 @@
+---
+title: Developer Productivity
+sidebar_position: 1
+---
+
+# Developer Productivity
+
+This section is a stub. Content will be authored in Phase 6 of the docs IA migration and will cover tools and workflows that help developers work efficiently with Solace Agent Mesh.

--- a/docs/docs/documentation/help/_category_.json
+++ b/docs/docs/documentation/help/_category_.json
@@ -1,0 +1,6 @@
+{
+  "position": 800,
+  "label": "Help",
+  "collapsible": true,
+  "collapsed": true
+}

--- a/docs/docs/documentation/help/community-and-support.md
+++ b/docs/docs/documentation/help/community-and-support.md
@@ -1,0 +1,8 @@
+---
+title: Community and Support
+sidebar_position: 2
+---
+
+# Community and Support
+
+This page is a stub. Content will be authored in Phase 6 of the docs IA migration and will describe how to get help from the Solace Agent Mesh community and support channels.

--- a/docs/docs/documentation/help/faq.md
+++ b/docs/docs/documentation/help/faq.md
@@ -1,0 +1,8 @@
+---
+title: FAQ
+sidebar_position: 1
+---
+
+# FAQ
+
+This page is a stub. Content will be authored in Phase 6 of the docs IA migration and will collect frequently asked questions about Solace Agent Mesh.

--- a/docs/docs/documentation/reference/_category_.json
+++ b/docs/docs/documentation/reference/_category_.json
@@ -1,0 +1,6 @@
+{
+  "position": 700,
+  "label": "Reference",
+  "collapsible": true,
+  "collapsed": true
+}

--- a/docs/docs/documentation/reference/cli-reference.md
+++ b/docs/docs/documentation/reference/cli-reference.md
@@ -1,0 +1,8 @@
+---
+title: CLI Reference
+sidebar_position: 1
+---
+
+# CLI Reference
+
+This page is a stub. Content will be authored in Phase 6 of the docs IA migration, when the existing Agent Mesh CLI page from Core Concepts is repurposed as the canonical CLI reference.

--- a/docs/docs/documentation/reference/configuration-reference.md
+++ b/docs/docs/documentation/reference/configuration-reference.md
@@ -1,0 +1,8 @@
+---
+title: Configuration Reference
+sidebar_position: 2
+---
+
+# Configuration Reference
+
+This page is a stub. Content will be authored in Phase 6 of the docs IA migration and will provide a standalone reference for all Agent Mesh configuration options.

--- a/docs/docs/documentation/reference/helm-values-reference.md
+++ b/docs/docs/documentation/reference/helm-values-reference.md
@@ -1,0 +1,8 @@
+---
+title: Helm Values Reference
+sidebar_position: 3
+---
+
+# Helm Values Reference
+
+This page is a stub. Content will be absorbed from the existing Helm site in Phase 2 of the docs IA migration and will provide a complete reference for Agent Mesh Helm chart values.


### PR DESCRIPTION
### What is the purpose of this change?

Final phase 1 of the SAM Docs IA migration. Creates placeholder sections for **Reference**, **Help**, and **Developer Productivity** so the full target sidebar IA is visible to stakeholders before any content is authored. Content for these stubs lands in Phase 6 (Helm Values Reference is absorbed in Phase 2).

### How was this change implemented?

Added new sections under `docs/docs/documentation/` with Docusaurus `_category_.json` files and stub Markdown pages:

- `reference/` — `cli-reference.md`, `configuration-reference.md`, `helm-values-reference.md`
- `help/` — `faq.md`, `community-and-support.md`
- `developer-productivity/` — `developer-productivity.md` (linked from the category as the section landing page)

Each stub contains a one-line note indicating the phase in which content will be authored. 

### How was this change tested?

- [x] Manual testing: rendered locally; new sections appear in the sidebar in the expected order with stub pages reachable.
- [ ] Unit tests: n/a (docs-only).
- [ ] Integration tests: n/a.

### Is there anything the reviewers should focus on/be aware of?