### PR TITLE
fix: block IPv4-mapped IPv6 addresses in SSRF webhook validation

### DIFF
--- a/src/solace_agent_mesh/gateway/http_sse/services/scheduler/notification_service.py
+++ b/src/solace_agent_mesh/gateway/http_sse/services/scheduler/notification_service.py
@@ -50,15 +50,20 @@ _BROKER_TOPIC_PREFIX = "scheduled-tasks/"
 
 
 def _check_ip_blocked(ip_str: str) -> None:
-    """Raise ValueError if the IP falls within a blocked network range."""
     ip = ipaddress.ip_address(ip_str)
+
+    # Normalize IPv4-mapped IPv6 addresses (e.g. ::ffff:127.0.0.1 → 127.0.0.1)
+    # Without this, ::ffff:127.0.0.1 is treated as IPv6 and won't match
+    # IPv4 blocked networks like 127.0.0.0/8, allowing SSRF bypass.
+    if isinstance(ip, ipaddress.IPv6Address) and ip.ipv4_mapped is not None:
+        ip = ip.ipv4_mapped
+
     for network in _BLOCKED_IP_NETWORKS:
         if ip in network:
             raise ValueError(
                 f"Webhook URL resolves to blocked IP range ({ip}). "
                 "Private, loopback, and link-local addresses are not allowed."
             )
-
 
 def _validate_webhook_url(url: str) -> None:
     """


### PR DESCRIPTION
## Problem
The SSRF webhook protection can be bypassed using IPv4-mapped IPv6
notation. For example:

    http://[::ffff:127.0.0.1]:6666

`ipaddress.ip_address("::ffff:127.0.0.1")` returns an `IPv6Address`,
which never matches the IPv4 network `127.0.0.0/8` in `_BLOCKED_IP_NETWORKS`.
This allows loopback, private, and link-local addresses to slip through.

Affected addresses:
- `::ffff:127.0.0.1` (loopback)
- `::ffff:10.0.0.1` (private)
- `::ffff:192.168.1.1` (private)
- `::ffff:169.254.169.254` (metadata server)

## Fix
In `_check_ip_blocked()`, check if the resolved IP is an IPv4-mapped
IPv6 address using `ip.ipv4_mapped`. If it is, unwrap it to the
embedded IPv4 address before comparing against blocked networks.

## Testing
| URL | Before | After |
|-----|--------|-------|
| `http://[::ffff:127.0.0.1]:6666` | ✅ allowed (bypass!) | ❌ blocked |
| `http://127.0.0.1` | ❌ blocked | ❌ blocked |
| `https://webhook.site/test` | ✅ allowed | ✅ allowed |

Affected file:
`src/solace_agent_mesh/gateway/http_sse/services/scheduler/notification_service.py`
Reference commit: a4804c2ab628d1461870acf1c973f492825a7ef3