### PR TITLE
fix(DATAGO-132491): bump mako to 1.3.12 for security vulnerabilities

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,6 +68,7 @@ dependencies = [
     "rouge==1.0.1",
     "SQLAlchemy==2.0.40",
     "alembic==1.16.5",
+    "mako>=1.3.12",  # [CVE-2026-44307, CVE-2026-41205] Security fix: path traversal vulnerabilities (transitive from alembic)
     "openai==2.24.0",
     "rich==13.9.4",
     "boto3==1.40.37",

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 3
+revision = 2
 requires-python = ">=3.10.16, <3.14"
 resolution-markers = [
     "python_full_version >= '3.13' and sys_platform == 'win32'",
@@ -4715,6 +4715,7 @@ dependencies = [
     { name = "kaleido" },
     { name = "litellm" },
     { name = "lxml" },
+    { name = "mako" },
     { name = "markdownify" },
     { name = "markitdown", extra = ["all"] },
     { name = "mermaid-cli" },
@@ -4821,6 +4822,7 @@ requires-dist = [
     { name = "kaleido", specifier = "==0.2.1" },
     { name = "litellm", specifier = "==1.83.14" },
     { name = "lxml", specifier = "==6.1.0" },
+    { name = "mako", specifier = ">=1.3.12" },
     { name = "markdownify", specifier = "==1.2.0" },
     { name = "markitdown", extras = ["all"], specifier = "==0.1.4" },
     { name = "mermaid-cli", specifier = "==0.1.2" },


### PR DESCRIPTION
## Summary
- Add mako>=1.3.12 as direct dependency to fix path traversal vulnerabilities
- CVE-2026-44307 (CVSS 8.7) 
- CVE-2026-41205 (CVSS 7.7)

Fixes: [DATAGO-132491](https://sol-jira.atlassian.net/browse/DATAGO-132491)

## Test plan
- [x] Verify lockfile resolves correctly
- [x] Run unit tests

🤖 Generated with [Claude Code](https://claude.ai/code)

[DATAGO-132491]: https://sol-jira.atlassian.net/browse/DATAGO-132491?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ