### PR TITLE
fix(DATAGO-136753): Missing RBAC handling and documentation on model config endpoints

### DIFF
--- a/docs/docs/documentation/enterprise/rbac-setup-guide.md
+++ b/docs/docs/documentation/enterprise/rbac-setup-guide.md
@@ -244,6 +244,22 @@ roles:
       - "tool:data:*"
 ```
 
+#### Model Configuration Scopes
+
+Model configuration scopes control who can create, edit, and delete LLM model configurations. A single scope governs every write operation:
+
+- `sam:model_config:write` - Permission to create, edit, and delete model configurations
+
+Example role configuration:
+
+```yaml
+roles:
+  model_admin:
+    description: "Manages LLM model configurations"
+    scopes:
+      - "sam:model_config:write"
+```
+
 #### Monitoring Scopes
 
 Monitoring scopes control access to system monitoring features and follow the pattern `monitor/namespace/<namespace>:a2a_messages:subscribe`. These scopes allow users to observe message traffic in specific namespaces.

--- a/src/solace_agent_mesh/services/platform/api/routers/model_configurations_router.py
+++ b/src/solace_agent_mesh/services/platform/api/routers/model_configurations_router.py
@@ -34,7 +34,7 @@ from solace_agent_mesh.services.platform.api.routers.dto.requests import (
 )
 from solace_agent_mesh.agent.adk.models.dynamic_model_provider_topics import get_model_config_update_topic
 from solace_agent_mesh.shared.api.pagination import DataResponse
-from solace_agent_mesh.shared.auth.dependencies import get_current_user
+from solace_agent_mesh.shared.auth.dependencies import ValidatedUserConfig, get_current_user
 from solace_agent_mesh.shared.api.response_utils import create_data_response
 from solace_agent_mesh.shared.exceptions.exceptions import ValidationErrorBuilder
 
@@ -147,6 +147,7 @@ async def create_model(
     request: ModelConfigurationBaseRequest,
     response: Response,
     _: None = Depends(require_model_config_ui_enabled),
+    _user_config: dict = Depends(ValidatedUserConfig(["sam:model_config:write"])),
     validate_only: bool = Query(False, alias="validateOnly"),
     db: Session = Depends(get_platform_db),
     user: dict = Depends(get_current_user),
@@ -195,6 +196,7 @@ async def update_model(
     model_id: str,
     request: ModelConfigurationUpdateRequest,
     _: None = Depends(require_model_config_ui_enabled),
+    _user_config: dict = Depends(ValidatedUserConfig(["sam:model_config:write"])),
     db: Session = Depends(get_platform_db),
     user: dict = Depends(get_current_user),
     service: ModelConfigService = Depends(get_model_config_service),
@@ -262,6 +264,7 @@ async def get_model_dependents(
 async def delete_model(
     model_id: str,
     _: None = Depends(require_model_config_ui_enabled),
+    _user_config: dict = Depends(ValidatedUserConfig(["sam:model_config:write"])),
     db: Session = Depends(get_platform_db),
     user: dict = Depends(get_current_user),
     service: ModelConfigService = Depends(get_model_config_service),

--- a/src/solace_agent_mesh/services/platform/api/routers/providers_router.py
+++ b/src/solace_agent_mesh/services/platform/api/routers/providers_router.py
@@ -25,6 +25,7 @@ from solace_agent_mesh.services.platform.api.routers.dto.responses import (
 )
 from solace_agent_mesh.shared.api.pagination import DataResponse
 from solace_agent_mesh.shared.api.response_utils import create_data_response
+from solace_agent_mesh.shared.auth.dependencies import ValidatedUserConfig
 from solace_agent_mesh.shared.exceptions.exceptions import ValidationErrorBuilder
 
 log = logging.getLogger(__name__)
@@ -42,6 +43,7 @@ async def list_provider_models(
     provider: str,
     request: ProviderQueryBaseRequest,
     _: None = Depends(require_model_config_ui_enabled),
+    _user_config: dict = Depends(ValidatedUserConfig(["sam:model_config:write"])),
     db: Session = Depends(get_platform_db),
     service: ModelListService = Depends(get_model_list_service),
     config_service: ModelConfigService = Depends(get_model_config_service),
@@ -98,6 +100,7 @@ async def get_supported_params(
     provider: str,
     request: SupportedParamsRequest,
     _: None = Depends(require_model_config_ui_enabled),
+    _user_config: dict = Depends(ValidatedUserConfig(["sam:model_config:write"])),
     service: ModelListService = Depends(get_model_list_service),
 ) -> DataResponse[SupportedParamsResponse]:
     """

--- a/tests/unit/services/platform/routers/test_model_configurations_router.py
+++ b/tests/unit/services/platform/routers/test_model_configurations_router.py
@@ -5,15 +5,19 @@ Tests:
 - POST /models emits events after create
 - PUT /models/{model_id} emits events after update
 - DELETE /models/{model_id} emits events after delete
+- Each endpoint declares the correct ValidatedUserConfig scope (RBAC)
 """
 
+import inspect
 from unittest.mock import Mock, patch, AsyncMock
 
 import pytest
+from fastapi.params import Depends
 
 from solace_agent_mesh.services.platform.api.routers.model_configurations_router import (
     _emit_model_config_update,
 )
+from solace_agent_mesh.shared.auth.dependencies import ValidatedUserConfig
 
 
 class TestEmitModelConfigUpdate:
@@ -207,4 +211,55 @@ class TestDeleteModelEndpoint:
         mock_service.delete.assert_called_once()
         mock_emit.assert_called_once_with(
             mock_component, "uuid-789", "my-alias", None
+        )
+
+
+def _endpoint_scopes(endpoint_func) -> list[list[str]]:
+    """Return all ValidatedUserConfig.required_scopes declared on an endpoint."""
+    scopes: list[list[str]] = []
+    for param in inspect.signature(endpoint_func).parameters.values():
+        default = param.default
+        if isinstance(default, Depends):
+            dep = default.dependency
+            if isinstance(dep, ValidatedUserConfig):
+                scopes.append(dep.required_scopes)
+    return scopes
+
+
+class TestModelEndpointScopes:
+    """Write endpoints gate on sam:model_config:write; reads stay open so
+    chat, agent builder, and evaluations keep working for non-admin users.
+
+    Runtime enforcement of ValidatedUserConfig itself is covered by
+    tests/unit/gateway/http_sse/test_dependencies.py — here we only verify
+    that each endpoint asks for the right scope (or no scope at all).
+    """
+
+    @pytest.mark.parametrize(
+        "endpoint_name",
+        ["create_model", "update_model", "delete_model"],
+    )
+    def test_write_endpoint_requires_model_config_write(self, endpoint_name):
+        from solace_agent_mesh.services.platform.api.routers import (
+            model_configurations_router,
+        )
+
+        endpoint = getattr(model_configurations_router, endpoint_name)
+        assert [["sam:model_config:write"]] == _endpoint_scopes(endpoint), (
+            f"{endpoint_name} should depend on ValidatedUserConfig(['sam:model_config:write'])"
+        )
+
+    @pytest.mark.parametrize(
+        "endpoint_name",
+        ["list_models", "get_model", "get_model_dependents"],
+    )
+    def test_read_endpoint_is_ungated(self, endpoint_name):
+        from solace_agent_mesh.services.platform.api.routers import (
+            model_configurations_router,
+        )
+
+        endpoint = getattr(model_configurations_router, endpoint_name)
+        assert _endpoint_scopes(endpoint) == [], (
+            f"{endpoint_name} should not declare a ValidatedUserConfig scope — "
+            "reads must stay open for chat/agent-builder/evaluations consumers"
         )

--- a/tests/unit/services/platform/routers/test_providers_router.py
+++ b/tests/unit/services/platform/routers/test_providers_router.py
@@ -1,0 +1,44 @@
+"""Unit tests for providers_router RBAC scope declarations.
+
+Runtime enforcement of ValidatedUserConfig is covered by
+tests/unit/gateway/http_sse/test_dependencies.py — here we only verify
+that each provider endpoint declares the expected sam:models:* scope.
+"""
+
+import inspect
+
+import pytest
+from fastapi.params import Depends
+
+from solace_agent_mesh.shared.auth.dependencies import ValidatedUserConfig
+
+
+def _endpoint_scopes(endpoint_func) -> list[list[str]]:
+    """Return all ValidatedUserConfig.required_scopes declared on an endpoint."""
+    scopes: list[list[str]] = []
+    for param in inspect.signature(endpoint_func).parameters.values():
+        default = param.default
+        if isinstance(default, Depends):
+            dep = default.dependency
+            if isinstance(dep, ValidatedUserConfig):
+                scopes.append(dep.required_scopes)
+    return scopes
+
+
+class TestProvidersEndpointScopes:
+    """Provider query endpoints are only reachable from the create/edit model
+    form, so they share the same sam:model_config:write gate as the underlying
+    write endpoints.
+    """
+
+    @pytest.mark.parametrize(
+        "endpoint_name",
+        ["list_provider_models", "get_supported_params"],
+    )
+    def test_endpoint_requires_model_config_write(self, endpoint_name):
+        from solace_agent_mesh.services.platform.api.routers import providers_router
+
+        endpoint = getattr(providers_router, endpoint_name)
+        assert [["sam:model_config:write"]] == _endpoint_scopes(endpoint), (
+            f"{endpoint_name} should depend on ValidatedUserConfig(['sam:model_config:write'])"
+        )


### PR DESCRIPTION
### What is the purpose of this change?

The Platform Service model configuration endpoints (model_configurations_router and providers_router) had no RBAC enforcement. Any authenticated user could create, edit, or delete LLM model configurations. This PR gates every model-config mutation behind the existing `sam:model_config:write` capability so only administrators can change model
configurations.

### How was this change implemented?

Added `ValidatedUserConfig(["sam:model_config:write"])` from
`shared/auth/dependencies.py` as a FastAPI dependency on every write endpoint:

- `POST /api/v1/platform/models` (create)
- `PATCH /api/v1/platform/models/{id}` (update)
- `DELETE /api/v1/platform/models/{id}` (delete)
- `POST /api/v1/platform/providers/{provider}/models` (provider model lookup
  used by the create/edit form)
- `POST /api/v1/platform/providers/{provider}/params` (provider params lookup
  used by the create/edit form)

GET endpoints (`/models`, `/models/{id}`, `/models/{id}/dependents`,
`/models/status`) are intentionally left ungated — see Key Design Decisions.

Documentation: added a "Model Configuration Scopes" subsection to
`docs/docs/documentation/enterprise/rbac-setup-guide.md`, placed alongside
the other scope-family subsections (Tool, Agent, Artifact, Monitoring).

### Key Design Decisions _(optional - delete if not applicable)_

**Why are reads ungated?** Listing and fetching model configurations is a
dependency of non-administrator features: the chat context-usage indicator
(`useSessionContextUsage`), Agent Builder model picker (`AgentModelEdit`,
`AgentView`), and Evaluations model selection (`EvalCreateEvaluatorPage`,
`ModelSelect`) all call `GET /models` from non-admin user flows. Gating reads
would break all three. Non-sensitive read access is already the de-facto
contract — sensitive auth credentials are filtered from responses by
`ModelConfigService` regardless.

### How was this change tested?

- [x] Manual testing: [describe scenarios]
- [x] Unit tests: [new/modified tests]
- [ ] Integration tests: [if applicable]
- [ ] Known limitations: [what wasn't tested]

### Is there anything the reviewers should focus on/be aware of?

    Special attention areas, potential risks, or open questions
