### PR TITLE
fix(DATAGO-135331): bump npm to 11.15.0 for CVE-2026-42338, CVE-2026-45149

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -193,7 +193,8 @@ RUN echo "deb http://deb.debian.org/debian unstable main" > /etc/apt/sources.lis
     rm -rf /var/lib/apt/lists/* /etc/apt/sources.list.d/unstable.list /etc/apt/preferences.d/99pin-libtasn1
 
 # Node 25.5.0 ships with npm 11.8.0; upgrade to pick up security fixes in bundled dependencies
-RUN node /usr/local/lib/node_modules/npm/bin/npm-cli.js install -g npm@11.13.0
+# Upgrade npm to fix CVE-2026-42338 (ip-address XSS vulnerability)
+RUN node /usr/local/lib/node_modules/npm/bin/npm-cli.js install -g npm@11.15.0
 
 # Install playwright temporarily just for browser installation (cached layer)
 # This is separate from the full venv to keep this layer cached


### PR DESCRIPTION
## Summary
- Bump npm from 11.13.0 to 11.15.0
- Fixes CVE-2026-42338 (CVSS 6.1 Medium) - ip-address XSS vulnerability
- Fixes CVE-2026-45149 (CVSS 6.5 Medium) - brace-expansion vulnerability

Fixes: [DATAGO-135331](https://sol-jira.atlassian.net/browse/DATAGO-135331)
Fixes: [DATAGO-130674](https://sol-jira.atlassian.net/browse/DATAGO-130674)

## Test plan
- [x] Docker build succeeds
- [x] Image scans clean for CVE-2026-42338 and CVE-2026-45149

🤖 Generated with [Claude Code](https://claude.ai/code)

[DATAGO-135331]: https://sol-jira.atlassian.net/browse/DATAGO-135331?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[DATAGO-130674]: https://sol-jira.atlassian.net/browse/DATAGO-130674?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ