### PR TITLE
fix(DATAGO-134066): bump authlib to 1.6.12+ for CVE-2026-41425, CVE-2026-44681

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -84,7 +84,7 @@ dependencies = [
     "google-cloud-storage==3.9.0",
     "azure-identity>=1.17.0",
     "azure-storage-blob==12.28.0",
-    "authlib>=1.6.9",  # [CVE-2026-27962] Security fix: GHSA-wvwj-cvrp-7pv5 JWK Header Injection
+    "authlib>=1.6.12",  # [CVE-2026-27962, CVE-2026-41425, CVE-2026-44681] Security fixes
     "pyasn1>=0.6.3",  # [CVE-2026-30922] Security fix: Prevents DoS via unbounded recursion in ASN.1 decoder
     "cachetools==7.0.1",
     "openfeature-sdk==0.8.4",

--- a/uv.lock
+++ b/uv.lock
@@ -337,14 +337,15 @@ wheels = [
 
 [[package]]
 name = "authlib"
-version = "1.6.9"
+version = "1.7.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "cryptography" },
+    { name = "joserfc" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/af/98/00d3dd826d46959ad8e32af2dbb2398868fd9fd0683c26e56d0789bd0e68/authlib-1.6.9.tar.gz", hash = "sha256:d8f2421e7e5980cc1ddb4e32d3f5fa659cfaf60d8eaf3281ebed192e4ab74f04", size = 165134, upload-time = "2026-03-02T07:44:01.998Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/36/98/7d93f30d029643c0275dbc0bd6d5a6f670661ee6c9a94d93af7ab4887600/authlib-1.7.2.tar.gz", hash = "sha256:2cea25fefcd4e7173bdf1372c0afc265c8034b23a8cd5dcb6a9164b826c64231", size = 176511, upload-time = "2026-05-06T08:10:23.116Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/53/23/b65f568ed0c22f1efacb744d2db1a33c8068f384b8c9b482b52ebdbc3ef6/authlib-1.6.9-py2.py3-none-any.whl", hash = "sha256:f08b4c14e08f0861dc18a32357b33fbcfd2ea86cfe3fe149484b4d764c4a0ac3", size = 244197, upload-time = "2026-03-02T07:44:00.307Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/95/adcb68e20c34162e9135f370d6e31737719c2b6f94bc953fe7ed1f10fe21/authlib-1.7.2-py2.py3-none-any.whl", hash = "sha256:3e1faedc9d87e7d56a164eca3ccb6ace0d61b94abe83e92242f8dc8bba9b4a9f", size = 259548, upload-time = "2026-05-06T08:10:21.436Z" },
 ]
 
 [[package]]
@@ -2288,6 +2289,18 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/00/2a/e867e8531cf3e36b41201936b7fa7ba7b5702dbef42922193f05c8976cd6/jmespath-1.0.1.tar.gz", hash = "sha256:90261b206d6defd58fdd5e85f478bf633a2901798906be2ad389150c5c60edbe", size = 25843, upload-time = "2022-06-17T18:00:12.224Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/31/b4/b9b800c45527aadd64d5b442f9b932b00648617eb5d63d2c7a6587b7cafc/jmespath-1.0.1-py3-none-any.whl", hash = "sha256:02e2e4cc71b5bcab88332eebf907519190dd9e6e82107fa7f83b1003a6252980", size = 20256, upload-time = "2022-06-17T18:00:10.251Z" },
+]
+
+[[package]]
+name = "joserfc"
+version = "1.6.7"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cryptography" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/1b/cb/52e479f20804904f5df20ac4539d292dcecd1287aaa33cba1d1def1d9d8e/joserfc-1.6.7.tar.gz", hash = "sha256:6999fe89457069ecacd8cc797c88a805f83054dd883333fa0409f74b46479fd7", size = 232158, upload-time = "2026-05-23T01:46:44.069Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c5/e4/bcf6718b5662894c6831f46296b73cd4b1a2e90c20b6d437e20c4997388c/joserfc-1.6.7-py3-none-any.whl", hash = "sha256:9e51e4a64840aa1734a058258e80a4480e2ff2d5686e480e7c92c954a92fbe05", size = 70603, upload-time = "2026-05-23T01:46:42.129Z" },
 ]
 
 [[package]]
@@ -4789,7 +4802,7 @@ requires-dist = [
     { name = "apscheduler", specifier = "==3.10.4" },
     { name = "asteval", specifier = "==1.0.6" },
     { name = "asyncpg", marker = "extra == 'test'" },
-    { name = "authlib", specifier = ">=1.6.9" },
+    { name = "authlib", specifier = ">=1.6.12" },
     { name = "azure-cognitiveservices-speech", specifier = "==1.41.1" },
     { name = "azure-identity", specifier = ">=1.17.0" },
     { name = "azure-storage-blob", specifier = "==12.28.0" },


### PR DESCRIPTION
## Summary
- Bump authlib from >=1.6.9 to >=1.6.12 (resolved to 1.7.2)
- Fixes CVE-2026-41425 (CVSS 5.4 Medium) - CSRF vulnerability
- Fixes CVE-2026-44681 (CVSS 6.1 Medium) - General vulnerability

Fixes: [DATAGO-134066](https://sol-jira.atlassian.net/browse/DATAGO-134066)

## Test plan
- [ ] Unit tests pass
- [ ] Lockfile resolves correctly

🤖 Generated with [Claude Code](https://claude.ai/code)

[DATAGO-134066]: https://sol-jira.atlassian.net/browse/DATAGO-134066?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ