### PR TITLE
Fix frontend pre-commit hook syntax error and improve reliability #1546

### DIFF
--- a/hooks/pre-commit.sh
+++ b/hooks/pre-commit.sh
@@ -1,0 +1,18 @@
+#!/bin/sh
+
+set -e
+
+ROOT_DIR=$(git rev-parse --show-toplevel)
+
+# Check if any frontend files are staged
+if git diff --cached --name-only --diff-filter=ACM | grep -q '^client/webui/frontend/'; then
+  echo "Frontend changes detected, running frontend pre-commit hook..."
+
+  cd "$ROOT_DIR/client/webui/frontend" || exit 1
+
+  npm run precommit
+
+  echo "Frontend pre-commit hook completed successfully"
+fi
+
+exit 0


### PR DESCRIPTION
What is the purpose of this change?

This change fixes a syntax error in the frontend pre-commit hook script and improves its reliability. The issue was caused by invalid trailing text after exit 0, which could break script execution. The update also ensures the hook only runs when frontend files are staged and behaves more safely.

#closes 1546


How was this change implemented?
Removed invalid trailing text after exit 0
Improved staged file detection using a safer grep -q check
Added set -e to ensure the script fails fast on errors
Refactored structure for better readability and maintainability
Ensured the hook only runs for changes under client/webui/frontend/
Key Design Decisions (optional - delete if not applicable)
Used git diff --cached --name-only with grep -q instead of storing output in a variable for simplicity and reliability
Added set -e to enforce strict error handling rather than manually checking each command
Kept the script POSIX-compliant (/bin/sh) for maximum compatibility


How was this change tested?
 Manual testing: staged frontend and non-frontend files and verified hook execution behavior
 Unit tests: not applicable (shell hook script)
 Integration tests: validated via local git commit flow
 Known limitations: does not lint only changed files (runs full npm run precommit if triggered)
Is there anything the reviewers should focus on/be aware of?
Ensure hook triggers only for client/webui/frontend/ changes
Confirm no unintended execution for unrelated file changes
Verify npm script exit codes correctly propagate to git commit flow
Review POSIX compatibility assumptions if environment differs