### PR TITLE
fix(DATAGO-137348): bump idna to 3.15 for CVE-2026-45409

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,6 +28,7 @@ dependencies = [
     "python-dotenv==1.2.2",
     "google-genai==1.49.0",
     "httpx==0.28.1",
+    "idna==3.15",  # [CVE-2026-45409] Security fix (transitive from httpx, requests)
     "jwcrypto==1.5.6",
     "python-jwt==4.1.0",
     "pyjwt>=2.12.0",  # [CVE-2026-32597] Security fix: validates the crit (Critical) Header Parameter in JWS tokens (transitive from a2a-sdk, msal)

--- a/uv.lock
+++ b/uv.lock
@@ -2106,11 +2106,11 @@ wheels = [
 
 [[package]]
 name = "idna"
-version = "3.11"
+version = "3.15"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/6f/6d/0703ccc57f3a7233505399edb88de3cbd678da106337b9fcde432b65ed60/idna-3.11.tar.gz", hash = "sha256:795dafcc9c04ed0c1fb032c2aa73654d8e8c5023a7df64a53f39190ada629902", size = 194582, upload-time = "2025-10-12T14:55:20.501Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/82/77/7b3966d0b9d1d31a36ddf1746926a11dface89a83409bf1483f0237aa758/idna-3.15.tar.gz", hash = "sha256:ca962446ea538f7092a95e057da437618e886f4d349216d2b1e294abfdb65fdc", size = 199245, upload-time = "2026-05-12T22:45:57.011Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/0e/61/66938bbb5fc52dbdf84594873d5b51fb1f7c7794e9c0f5bd885f30bc507b/idna-3.11-py3-none-any.whl", hash = "sha256:771a87f49d9defaf64091e6e6fe9c18d4833f140bd19464795bc32d966ca37ea", size = 71008, upload-time = "2025-10-12T14:55:18.883Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/23/408243171aa9aaba178d3e2559159c24c1171a641aa83b67bdd3394ead8e/idna-3.15-py3-none-any.whl", hash = "sha256:048adeaf8c2d788c40fee287673ccaa74c24ffd8dcf09ffa555a2fbb59f10ac8", size = 72340, upload-time = "2026-05-12T22:45:55.733Z" },
 ]
 
 [[package]]
@@ -4707,6 +4707,7 @@ dependencies = [
     { name = "google-genai" },
     { name = "holidays" },
     { name = "httpx" },
+    { name = "idna" },
     { name = "itsdangerous" },
     { name = "jaraco-context" },
     { name = "jmespath" },
@@ -4814,6 +4815,7 @@ requires-dist = [
     { name = "holidays", marker = "extra == 'employee-tools'", specifier = "==0.81.0" },
     { name = "httpx", specifier = "==0.28.1" },
     { name = "httpx", marker = "extra == 'test'", specifier = ">=0.25" },
+    { name = "idna", specifier = "==3.15" },
     { name = "itsdangerous", specifier = "==2.2.0" },
     { name = "jaraco-context", specifier = "==6.1.0" },
     { name = "jmespath", specifier = "==1.0.1" },


### PR DESCRIPTION
## Summary
- Add idna==3.15 as direct dependency to override transitive version
- Fixes CVE-2026-45409 (CVSS 6.9 Medium)

Fixes: [DATAGO-137348](https://sol-jira.atlassian.net/browse/DATAGO-137348)

## Test plan
- [ ] Unit tests pass
- [ ] Lockfile resolves correctly

🤖 Generated with [Claude Code](https://claude.ai/code)

[DATAGO-137348]: https://sol-jira.atlassian.net/browse/DATAGO-137348?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ