### PR TITLE
fix(DATAGO-134649): sort litellm fallback model list for OpenAI provider

### DIFF
--- a/src/solace_agent_mesh/services/platform/services/model_list_service.py
+++ b/src/solace_agent_mesh/services/platform/services/model_list_service.py
@@ -452,7 +452,7 @@ class ModelListService:
                     result.append(model.split("/", 1)[1])
                 else:
                     result.append(model)
-            return result
+            return sorted(result)
         except Exception as e:
             log.debug("Could not get models from LiteLLM registry for %s: %s", provider, e)
             return []


### PR DESCRIPTION
### What is the purpose of this change?

 When the direct fetch from a provider's models API fails, we fall back to LiteLLM's static `models_by_provider` registry. That registry preserves whatever order LiteLLM ships, which for OpenAI interleaves `gpt-4-yyyy-mm-dd` dated variants unsortedly — making the Model Name dropdown hard to scan when the live fetch fails.

### How was this change implemented?

- Sort the list returned by `_get_litellm_models_for_provider` in `model_list_service.py` before it's converted into the API response shape.

### How was this change tested?

- [x] Manual testing: forced the OpenAI direct-fetch path to fail (temporary `raise` removed before commit), confirmed the litellm fallback now returns a sorted list in the Model Name dropdown.
- [ ] Unit tests: none added — change is a one-line `sorted()` over a list whose ordering is the only behavior under test.
- [ ] Integration tests: n/a
- [ ] Known limitations: only the litellm fallback path is sorted here. The direct-fetch path still returns whatever order the provider's API gives back.
### Is there anything the reviewers should focus on/be aware of?

Nothing specific.
