### PR TITLE
fix: bump python-liquid and add tar override for security vulnerabilities

### DIFF
--- a/client/webui/frontend/package.json
+++ b/client/webui/frontend/package.json
@@ -182,7 +182,8 @@
         "lodash-es": "^4.18.0",
         "lodash": ">=4.18.0",
         "flatted": ">=3.4.2",
-        "serialize-javascript": ">=7.0.3"
+        "serialize-javascript": ">=7.0.3",
+        "tar": ">=7.5.11"
     },
     "msw": {
         "workerDirectory": [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,7 @@ dependencies = [
     "pyjwt>=2.12.0",  # [CVE-2026-32597] Security fix: validates the crit (Critical) Header Parameter in JWS tokens (transitive from a2a-sdk, msal)
     "asteval==1.0.6",
     "pystache==0.6.8",
-    "python-liquid==2.1.0",
+    "python-liquid==2.2.0",  # [CVE-2026-45017] Security fix: addresses template injection vulnerability
     "pandas==2.3.2",
     "numpy==2.2.6",
     "plotly==6.3.0",

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 3
+revision = 2
 requires-python = ">=3.10.16, <3.14"
 resolution-markers = [
     "python_full_version >= '3.13' and sys_platform == 'win32'",
@@ -4084,7 +4084,7 @@ wheels = [
 
 [[package]]
 name = "python-liquid"
-version = "2.1.0"
+version = "2.2.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "babel" },
@@ -4092,9 +4092,9 @@ dependencies = [
     { name = "python-dateutil" },
     { name = "pytz" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/cc/46/3b2731966bf24a1cab027eae3c87c41e379750a7dd8c7041c37b9a29d168/python_liquid-2.1.0.tar.gz", hash = "sha256:a4c2abb24ac40ded8c9ba844ebbfbe78a3e41c6fe10a7bbe94144582569b73d0", size = 93152, upload-time = "2025-08-15T07:33:26.019Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/96/15/f76284f919bd1eda0490b4fc34b416ccb10dcb20628b4afe133bf1c03366/python_liquid-2.2.0.tar.gz", hash = "sha256:ee3cda2ce6e9ef873a9d0e5180ad1de38dc39bf05044d8a6459ca1b999dbe13e", size = 95137, upload-time = "2026-05-06T17:51:28.888Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/c0/0d/8c0cc6895ff2ec26b963f055ff2514596e71b509cde3b9ffbbf0f7f59995/python_liquid-2.1.0-py3-none-any.whl", hash = "sha256:d3bbcddff4e1a73287b59218df3471613598271e69ac3d17d97e000f4b984e3e", size = 137984, upload-time = "2025-08-15T07:33:24.274Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/1b/33701a1ee066054a1e6ae1ec27540dd86f63c6138d214985599440c2a0dc/python_liquid-2.2.0-py3-none-any.whl", hash = "sha256:4d71b3f2c0147ffe150ba84e252b8c71e04f12c60a1d770962b0c8c977419f09", size = 140932, upload-time = "2026-05-06T17:51:27.468Z" },
 ]
 
 [[package]]
@@ -4851,7 +4851,7 @@ requires-dist = [
     { name = "python-docx", specifier = "==1.2.0" },
     { name = "python-dotenv", specifier = "==1.2.2" },
     { name = "python-jwt", specifier = "==4.1.0" },
-    { name = "python-liquid", specifier = "==2.1.0" },
+    { name = "python-liquid", specifier = "==2.2.0" },
     { name = "python-multipart", specifier = "==0.0.27" },
     { name = "python-pptx", specifier = "==1.0.2" },
     { name = "pyyaml", specifier = "==6.0.2" },


### PR DESCRIPTION
## Summary
- Bump `python-liquid` from 2.1.0 to 2.2.0 to fix CVE-2026-45017 (template injection vulnerability)
- Add `tar` npm override (>=7.5.11) to fix 6 HIGH CVEs in transitive dependencies

## Test plan
- [ ] Verify `uv lock` succeeds after python-liquid bump
- [ ] Verify `npm install` succeeds in `client/webui/frontend/`
- [ ] Run existing tests to ensure no regressions

🤖 Generated with [Claude Code](https://claude.ai/code)