### PR TITLE
fix(ci): bump libc6 pin to 2.41-12+deb13u3 to unblock Docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -70,7 +70,7 @@ RUN echo "deb http://deb.debian.org/debian unstable main" > /etc/apt/sources.lis
     dpkg=1.22.22 \
     ffmpeg=7:7.1.3-0+deb13u1  \
     git \
-    libc6=2.41-12+deb13u2 \
+    libc6=2.41-12+deb13u3 \
     libtasn1-6/unstable \
     libpng16-16t64=1.6.48-1+deb13u5 \
     libsqlite3-0=3.46.1-7+deb13u1 \
@@ -167,7 +167,7 @@ RUN echo "deb http://deb.debian.org/debian unstable main" > /etc/apt/sources.lis
     ffmpeg=7:7.1.3-0+deb13u1 \
     git \
     libatomic1 \
-    libc6=2.41-12+deb13u2 \
+    libc6=2.41-12+deb13u3 \
     libtasn1-6/unstable \
     libpng16-16t64=1.6.48-1+deb13u5 \
     libsqlite3-0=3.46.1-7+deb13u1 \

--- a/Dockerfile
+++ b/Dockerfile
@@ -59,7 +59,7 @@ COPY --from=node-binaries /usr/local/lib/node_modules /usr/local/lib/node_module
 
 # Install system dependencies and uv
 # Add unstable repo with APT pinning to only upgrade libtasn1-6 (CVE-2025-13151 fix)
-# Pin libc6=2.41-12+deb13u2 to fix CVE-2026-0861, CVE-2026-0915, CVE-2025-15281 (glibc vulnerabilities)
+# Pin libc6=2.41-12+deb13u3 to fix CVE-2026-0861, CVE-2026-0915, CVE-2025-15281 (glibc vulnerabilities)
 # Pin dpkg=1.22.22 to fix CVE-2026-2219 (denial of service via zstd-compressed .deb archives)
 RUN echo "deb http://deb.debian.org/debian unstable main" > /etc/apt/sources.list.d/unstable.list && \
     printf "Package: *\nPin: release a=unstable\nPin-Priority: 50\n\nPackage: libtasn1-6\nPin: release a=unstable\nPin-Priority: 900\n" > /etc/apt/preferences.d/99pin-libtasn1 && \
@@ -157,7 +157,7 @@ COPY --from=node-binaries /usr/local/lib/node_modules /usr/local/lib/node_module
 # Install minimal runtime dependencies (no uv for licensing compliance, no curl - due to vulnerabilities)
 # LibreOffice is optionally installed for document conversion (DOCX/PPTX to PDF for preview)
 # Add unstable repo with APT pinning to only upgrade libtasn1-6 (CVE-2025-13151 fix)
-# Pin libc6=2.41-12+deb13u2 to fix CVE-2026-0861, CVE-2026-0915, CVE-2025-15281 (glibc vulnerabilities)
+# Pin libc6=2.41-12+deb13u3 to fix CVE-2026-0861, CVE-2026-0915, CVE-2025-15281 (glibc vulnerabilities)
 # Pin dpkg=1.22.22 to fix CVE-2026-2219 (denial of service via zstd-compressed .deb archives)
 RUN echo "deb http://deb.debian.org/debian unstable main" > /etc/apt/sources.list.d/unstable.list && \
     printf "Package: *\nPin: release a=unstable\nPin-Priority: 50\n\nPackage: libtasn1-6\nPin: release a=unstable\nPin-Priority: 900\n" > /etc/apt/preferences.d/99pin-libtasn1 && \


### PR DESCRIPTION
## Summary
- Debian trixie mirror rotated `libc6` from `2.41-12+deb13u2` to `2.41-12+deb13u3`, removing the exact-pinned version and breaking every CI Docker build with `E: Version '2.41-12+deb13u2' for 'libc6' was not found` (e.g. [run 26123331112](https://github.com/SolaceLabs/solace-agent-mesh/actions/runs/26123331112/job/76830716938))
- Bumped the pin in both the `builder` and `runtime` stages (`Dockerfile:73`, `Dockerfile:170`)
- Verified all other pinned versions (`dpkg`, `ffmpeg`, `libpng16-16t64`, `libsqlite3-0`, `libssl3t64`, `libvpx9`, `openssl`) still resolve against current trixie / trixie-security indexes via `apt-get install --simulate`

Note: this pattern recurs every time a security patch rotates the older version off the mirror. Worth considering Renovate or `>=` constraints as a follow-up.

## Test plan
- [ ] CI Docker build passes on this branch