### PR TITLE
fix(DATAGO-137421): WebUI slow due to S3 connection pool exhaustion on /api/v1/artifacts/all

### DIFF
--- a/src/solace_agent_mesh/agent/adk/artifacts/s3_artifact_service.py
+++ b/src/solace_agent_mesh/agent/adk/artifacts/s3_artifact_service.py
@@ -377,6 +377,78 @@ class S3ArtifactService(BaseArtifactService):
         logger.debug("%sFound %d artifact keys.", log_prefix, len(sorted_filenames))
         return sorted_filenames
 
+    async def list_artifact_keys_with_latest_versions(
+        self, *, app_name: str, user_id: str, session_id: str
+    ) -> dict[str, int]:
+        """Like list_artifact_keys, but also returns the latest version per key.
+
+        Returns a dict mapping each filename (as stored, including any
+        ``.metadata.json`` suffix, and prefixed with ``user:`` for
+        user-scoped artifacts to match list_artifact_keys) to its highest
+        version number observed in S3.
+
+        Built from the same paginated ListObjectsV2 walk that
+        list_artifact_keys runs, so the version map is captured for free.
+        Callers on the list path can use this to pass a concrete version
+        into load_artifact_content_or_metadata and avoid an extra
+        list_versions S3 round-trip per artifact.
+        """
+        log_prefix = "[S3Artifact:ListKeysWithVersions] "
+        latest: dict[str, int] = {}
+        app_name = app_name.strip("/")
+
+        def _walk(pages, key_prefix: str = "") -> None:
+            for page in pages:
+                for obj in page.get("Contents", []):
+                    parts = obj["Key"].split("/")
+                    if len(parts) < 5:
+                        continue
+                    try:
+                        version = int(parts[4])
+                    except ValueError:
+                        # Non-integer version segment — unexpected, skip.
+                        continue
+                    name = f"{key_prefix}{parts[3]}"
+                    if version > latest.get(name, -1):
+                        latest[name] = version
+
+        session_prefix = f"{app_name}/{user_id}/{session_id}/"
+        try:
+
+            def _list_session_objects():
+                paginator = self.s3.get_paginator("list_objects_v2")
+                return paginator.paginate(
+                    Bucket=self.bucket_name, Prefix=session_prefix
+                )
+
+            _walk(await asyncio.to_thread(_list_session_objects))
+        except ClientError as e:
+            logger.warning(
+                "%sError listing session objects with prefix '%s': %s",
+                log_prefix,
+                session_prefix,
+                e,
+            )
+
+        user_prefix = f"{app_name}/{user_id}/user/"
+        try:
+
+            def _list_user_objects():
+                paginator = self.s3.get_paginator("list_objects_v2")
+                return paginator.paginate(Bucket=self.bucket_name, Prefix=user_prefix)
+
+            _walk(await asyncio.to_thread(_list_user_objects), key_prefix="user:")
+        except ClientError as e:
+            logger.warning(
+                "%sError listing user objects with prefix '%s': %s",
+                log_prefix,
+                user_prefix,
+                e,
+            )
+
+        logger.debug("%sFound %d artifact keys.", log_prefix, len(latest))
+        return latest
+
     async def list_sessions_with_artifacts_for_user(
         self, *, app_name: str, user_id: str
     ) -> set[str] | None:

--- a/src/solace_agent_mesh/agent/utils/artifact_helpers.py
+++ b/src/solace_agent_mesh/agent/utils/artifact_helpers.py
@@ -1296,10 +1296,32 @@ async def get_artifact_info_list_fast(
     log_prefix = f"[ArtifactHelper:get_info_list_fast] App={app_name}, User={user_id}, Session={session_id} -"
 
     try:
-        list_keys_method = getattr(artifact_service, "list_artifact_keys")
-        keys = await list_keys_method(
-            app_name=app_name, user_id=user_id, session_id=session_id
+        # If the service can give us filenames + latest versions in a single
+        # listing pass, use that — load_artifact_content_or_metadata then skips
+        # its own per-artifact list_versions call to resolve "latest", saving
+        # one S3 round-trip per artifact on this list path.
+        keys_with_versions_method = getattr(
+            artifact_service, "list_artifact_keys_with_latest_versions", None
         )
+        latest_metadata_version_by_filename: Dict[str, int] = {}
+        if keys_with_versions_method is not None:
+            version_map = await keys_with_versions_method(
+                app_name=app_name, user_id=user_id, session_id=session_id
+            )
+            keys = list(version_map.keys())
+            # The metadata.json file's latest version drives what we load. In
+            # normal save flows it matches the content version, but the
+            # metadata sidecar is the source of truth here because that's what
+            # load_artifact_content_or_metadata(load_metadata_only=True) reads.
+            for key, version in version_map.items():
+                if key.endswith(METADATA_SUFFIX):
+                    base_filename = key[: -len(METADATA_SUFFIX)]
+                    latest_metadata_version_by_filename[base_filename] = version
+        else:
+            list_keys_method = getattr(artifact_service, "list_artifact_keys")
+            keys = await list_keys_method(
+                app_name=app_name, user_id=user_id, session_id=session_id
+            )
         log.debug("%s Found %d artifact keys.", log_prefix, len(keys))
 
         # Filter out metadata suffix keys
@@ -1313,6 +1335,15 @@ async def get_artifact_info_list_fast(
         async def _load_single_metadata(filename: str) -> Optional[ArtifactInfo]:
             """Load metadata for a single artifact. Returns None on failure."""
             try:
+                # Pass the concrete metadata version when we have it so the
+                # loader skips its internal list_versions "latest" resolve.
+                # Falls back to "latest" for services that don't expose
+                # list_artifact_keys_with_latest_versions, or for content
+                # artifacts that somehow have no matching metadata key
+                # (defensive — same-version save invariant should hold).
+                version_to_load: int | str = latest_metadata_version_by_filename.get(
+                    filename, "latest"
+                )
                 async with _METADATA_LOAD_SEMAPHORE:
                     data = await load_artifact_content_or_metadata(
                         artifact_service=artifact_service,
@@ -1320,17 +1351,16 @@ async def get_artifact_info_list_fast(
                         user_id=user_id,
                         session_id=session_id,
                         filename=filename,
-                        version="latest",
+                        version=version_to_load,
                         load_metadata_only=True,
                         log_identifier_prefix=f"{log_prefix} [{filename}]",
                     )
 
-                # `version` is the metadata file's resolved-latest version,
-                # captured for free here (load_artifact_content_or_metadata
-                # already had to call list_versions to resolve "latest"). The
-                # WebUI's attach-artifact dialog uses this to pre-fill its
-                # version picker default with a concrete number rather than a
-                # "Latest" sentinel.
+                # `version` is the metadata file's resolved version, returned
+                # by load_artifact_content_or_metadata. The WebUI's
+                # attach-artifact dialog uses this to pre-fill its version
+                # picker default with a concrete number rather than a "Latest"
+                # sentinel.
                 info = _metadata_to_artifact_info(
                     filename,
                     data.get("metadata", {}),

--- a/src/solace_agent_mesh/agent/utils/artifact_helpers.py
+++ b/src/solace_agent_mesh/agent/utils/artifact_helpers.py
@@ -38,6 +38,14 @@ BM25_INDEX_FILENAME = "project_bm25_index.zip"
 DEFAULT_SCHEMA_MAX_KEYS = 20
 DEFAULT_SCHEMA_INFERENCE_DEPTH = 4
 
+# Caps concurrent artifact-metadata S3 loads across the whole process. Without
+# this, get_artifact_info_list_fast does an unbounded asyncio.gather over every
+# artifact in a session, and the /api/v1/artifacts/all router fans out across
+# many sessions in parallel. Under multi-user load the combined fan-out
+# exhausts the botocore connection pool (default 200), discards connections,
+# and stalls the FastAPI event loop on TLS handshakes for unrelated requests.
+_METADATA_LOAD_SEMAPHORE = asyncio.Semaphore(50)
+
 
 def is_internal_artifact(filename: str) -> bool:
     """
@@ -1305,16 +1313,17 @@ async def get_artifact_info_list_fast(
         async def _load_single_metadata(filename: str) -> Optional[ArtifactInfo]:
             """Load metadata for a single artifact. Returns None on failure."""
             try:
-                data = await load_artifact_content_or_metadata(
-                    artifact_service=artifact_service,
-                    app_name=app_name,
-                    user_id=user_id,
-                    session_id=session_id,
-                    filename=filename,
-                    version="latest",
-                    load_metadata_only=True,
-                    log_identifier_prefix=f"{log_prefix} [{filename}]",
-                )
+                async with _METADATA_LOAD_SEMAPHORE:
+                    data = await load_artifact_content_or_metadata(
+                        artifact_service=artifact_service,
+                        app_name=app_name,
+                        user_id=user_id,
+                        session_id=session_id,
+                        filename=filename,
+                        version="latest",
+                        load_metadata_only=True,
+                        log_identifier_prefix=f"{log_prefix} [{filename}]",
+                    )
 
                 # `version` is the metadata file's resolved-latest version,
                 # captured for free here (load_artifact_content_or_metadata

--- a/tests/unit/agent/adk/artifacts/test_s3_artifact_service.py
+++ b/tests/unit/agent/adk/artifacts/test_s3_artifact_service.py
@@ -626,6 +626,96 @@ class TestS3ArtifactServiceListArtifactKeys:
         assert keys == []
 
 
+class TestS3ArtifactServiceListArtifactKeysWithLatestVersions:
+    """Tests for list_artifact_keys_with_latest_versions method"""
+
+    @pytest.mark.asyncio
+    async def test_returns_max_version_per_filename(self, mock_s3_client):
+        """Multiple versions of the same key collapse to the highest version."""
+        service = S3ArtifactService("test-bucket", s3_client=mock_s3_client)
+
+        paginator = Mock()
+        session_objects = [
+            {'Key': 'app/u1/sess1/doc.txt/0'},
+            {'Key': 'app/u1/sess1/doc.txt/2'},
+            {'Key': 'app/u1/sess1/doc.txt/1'},
+            {'Key': 'app/u1/sess1/doc.txt.metadata.json/0'},
+            {'Key': 'app/u1/sess1/doc.txt.metadata.json/2'},
+            {'Key': 'app/u1/sess1/doc.txt.metadata.json/1'},
+        ]
+        paginator.paginate.side_effect = [
+            [{'Contents': session_objects}],
+            [{'Contents': []}],
+        ]
+        mock_s3_client.get_paginator.return_value = paginator
+
+        result = await service.list_artifact_keys_with_latest_versions(
+            app_name="app", user_id="u1", session_id="sess1"
+        )
+
+        assert result == {"doc.txt": 2, "doc.txt.metadata.json": 2}
+
+    @pytest.mark.asyncio
+    async def test_user_scoped_keys_carry_user_prefix(self, mock_s3_client):
+        """User-namespaced keys are prefixed with 'user:' to match list_artifact_keys."""
+        service = S3ArtifactService("test-bucket", s3_client=mock_s3_client)
+
+        paginator = Mock()
+        paginator.paginate.side_effect = [
+            [{'Contents': []}],
+            [{'Contents': [
+                {'Key': 'app/u1/user/profile.json/0'},
+                {'Key': 'app/u1/user/profile.json/1'},
+            ]}],
+        ]
+        mock_s3_client.get_paginator.return_value = paginator
+
+        result = await service.list_artifact_keys_with_latest_versions(
+            app_name="app", user_id="u1", session_id="sess1"
+        )
+
+        assert result == {"user:profile.json": 1}
+
+    @pytest.mark.asyncio
+    async def test_skips_keys_with_non_integer_version_segment(self, mock_s3_client):
+        """Defensive: keys whose version segment isn't a number are skipped, not crashed on."""
+        service = S3ArtifactService("test-bucket", s3_client=mock_s3_client)
+
+        paginator = Mock()
+        paginator.paginate.side_effect = [
+            [{'Contents': [
+                {'Key': 'app/u1/sess1/ok.txt/3'},
+                {'Key': 'app/u1/sess1/weird.txt/not-a-number'},
+            ]}],
+            [{'Contents': []}],
+        ]
+        mock_s3_client.get_paginator.return_value = paginator
+
+        result = await service.list_artifact_keys_with_latest_versions(
+            app_name="app", user_id="u1", session_id="sess1"
+        )
+
+        assert result == {"ok.txt": 3}
+
+    @pytest.mark.asyncio
+    async def test_client_error_returns_partial_result(self, mock_s3_client):
+        """If one prefix LIST fails, the other still contributes (mirrors list_artifact_keys)."""
+        service = S3ArtifactService("test-bucket", s3_client=mock_s3_client)
+
+        paginator = Mock()
+        paginator.paginate.side_effect = [
+            ClientError({'Error': {'Code': '403'}}, 'ListObjectsV2'),
+            [{'Contents': [{'Key': 'app/u1/user/u.json/0'}]}],
+        ]
+        mock_s3_client.get_paginator.return_value = paginator
+
+        result = await service.list_artifact_keys_with_latest_versions(
+            app_name="app", user_id="u1", session_id="sess1"
+        )
+
+        assert result == {"user:u.json": 0}
+
+
 class TestS3ArtifactServiceListSessionsWithArtifactsForUser:
     """Tests for list_sessions_with_artifacts_for_user method"""
 

--- a/tests/unit/agent/utils/test_artifact_helpers.py
+++ b/tests/unit/agent/utils/test_artifact_helpers.py
@@ -1727,3 +1727,75 @@ class TestGetArtifactInfoListFast:
             session_id="sess",
         )
         assert result == []
+
+    @pytest.mark.asyncio
+    async def test_uses_keys_with_versions_when_available(self):
+        """When the service exposes list_artifact_keys_with_latest_versions,
+        load_artifact_content_or_metadata is called with the concrete metadata
+        version (not 'latest'), so its internal list_versions step is skipped.
+        """
+        svc = AsyncMock(spec=BaseArtifactService)
+        svc.list_artifact_keys_with_latest_versions = AsyncMock(
+            return_value={
+                "report.csv": 3,
+                "report.csv.metadata.json": 3,
+                "notes.txt": 1,
+                "notes.txt.metadata.json": 1,
+            }
+        )
+
+        with patch(
+            "solace_agent_mesh.agent.utils.artifact_helpers.load_artifact_content_or_metadata",
+            new_callable=AsyncMock,
+        ) as mock_load:
+            mock_load.return_value = {
+                "metadata": {"mime_type": "text/plain", "size_bytes": 50},
+                "version": 3,
+            }
+            result = await get_artifact_info_list_fast(
+                artifact_service=svc,
+                app_name="app",
+                user_id="user",
+                session_id="sess",
+            )
+
+        # list_artifact_keys (the old per-artifact-version-resolving path) must
+        # not be called when the richer method is available.
+        assert not hasattr(svc, "list_artifact_keys") or not svc.list_artifact_keys.called
+        # Both content files come back, metadata sidecars are filtered out.
+        assert {r.filename for r in result} == {"report.csv", "notes.txt"}
+        # Each load was called with a concrete int version sourced from the map,
+        # never the "latest" sentinel.
+        load_versions = [call.kwargs["version"] for call in mock_load.call_args_list]
+        assert "latest" not in load_versions
+        assert sorted(load_versions) == [1, 3]
+
+    @pytest.mark.asyncio
+    async def test_keys_with_versions_falls_back_to_latest_when_metadata_missing(self):
+        """If the version map lacks a metadata sidecar for a content key
+        (unexpected, but defensive), the loader is asked for 'latest' so the
+        artifact still resolves rather than silently dropping."""
+        svc = AsyncMock(spec=BaseArtifactService)
+        svc.list_artifact_keys_with_latest_versions = AsyncMock(
+            return_value={
+                # Only the content key; no .metadata.json entry.
+                "orphan.bin": 7,
+            }
+        )
+
+        with patch(
+            "solace_agent_mesh.agent.utils.artifact_helpers.load_artifact_content_or_metadata",
+            new_callable=AsyncMock,
+        ) as mock_load:
+            mock_load.return_value = {
+                "metadata": {"mime_type": "application/octet-stream", "size_bytes": 1},
+                "version": 7,
+            }
+            await get_artifact_info_list_fast(
+                artifact_service=svc,
+                app_name="app",
+                user_id="user",
+                session_id="sess",
+            )
+
+        assert mock_load.call_args.kwargs["version"] == "latest"


### PR DESCRIPTION
## Summary

Two complementary changes to the `/api/v1/artifacts/all` S3 hot path. Either reverts cleanly on its own.

**1. Bound concurrent artifact-metadata S3 loads (`artifact_helpers.py`)**

`get_artifact_info_list_fast` did an unbounded `asyncio.gather` over every artifact's metadata in a session. The router caps concurrent *sessions* at 10 but the per-session fan-out had no limit, so under multi-user load the combined fan-out exceeded the botocore S3 connection pool (default 200). In production today the WebUI pod was emitting ~1,900 `Connection pool is full, discarding connection: s3-ca-central-1.amazonaws.com. Connection pool size: 200` warnings per hour. The pool would saturate, the FastAPI event loop would stall on TLS handshakes for unrelated requests, and every endpoint sharing the loop (`/auth/refresh`, `/sessions`, `/projects`, `/artifacts/*`) showed p50 ~15 s / p90 ~62 s.

Add a module-level `asyncio.Semaphore(50)` and gate each metadata S3 call with it, releasing as soon as the call returns so dict post-processing isn't held in the critical section. 50 keeps useful parallelism while staying well under the 200-conn pool and leaving headroom for artifact-content fetches and other S3 traffic.

**2. Skip per-artifact `list_versions` on the list path (`s3_artifact_service.py`, `artifact_helpers.py`)**

`get_artifact_info_list_fast` was making two S3 calls per artifact: one to load the `metadata.json`, and one inside `load_artifact_content_or_metadata` to resolve `"latest"` via `list_versions`. The `ListObjectsV2` walk that `list_artifact_keys` already runs sees every versioned key — the previous code just threw the version segment away.

Add `list_artifact_keys_with_latest_versions` on `S3ArtifactService` that returns `{filename: max_version}` from the same paginated walk. `get_artifact_info_list_fast` uses it via duck typing (other `ArtifactService` implementations keep the old path) to pass a concrete metadata version into `load_artifact_content_or_metadata`, which then skips its internal `list_versions` resolve step.

Halves S3 round-trips on the list path without changing the response shape — the `version` field on each card is still populated (the loader returns whichever version it loaded, whether resolved or passed in).

## Test plan

- [x] `TestGetArtifactInfoListFast` — 8 tests pass (6 existing + 2 new covering fast-path version-skip and metadata-missing fallback).
- [x] `TestS3ArtifactServiceListArtifactKeysWithLatestVersions` — 4 new tests covering max-version selection, user-prefix, non-integer-version safety, and partial-failure behaviour.
- [x] `TestS3ArtifactServiceListArtifactKeys` — 5 existing tests still pass (unchanged path).
- [ ] After deploy: confirm `"Connection pool is full"` warning rate drops to ~0 on the webui pod and `/api/v1/artifacts/all` p95 returns to single-digit seconds. Unrelated endpoints (`/sessions`, `/auth/refresh`) should also drop back to sub-second once the loop isn't stalled on TLS handshakes.