### PR TITLE
fix(DATAGO-127291): use project store for projects-page downloads

### DIFF
--- a/client/webui/frontend/src/lib/hooks/useDownload.ts
+++ b/client/webui/frontend/src/lib/hooks/useDownload.ts
@@ -32,7 +32,8 @@ export const useDownload = (projectIdOverride?: string | null) => {
     const onDownload = async (artifact: ArtifactInfo) => {
         try {
             const effectiveProjectId = projectIdOverride || activeProject?.id || null;
-            await downloadArtifactFile(sessionId, effectiveProjectId, artifact);
+            const effectiveSessionId = projectIdOverride ? null : sessionId;
+            await downloadArtifactFile(effectiveSessionId, effectiveProjectId, artifact);
             addNotification(`Downloaded artifact: ${artifact.filename}.`, "success");
         } catch (error) {
             displayError({ title: "Failed to Download Artifact", error: getErrorMessage(error, "An unknown error occurred while downloading the artifact.") });


### PR DESCRIPTION
### What is the purpose of this change?

When both a session ID and a project ID are sent to the download endpoint, the backend prefers the session ID — but a file uploaded straight to the project from the projects tab isn't in the chat session's artifact store yet, so the lookup fails. Downloads initiated from the projects page should resolve against the project store only.

### How was this change implemented?

- `client/webui/frontend/src/lib/hooks/useDownload.ts`: when `projectIdOverride` is supplied (the projects-page call path), pass `null` as the session ID to `downloadArtifactFile` so the request is resolved against the project store and never falls through to the session store.

### How was this change tested?

- [x] Manual testing: reproduced the bug per the steps in DATAGO-127291 (create project + chat session, upload a new file from the projects tab, return to projects page, download the new file) and confirmed the download now succeeds.
- [ ] Unit tests: none added — the change is a one-line conditional in a small hook.
- [ ] Integration tests: n/a
- [ ] Known limitations: only the projects-page download path was exercised; chat-session downloads were not re-verified.

### Is there anything the reviewers should focus on/be aware of?
