### PR TITLE
fix(DATAGO-137349): pin libcap2 to 1:2.75-10+deb13u1+b1 for CVE-2026-4878

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -61,6 +61,7 @@ COPY --from=node-binaries /usr/local/lib/node_modules /usr/local/lib/node_module
 # Add unstable repo with APT pinning to only upgrade libtasn1-6 (CVE-2025-13151 fix)
 # Pin libc6=2.41-12+deb13u3 to fix CVE-2026-0861, CVE-2026-0915, CVE-2025-15281 (glibc vulnerabilities)
 # Pin dpkg=1.22.22 to fix CVE-2026-2219 (denial of service via zstd-compressed .deb archives)
+# Pin libcap2=1:2.75-10+deb13u1+b1 to fix CVE-2026-4878 (TOCTOU race condition)
 RUN echo "deb http://deb.debian.org/debian unstable main" > /etc/apt/sources.list.d/unstable.list && \
     printf "Package: *\nPin: release a=unstable\nPin-Priority: 50\n\nPackage: libtasn1-6\nPin: release a=unstable\nPin-Priority: 900\n" > /etc/apt/preferences.d/99pin-libtasn1 && \
     apt-get update && \
@@ -71,6 +72,7 @@ RUN echo "deb http://deb.debian.org/debian unstable main" > /etc/apt/sources.lis
     ffmpeg=7:7.1.3-0+deb13u1  \
     git \
     libc6=2.41-12+deb13u3 \
+    libcap2=1:2.75-10+deb13u1+b1 \
     libtasn1-6/unstable \
     libpng16-16t64=1.6.48-1+deb13u5 \
     libsqlite3-0=3.46.1-7+deb13u1 \
@@ -159,6 +161,7 @@ COPY --from=node-binaries /usr/local/lib/node_modules /usr/local/lib/node_module
 # Add unstable repo with APT pinning to only upgrade libtasn1-6 (CVE-2025-13151 fix)
 # Pin libc6=2.41-12+deb13u3 to fix CVE-2026-0861, CVE-2026-0915, CVE-2025-15281 (glibc vulnerabilities)
 # Pin dpkg=1.22.22 to fix CVE-2026-2219 (denial of service via zstd-compressed .deb archives)
+# Pin libcap2=1:2.75-10+deb13u1+b1 to fix CVE-2026-4878 (TOCTOU race condition)
 RUN echo "deb http://deb.debian.org/debian unstable main" > /etc/apt/sources.list.d/unstable.list && \
     printf "Package: *\nPin: release a=unstable\nPin-Priority: 50\n\nPackage: libtasn1-6\nPin: release a=unstable\nPin-Priority: 900\n" > /etc/apt/preferences.d/99pin-libtasn1 && \
     apt-get update && \
@@ -168,6 +171,7 @@ RUN echo "deb http://deb.debian.org/debian unstable main" > /etc/apt/sources.lis
     git \
     libatomic1 \
     libc6=2.41-12+deb13u3 \
+    libcap2=1:2.75-10+deb13u1+b1 \
     libtasn1-6/unstable \
     libpng16-16t64=1.6.48-1+deb13u5 \
     libsqlite3-0=3.46.1-7+deb13u1 \


### PR DESCRIPTION
## Summary
- Pin libcap2 to 1:2.75-10+deb13u1+b1 in both builder and runtime stages
- Fixes CVE-2026-4878 (CVSS 7.0 High) - TOCTOU race condition in cap_set_file()

Fixes: [DATAGO-137349](https://sol-jira.atlassian.net/browse/DATAGO-137349)

## Test plan
- [ ] Docker build succeeds
- [ ] Image scans clean for CVE-2026-4878

🤖 Generated with [Claude Code](https://claude.ai/code)

[DATAGO-137349]: https://sol-jira.atlassian.net/browse/DATAGO-137349?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ