### PR TITLE
fix(DATAGO-136970): bump ffmpeg to 7.1.4 for CVE-2026-40962

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -68,7 +68,7 @@ RUN echo "deb http://deb.debian.org/debian unstable main" > /etc/apt/sources.lis
     build-essential \
     curl \
     dpkg=1.22.22 \
-    ffmpeg=7:7.1.3-0+deb13u1  \
+    ffmpeg=7:7.1.4-0+deb13u1  \
     git \
     libc6=2.41-12+deb13u3 \
     libtasn1-6/unstable \
@@ -164,7 +164,7 @@ RUN echo "deb http://deb.debian.org/debian unstable main" > /etc/apt/sources.lis
     apt-get update && \
     apt-get install -y --no-install-recommends \
     dpkg=1.22.22 \
-    ffmpeg=7:7.1.3-0+deb13u1 \
+    ffmpeg=7:7.1.4-0+deb13u1 \
     git \
     libatomic1 \
     libc6=2.41-12+deb13u3 \


### PR DESCRIPTION
## Summary
- Bump ffmpeg from 7:7.1.3-0+deb13u1 to 7:7.1.4-0+deb13u1
- Fixes CVE-2026-40962 (CVSS 9.8 Critical) - integer overflow and out-of-bounds write via CENC subsample data

Fixes: [DATAGO-136970](https://sol-jira.atlassian.net/browse/DATAGO-136970)

## Test plan
- [x] Docker build succeeds
- [x] Image scans clean for CVE-2026-40962

🤖 Generated with [Claude Code](https://claude.ai/code)

[DATAGO-136970]: https://sol-jira.atlassian.net/browse/DATAGO-136970?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ