### PR TITLE
feat(DATAGO-138153): add Agent Mode — a chat-only view pinned to a single agent

### DIFF
--- a/client/webui/frontend/src/AppLayout.tsx
+++ b/client/webui/frontend/src/AppLayout.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState, useCallback } from "react";
 import { Outlet, useLocation, useNavigate } from "react-router-dom";
 
 import { NavigationSidebar, CollapsibleNavigationSidebar, ToastContainer, bottomNavigationItems, getTopNavigationItems, EmptyState } from "@/lib/components";
+import { Button } from "@/lib/components/ui/button";
 import { SelectionContextMenu, useTextSelection } from "@/lib/components/chat/selection";
 import { MoveSessionDialog } from "@/lib/components/chat/MoveSessionDialog";
 import { ModelSetupDialog } from "@/lib/components/models/ModelSetupDialog";
@@ -17,7 +18,7 @@ function AppLayoutContent() {
     const location = useLocation();
     const navigate = useNavigate();
     const { isAuthenticated, login, logout, useAuthorization } = useAuthContext();
-    const { configFeatureEnablement } = useConfigContext();
+    const { configFeatureEnablement, agentMode } = useConfigContext();
     const { value: modelConfigUiEnabled } = useBooleanFlagDetails("model_config_ui", false);
     const { isMenuOpen, menuPosition, selectedText, sourceTaskId, clearSelection } = useTextSelection();
     const { hasModelConfigWrite } = useChatContext();
@@ -106,6 +107,15 @@ function AppLayoutContent() {
     };
 
     if (useAuthorization && !isAuthenticated) {
+        if (agentMode) {
+            return (
+                <div className="flex h-screen w-screen items-center justify-center">
+                    <Button testid="Login" title="Login" variant="default" onClick={() => login()}>
+                        Login
+                    </Button>
+                </div>
+            );
+        }
         return (
             <EmptyState
                 variant="noImage"
@@ -140,7 +150,7 @@ function AppLayoutContent() {
         <div className={`relative flex h-screen`}>
             {useNewNav ? (
                 <CollapsibleNavigationSidebar items={items} activeItemId={activeItemId} showNewChatButton showRecentChats />
-            ) : (
+            ) : agentMode ? null : (
                 <NavigationSidebar items={topNavItems} bottomItems={bottomNavigationItems} activeItem={getActiveItem()} onItemChange={handleNavItemChange} onHeaderClick={handleHeaderClick} />
             )}
             <main className="flex h-full w-full min-w-0 flex-1 flex-col">

--- a/client/webui/frontend/src/AppLayout.tsx
+++ b/client/webui/frontend/src/AppLayout.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useState, useCallback } from "react";
 import { Outlet, useLocation, useNavigate } from "react-router-dom";
 
-import { NavigationSidebar, CollapsibleNavigationSidebar, ToastContainer, bottomNavigationItems, getTopNavigationItems, EmptyState } from "@/lib/components";
+import { NavigationSidebar, CollapsibleNavigationSidebar, ToastContainer, bottomNavigationItems, getTopNavigationItems } from "@/lib/components";
 import { Button } from "@/lib/components/ui/button";
 import { SelectionContextMenu, useTextSelection } from "@/lib/components/chat/selection";
 import { MoveSessionDialog } from "@/lib/components/chat/MoveSessionDialog";
@@ -107,28 +107,12 @@ function AppLayoutContent() {
     };
 
     if (useAuthorization && !isAuthenticated) {
-        if (agentMode) {
-            return (
-                <div className="flex h-screen w-screen items-center justify-center">
-                    <Button testid="Login" title="Login" variant="default" onClick={() => login()}>
-                        Login
-                    </Button>
-                </div>
-            );
-        }
         return (
-            <EmptyState
-                variant="noImage"
-                title="Welcome to Solace Agent Mesh!"
-                className="h-screen w-screen"
-                buttons={[
-                    {
-                        text: "Login",
-                        onClick: () => login(),
-                        variant: "default",
-                    },
-                ]}
-            />
+            <div className="flex h-screen w-screen items-center justify-center">
+                <Button testid="Login" title="Login" variant="default" onClick={() => login()}>
+                    Login
+                </Button>
+            </div>
         );
     }
 

--- a/client/webui/frontend/src/auth/authCallback.tsx
+++ b/client/webui/frontend/src/auth/authCallback.tsx
@@ -1,5 +1,7 @@
 import { useEffect } from "react";
 
+import { consumePostLoginRedirect } from "@/lib/utils/url";
+
 function AuthCallback() {
     useEffect(() => {
         const hash = window.location.hash.substring(1);
@@ -16,8 +18,9 @@ function AuthCallback() {
             if (refreshToken) {
                 localStorage.setItem("refresh_token", refreshToken);
             }
-            // Redirect to the main application page
-            window.location.href = "/";
+            // Redirect back to the URL the user left from (restores Agent Mode
+            // params dropped by the IdP round-trip), or "/" if none was stashed.
+            window.location.href = consumePostLoginRedirect();
         } else {
             console.error("AuthCallback: No access token found in URL hash.");
         }

--- a/client/webui/frontend/src/lib/api/client.ts
+++ b/client/webui/frontend/src/lib/api/client.ts
@@ -1,4 +1,5 @@
 import { getApiBearerToken, getSamAccessToken } from "@/lib/utils/api";
+import { stashPostLoginRedirect } from "@/lib/utils/url";
 
 interface RequestOptions {
     headers?: HeadersInit;
@@ -167,6 +168,7 @@ const refreshToken = async () => {
         }
 
         clearTokens();
+        stashPostLoginRedirect();
         globalThis.location.href = "/api/v1/auth/login";
         return null;
     })()
@@ -274,6 +276,7 @@ const authenticatedFetch = async (url: string, options: RequestInit = {}) => {
             // Redirect to login to break any external retry loop.
             if (retryResponse.status === 401) {
                 clearTokens();
+                stashPostLoginRedirect();
                 globalThis.location.href = "/api/v1/auth/login";
                 // Navigation is async — return the 401 as-is; the page will
                 // navigate away before callers can act on it.

--- a/client/webui/frontend/src/lib/components/chat/AgentModeWelcome.tsx
+++ b/client/webui/frontend/src/lib/components/chat/AgentModeWelcome.tsx
@@ -1,0 +1,16 @@
+import React from "react";
+
+import { MessageCircle } from "lucide-react";
+
+interface AgentModeWelcomeProps {
+    message?: string;
+}
+
+export const AgentModeWelcome: React.FC<AgentModeWelcomeProps> = ({ message }) => {
+    return (
+        <div className="flex min-h-0 flex-1 flex-col items-center justify-center gap-4">
+            <MessageCircle className="size-12 text-(--secondary-text-wMain)" />
+            <p className="text-2xl font-medium text-(--primary-text-wMain)">{message || "How can I help?"}</p>
+        </div>
+    );
+};

--- a/client/webui/frontend/src/lib/components/chat/AgentModeWelcome.tsx
+++ b/client/webui/frontend/src/lib/components/chat/AgentModeWelcome.tsx
@@ -1,16 +1,9 @@
 import React from "react";
 
-import { MessageCircle } from "lucide-react";
-
 interface AgentModeWelcomeProps {
     message?: string;
 }
 
 export const AgentModeWelcome: React.FC<AgentModeWelcomeProps> = ({ message }) => {
-    return (
-        <div className="flex min-h-0 flex-1 flex-col items-center justify-center gap-4">
-            <MessageCircle className="size-12 text-(--secondary-text-wMain)" />
-            <p className="text-2xl font-medium text-(--primary-text-wMain)">{message || "How can I help?"}</p>
-        </div>
-    );
+    return <h1 className="text-foreground text-center text-3xl font-semibold tracking-tight">{message || "How can I help?"}</h1>;
 };

--- a/client/webui/frontend/src/lib/components/chat/ChatInputArea.tsx
+++ b/client/webui/frontend/src/lib/components/chat/ChatInputArea.tsx
@@ -1160,27 +1160,31 @@ export const ChatInputArea: React.FC<{ agents: AgentCardInfo[]; scrollToBottom?:
                     </Button>
                 )}
 
-                <div className="hidden @[480px]:block">Agent: </div>
-                <Select
-                    value={selectedAgentName}
-                    onValueChange={agentName => {
-                        handleAgentSelection(agentName);
-                    }}
-                    disabled={isResponding || agents.length === 0}
-                >
-                    <SelectTrigger className="w-[250px]">
-                        <SelectValue placeholder="Select an agent..." />
-                    </SelectTrigger>
-                    <SelectContent>
-                        {agents
-                            .filter(agent => !agent.isWorkflow)
-                            .map(agent => (
-                                <SelectItem key={agent.name} value={agent.name}>
-                                    {agent.displayName || agent.name}
-                                </SelectItem>
-                            ))}
-                    </SelectContent>
-                </Select>
+                {!agentMode && (
+                    <>
+                        <div className="hidden @[480px]:block">Agent: </div>
+                        <Select
+                            value={selectedAgentName}
+                            onValueChange={agentName => {
+                                handleAgentSelection(agentName);
+                            }}
+                            disabled={isResponding || agents.length === 0}
+                        >
+                            <SelectTrigger className="w-[250px]">
+                                <SelectValue placeholder="Select an agent..." />
+                            </SelectTrigger>
+                            <SelectContent>
+                                {agents
+                                    .filter(agent => !agent.isWorkflow)
+                                    .map(agent => (
+                                        <SelectItem key={agent.name} value={agent.name}>
+                                            {agent.displayName || agent.name}
+                                        </SelectItem>
+                                    ))}
+                            </SelectContent>
+                        </Select>
+                    </>
+                )}
 
                 {/* Spacer to push buttons to the right */}
                 <div className="flex-1" />

--- a/client/webui/frontend/src/lib/components/chat/ChatInputArea.tsx
+++ b/client/webui/frontend/src/lib/components/chat/ChatInputArea.tsx
@@ -83,7 +83,7 @@ export const ChatInputArea: React.FC<{ agents: AgentCardInfo[]; scrollToBottom?:
     } = useChatContext();
     const { handleAgentSelection } = useAgentSelection();
     const { settings } = useAudioSettings();
-    const { configFeatureEnablement } = useConfigContext();
+    const { configFeatureEnablement, agentMode } = useConfigContext();
     const { value: modelConfigUiEnabled } = useBooleanFlagDetails("model_config_ui", false);
     const { value: artifactAttachmentEnabled } = useBooleanFlagDetails("artifact_attachment", false);
     const { data: modelConfigStatus } = useModelConfigStatus();
@@ -417,8 +417,11 @@ export const ChatInputArea: React.FC<{ agents: AgentCardInfo[]; scrollToBottom?:
     }, [selectedArtifactRefs.length]);
 
     const isSubmittingEnabled = useMemo(
-        () => !isResponding && !modelNotConfigured && (inputValue?.trim() || selectedFiles.length !== 0 || pendingPastedTextItems.length !== 0 || selectedArtifactRefs.length !== 0),
-        [isResponding, modelNotConfigured, inputValue, selectedFiles, pendingPastedTextItems, selectedArtifactRefs]
+        // Agent Mode: no agent, no send. Until the pinned agent resolves
+        // (selectedAgentName === ""), block sending into a void. UX-only — the
+        // provider re-guards on send.
+        () => !isResponding && !modelNotConfigured && (!agentMode || !!selectedAgentName) && (inputValue?.trim() || selectedFiles.length !== 0 || pendingPastedTextItems.length !== 0 || selectedArtifactRefs.length !== 0),
+        [isResponding, modelNotConfigured, agentMode, selectedAgentName, inputValue, selectedFiles, pendingPastedTextItems, selectedArtifactRefs]
     );
 
     const onSubmit = async (event: FormEvent) => {

--- a/client/webui/frontend/src/lib/components/chat/ChatInputArea.tsx
+++ b/client/webui/frontend/src/lib/components/chat/ChatInputArea.tsx
@@ -672,8 +672,9 @@ export const ChatInputArea: React.FC<{ agents: AgentCardInfo[]; scrollToBottom?:
         const textBeforeCursor = value.substring(0, cursorPosition);
 
         // Check if "/" is typed as the first character (position 0)
-        // Only trigger prompt popover when "/" is at the very start of the input
-        if (textBeforeCursor === "/") {
+        // Only trigger prompt popover when "/" is at the very start of the input.
+        // Agent Mode never invokes prompts.
+        if (!agentMode && textBeforeCursor === "/") {
             setShowPromptsCommand(true);
             setShowMentionsCommand(false); // Close mentions if open
         } else if (showPromptsCommand && !textBeforeCursor.startsWith("/")) {
@@ -814,6 +815,9 @@ export const ChatInputArea: React.FC<{ agents: AgentCardInfo[]; scrollToBottom?:
     let inputPlaceholder: string;
     if (isRecording) {
         inputPlaceholder = "Recording...";
+    } else if (agentMode) {
+        // Agent Mode disallows prompts, so the "/" hint is omitted.
+        inputPlaceholder = mentionsEnabled ? "How can I help you today? (Type '@' to mention someone)" : "How can I help you today?";
     } else if (mentionsEnabled) {
         inputPlaceholder = "How can I help you today? (Type '/' to insert a prompt, '@' to mention someone)";
     } else {

--- a/client/webui/frontend/src/lib/components/chat/ChatMessage.tsx
+++ b/client/webui/frontend/src/lib/components/chat/ChatMessage.tsx
@@ -7,7 +7,7 @@ import { useBooleanFlagDetails } from "@openfeature/react-sdk";
 import { ChatBubble, ChatBubbleMessage, MarkdownHTMLConverter, MarkdownWrapper, MessageBanner } from "@/lib/components";
 import { Button } from "@/lib/components/ui";
 import { ViewWorkflowButton } from "@/lib/components/ui/ViewWorkflowButton";
-import { useChatContext, useCitationClick } from "@/lib/hooks";
+import { useChatContext, useCitationClick, useConfigContext } from "@/lib/hooks";
 import type { ArtifactInfo, ArtifactPart, DataPart, FileAttachment, FilePart, MessageFE, RAGSearchResult, TextPart } from "@/lib/types";
 import type { ChatContextValue } from "@/lib/contexts";
 import { InlineResearchProgress, type ResearchProgressData } from "@/lib/components/research/InlineResearchProgress";
@@ -627,7 +627,8 @@ const getChatBubble = (
     reportContentOverride?: string,
     highlightedText?: string | null,
     inlineActivityTimelineEnabled?: boolean,
-    showThinkingContentEnabled?: boolean
+    showThinkingContentEnabled?: boolean,
+    agentMode?: boolean
 ): React.ReactNode => {
     const { openSidePanelTab, setTaskIdInSidePanel, ragData, currentUserEmail } = chatContext;
 
@@ -678,7 +679,7 @@ const getChatBubble = (
         return (
             <>
                 {progressBlock}
-                {getChatBubble(messageWithoutProgress, chatContext, isLastWithTaskId, undefined, undefined, undefined, undefined, undefined, undefined, inlineActivityTimelineEnabled, showThinkingContentEnabled)}
+                {getChatBubble(messageWithoutProgress, chatContext, isLastWithTaskId, undefined, undefined, undefined, undefined, undefined, undefined, inlineActivityTimelineEnabled, showThinkingContentEnabled, agentMode)}
             </>
         );
     }
@@ -720,8 +721,9 @@ const getChatBubble = (
     // For alignment: current user's messages are right-aligned, other users' and agent messages are left-aligned
     const isRightAligned = message.isUser && !isOtherUser;
     // Only show workflow button in MessageActions if there are no inline progress updates
-    // (when progress updates exist and inline timeline is enabled, the button is shown in the InlineProgressUpdates header instead)
-    const showWorkflowButton = !message.isUser && message.isComplete && !!message.taskId && !!isLastWithTaskId && !hasProgressUpdates;
+    // (when progress updates exist and inline timeline is enabled, the button is shown in the InlineProgressUpdates header instead).
+    // Agent Mode hides the Activity panel this button opens, so suppress it there too.
+    const showWorkflowButton = !message.isUser && message.isComplete && !!message.taskId && !!isLastWithTaskId && !hasProgressUpdates && !agentMode;
     const showFeedbackActions = !message.isUser && message.isComplete && !!message.taskId && !!isLastWithTaskId;
 
     // Debug logging for error messages
@@ -904,6 +906,7 @@ export const ChatMessage: React.FC<{ message: MessageFE; isLastWithTaskId?: bool
     const { ragData, openSidePanelTab, setTaskIdInSidePanel, artifacts, sessionId, isCollaborativeSession, hasSharedEditors, currentUserEmail, agentNameDisplayNameMap } = chatContext;
     const { value: inlineActivityTimelineEnabled } = useBooleanFlagDetails("inline_activity_timeline", false);
     const { value: showThinkingContentEnabled } = useBooleanFlagDetails("show_thinking_content", false);
+    const { agentMode } = useConfigContext();
 
     // Determine if this is another user's message (for uploaded files alignment)
     const isOtherUser = message.isUser && isOtherUserMessage(message, currentUserEmail);
@@ -1175,7 +1178,8 @@ export const ChatMessage: React.FC<{ message: MessageFE; isLastWithTaskId?: bool
                     highlightedText,
                     // Feature flags
                     inlineActivityTimelineEnabled,
-                    showThinkingContentEnabled
+                    showThinkingContentEnabled,
+                    agentMode
                 )}
 
                 {/* Render images separately at the end for web search */}

--- a/client/webui/frontend/src/lib/components/chat/ChatSidePanel.tsx
+++ b/client/webui/frontend/src/lib/components/chat/ChatSidePanel.tsx
@@ -44,6 +44,13 @@ export const ChatSidePanel: React.FC<ChatSidePanelProps> = ({ onCollapsedToggle,
         return hasDocumentSearchResults(ragData);
     }, [ragData]);
 
+    // Agent Mode hides the Activity tab; fall back to Files so the panel never lands on a hidden tab.
+    useEffect(() => {
+        if (agentMode && activeSidePanelTab === "activity") {
+            setActiveSidePanelTab("files");
+        }
+    }, [agentMode, activeSidePanelTab, setActiveSidePanelTab]);
+
     // Process task data for visualization when the selected activity task ID changes
     // or when monitoredTasks is updated with new data.
     useEffect(() => {

--- a/client/webui/frontend/src/lib/components/chat/ChatSidePanel.tsx
+++ b/client/webui/frontend/src/lib/components/chat/ChatSidePanel.tsx
@@ -3,10 +3,10 @@ import React, { useState, useEffect, useMemo } from "react";
 import { PanelRightIcon, FileText, Network, RefreshCw, Link2 } from "lucide-react";
 
 import { Button, Tabs, TabsList, TabsTrigger, TabsContent } from "@/lib/components/ui";
-import { useTaskContext, useChatContext, useIsProjectIndexingEnabled } from "@/lib/hooks";
+import { useTaskContext, useChatContext, useConfigContext, useIsProjectIndexingEnabled } from "@/lib/hooks";
 import { FlowChartPanel, processTaskForVisualization } from "@/lib/components/activities";
 import type { VisualizedTask } from "@/lib/types";
-import { hasSourcesWithUrls, hasDocumentSearchResults } from "@/lib/utils";
+import { cn, hasSourcesWithUrls, hasDocumentSearchResults } from "@/lib/utils";
 
 import { ArtifactPanel } from "./artifact/ArtifactPanel";
 import { FlowChartDetails } from "../activities/FlowChartDetails";
@@ -21,6 +21,7 @@ interface ChatSidePanelProps {
 
 export const ChatSidePanel: React.FC<ChatSidePanelProps> = ({ onCollapsedToggle, isSidePanelCollapsed, setIsSidePanelCollapsed }) => {
     const { activeSidePanelTab, setActiveSidePanelTab, setPreviewArtifact, taskIdInSidePanel, ragData, ragEnabled } = useChatContext();
+    const { agentMode } = useConfigContext();
     const { isReconnecting, isTaskMonitorConnecting, isTaskMonitorConnected, monitoredTasks, connectTaskMonitorStream, loadTaskFromBackend } = useTaskContext();
     const isProjectIndexingEnabled = useIsProjectIndexingEnabled();
     const [visualizedTask, setVisualizedTask] = useState<VisualizedTask | null>(null);
@@ -168,9 +169,11 @@ export const ChatSidePanel: React.FC<ChatSidePanelProps> = ({ onCollapsedToggle,
                     <FileText className="size-5" />
                 </Button>
 
-                <Button variant="ghost" size="sm" onClick={() => handleIconClick("activity")} className={hasSourcesInSession ? "mb-2 h-10 w-10 p-0" : "h-10 w-10 p-0"} tooltip="Activity">
-                    <Network className="size-5" />
-                </Button>
+                {!agentMode && (
+                    <Button variant="ghost" size="sm" onClick={() => handleIconClick("activity")} className={hasSourcesInSession ? "mb-2 h-10 w-10 p-0" : "h-10 w-10 p-0"} tooltip="Activity">
+                        <Network className="size-5" />
+                    </Button>
+                )}
 
                 {hasSourcesInSession && (
                     <Button variant="ghost" size="sm" onClick={() => handleIconClick("rag")} className="h-10 w-10 p-0" tooltip="Sources">
@@ -191,14 +194,16 @@ export const ChatSidePanel: React.FC<ChatSidePanelProps> = ({ onCollapsedToggle,
                             <PanelRightIcon className="size-5" />
                         </Button>
                         <TabsList className="flex min-w-0 flex-1 bg-transparent p-0">
-                            <TabsTrigger value="files" title="Files" className="relative min-w-0 flex-1 rounded-none rounded-l-md px-2 data-[state=active]:z-10" onClick={() => setPreviewArtifact(null)}>
+                            <TabsTrigger value="files" title="Files" className={cn("relative min-w-0 flex-1 rounded-none rounded-l-md px-2 data-[state=active]:z-10", agentMode && !hasSourcesInSession && "rounded-r-md border-r")} onClick={() => setPreviewArtifact(null)}>
                                 <FileText className="h-4 w-4 shrink-0" />
                                 <span className="ml-1.5 hidden truncate @[240px]:inline">Files</span>
                             </TabsTrigger>
-                            <TabsTrigger value="activity" title="Activity" className={`relative min-w-0 flex-1 rounded-none border-x-0 border-y px-2 data-[state=active]:z-10 ${!hasSourcesInSession ? "rounded-r-md border-r" : ""}`}>
-                                <Network className="h-4 w-4 shrink-0" />
-                                <span className="ml-1.5 hidden truncate @[240px]:inline">Activity</span>
-                            </TabsTrigger>
+                            {!agentMode && (
+                                <TabsTrigger value="activity" title="Activity" className={cn("relative min-w-0 flex-1 rounded-none border-x-0 border-y px-2 data-[state=active]:z-10", !hasSourcesInSession && "rounded-r-md border-r")}>
+                                    <Network className="h-4 w-4 shrink-0" />
+                                    <span className="ml-1.5 hidden truncate @[240px]:inline">Activity</span>
+                                </TabsTrigger>
+                            )}
                             {hasSourcesInSession && (
                                 <TabsTrigger value="rag" title="Sources" className="relative min-w-0 flex-1 rounded-none rounded-r-md px-2 data-[state=active]:z-10">
                                     <Link2 className="h-4 w-4 shrink-0" />
@@ -214,44 +219,46 @@ export const ChatSidePanel: React.FC<ChatSidePanelProps> = ({ onCollapsedToggle,
                             </div>
                         </TabsContent>
 
-                        <TabsContent value="activity" className="m-0 h-full">
-                            <div className="h-full">
-                                {(() => {
-                                    const emptyStateContent = getActivityPanelContent();
+                        {!agentMode && (
+                            <TabsContent value="activity" className="m-0 h-full">
+                                <div className="h-full">
+                                    {(() => {
+                                        const emptyStateContent = getActivityPanelContent();
 
-                                    if (!emptyStateContent && visualizedTask) {
+                                        if (!emptyStateContent && visualizedTask) {
+                                            return (
+                                                <div className="flex h-full flex-col">
+                                                    <FlowChartDetails task={visualizedTask} />
+                                                    <FlowChartPanel processedSteps={visualizedTask.steps || []} isRightPanelVisible={false} />
+                                                </div>
+                                            );
+                                        }
+
                                         return (
-                                            <div className="flex h-full flex-col">
-                                                <FlowChartDetails task={visualizedTask} />
-                                                <FlowChartPanel processedSteps={visualizedTask.steps || []} isRightPanelVisible={false} />
+                                            <div className="flex h-full items-center justify-center p-4">
+                                                <div className="text-center text-(--secondary-text-wMain)">
+                                                    <Network className="mx-auto mb-4 h-12 w-12" />
+                                                    <div className="text-lg font-medium">Activity</div>
+                                                    <div className="mt-2 text-sm">{emptyStateContent?.message}</div>
+                                                    {emptyStateContent?.showButton && (
+                                                        <div className="mt-4">
+                                                            <Button onClick={emptyStateContent.buttonAction}>
+                                                                {emptyStateContent.buttonIcon &&
+                                                                    (() => {
+                                                                        const ButtonIcon = emptyStateContent.buttonIcon;
+                                                                        return <ButtonIcon className="h-4 w-4" />;
+                                                                    })()}
+                                                                {emptyStateContent.buttonText}
+                                                            </Button>
+                                                        </div>
+                                                    )}
+                                                </div>
                                             </div>
                                         );
-                                    }
-
-                                    return (
-                                        <div className="flex h-full items-center justify-center p-4">
-                                            <div className="text-center text-(--secondary-text-wMain)">
-                                                <Network className="mx-auto mb-4 h-12 w-12" />
-                                                <div className="text-lg font-medium">Activity</div>
-                                                <div className="mt-2 text-sm">{emptyStateContent?.message}</div>
-                                                {emptyStateContent?.showButton && (
-                                                    <div className="mt-4">
-                                                        <Button onClick={emptyStateContent.buttonAction}>
-                                                            {emptyStateContent.buttonIcon &&
-                                                                (() => {
-                                                                    const ButtonIcon = emptyStateContent.buttonIcon;
-                                                                    return <ButtonIcon className="h-4 w-4" />;
-                                                                })()}
-                                                            {emptyStateContent.buttonText}
-                                                        </Button>
-                                                    </div>
-                                                )}
-                                            </div>
-                                        </div>
-                                    );
-                                })()}
-                            </div>
-                        </TabsContent>
+                                    })()}
+                                </div>
+                            </TabsContent>
+                        )}
 
                         {hasSourcesInSession && (
                             <TabsContent value="rag" className="m-0 h-full">

--- a/client/webui/frontend/src/lib/components/chat/SessionActionMenu.tsx
+++ b/client/webui/frontend/src/lib/components/chat/SessionActionMenu.tsx
@@ -3,6 +3,7 @@ import { Trash2, Pencil, FolderInput, MoreHorizontal, PanelsTopLeft, Sparkles, S
 
 import { cn } from "@/lib/utils";
 import { Button, DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuSeparator, DropdownMenuTrigger } from "@/lib/components/ui";
+import { useConfigContext } from "@/lib/hooks";
 import type { Session } from "@/lib/types";
 
 export interface SessionActionMenuProps {
@@ -19,6 +20,45 @@ export interface SessionActionMenuProps {
 }
 
 export const SessionActionMenu: React.FC<SessionActionMenuProps> = ({ session, onRename, onRenameWithAI, onMove, onDelete, onGoToProject, onShare, isRegeneratingTitle = false, triggerClassName }) => {
+    const { agentMode } = useConfigContext();
+
+    const renameItem = (
+        <DropdownMenuItem
+            onClick={e => {
+                e.stopPropagation();
+                onRename(session);
+            }}
+        >
+            <Pencil size={16} className="mr-2" />
+            Rename
+        </DropdownMenuItem>
+    );
+
+    const renameWithAIItem = (
+        <DropdownMenuItem
+            onClick={e => {
+                e.stopPropagation();
+                onRenameWithAI(session);
+            }}
+            disabled={isRegeneratingTitle}
+        >
+            <Sparkles size={16} className={cn("mr-2", isRegeneratingTitle && "animate-pulse")} />
+            Rename with AI
+        </DropdownMenuItem>
+    );
+
+    const deleteItem = (
+        <DropdownMenuItem
+            onClick={e => {
+                e.stopPropagation();
+                onDelete(session);
+            }}
+        >
+            <Trash2 size={16} className="mr-2" />
+            Delete
+        </DropdownMenuItem>
+    );
+
     return (
         <DropdownMenu>
             <DropdownMenuTrigger asChild>
@@ -27,69 +67,57 @@ export const SessionActionMenu: React.FC<SessionActionMenuProps> = ({ session, o
                 </Button>
             </DropdownMenuTrigger>
             <DropdownMenuContent align="end" className="w-48">
-                {session.projectId && onGoToProject && (
+                {agentMode ? (
+                    // Agent Mode allowlist: only these actions are ever shown. New menu
+                    // items added below must be added to the full-UI branch only.
                     <>
+                        {renameItem}
+                        {renameWithAIItem}
+                        <DropdownMenuSeparator />
+                        {deleteItem}
+                    </>
+                ) : (
+                    <>
+                        {session.projectId && onGoToProject && (
+                            <>
+                                <DropdownMenuItem
+                                    onClick={e => {
+                                        e.stopPropagation();
+                                        onGoToProject(session);
+                                    }}
+                                >
+                                    <PanelsTopLeft size={16} className="mr-2" />
+                                    Go to Project
+                                </DropdownMenuItem>
+                                <DropdownMenuSeparator />
+                            </>
+                        )}
+                        {renameItem}
+                        {renameWithAIItem}
                         <DropdownMenuItem
                             onClick={e => {
                                 e.stopPropagation();
-                                onGoToProject(session);
+                                onMove(session);
                             }}
                         >
-                            <PanelsTopLeft size={16} className="mr-2" />
-                            Go to Project
+                            <FolderInput size={16} className="mr-2" />
+                            Move to Project
                         </DropdownMenuItem>
+                        {onShare && (
+                            <DropdownMenuItem
+                                onClick={e => {
+                                    e.stopPropagation();
+                                    onShare(session);
+                                }}
+                            >
+                                <Share2 size={16} className="mr-2" />
+                                Share
+                            </DropdownMenuItem>
+                        )}
                         <DropdownMenuSeparator />
+                        {deleteItem}
                     </>
                 )}
-                <DropdownMenuItem
-                    onClick={e => {
-                        e.stopPropagation();
-                        onRename(session);
-                    }}
-                >
-                    <Pencil size={16} className="mr-2" />
-                    Rename
-                </DropdownMenuItem>
-                <DropdownMenuItem
-                    onClick={e => {
-                        e.stopPropagation();
-                        onRenameWithAI(session);
-                    }}
-                    disabled={isRegeneratingTitle}
-                >
-                    <Sparkles size={16} className={cn("mr-2", isRegeneratingTitle && "animate-pulse")} />
-                    Rename with AI
-                </DropdownMenuItem>
-                <DropdownMenuItem
-                    onClick={e => {
-                        e.stopPropagation();
-                        onMove(session);
-                    }}
-                >
-                    <FolderInput size={16} className="mr-2" />
-                    Move to Project
-                </DropdownMenuItem>
-                {onShare && (
-                    <DropdownMenuItem
-                        onClick={e => {
-                            e.stopPropagation();
-                            onShare(session);
-                        }}
-                    >
-                        <Share2 size={16} className="mr-2" />
-                        Share
-                    </DropdownMenuItem>
-                )}
-                <DropdownMenuSeparator />
-                <DropdownMenuItem
-                    onClick={e => {
-                        e.stopPropagation();
-                        onDelete(session);
-                    }}
-                >
-                    <Trash2 size={16} className="mr-2" />
-                    Delete
-                </DropdownMenuItem>
             </DropdownMenuContent>
         </DropdownMenu>
     );

--- a/client/webui/frontend/src/lib/components/chat/index.ts
+++ b/client/webui/frontend/src/lib/components/chat/index.ts
@@ -1,3 +1,4 @@
+export { AgentModeWelcome } from "./AgentModeWelcome";
 export { AudioRecorder } from "./AudioRecorder";
 export { ChatInputArea } from "./ChatInputArea";
 export { ChatMessage } from "./ChatMessage";

--- a/client/webui/frontend/src/lib/components/navigation/NavigationSidebar.tsx
+++ b/client/webui/frontend/src/lib/components/navigation/NavigationSidebar.tsx
@@ -20,7 +20,7 @@ export const NavigationSidebar: React.FC<NavigationSidebarProps> = ({ items, bot
     const filteredBottomItems = bottomItems?.filter(item => item.id !== "theme-toggle");
 
     return (
-        <aside className="flex h-screen w-[100px] flex-col overflow-y-auto border-r border-(--darkSurface-border) bg-(--darkSurface-bg)">
+        <aside data-testid="navigation-sidebar" className="flex h-screen w-[100px] flex-col overflow-y-auto border-r border-(--darkSurface-border) bg-(--darkSurface-bg)">
             <NavigationHeader onClick={onHeaderClick} />
             <NavigationList items={items} bottomItems={filteredBottomItems} activeItem={activeItem} onItemClick={handleItemClick} />
         </aside>

--- a/client/webui/frontend/src/lib/components/pages/ChatPage.tsx
+++ b/client/webui/frontend/src/lib/components/pages/ChatPage.tsx
@@ -10,7 +10,7 @@ import { useChatContext, useConfigContext, useIsAutoTitleGenerationEnabled, useI
 import { SLIDE_OUT_DURATION_MS, FADE_OUT_DURATION_MS } from "@/lib/hooks/useTurnDividerAnimation";
 import { useProjectContext } from "@/lib/providers";
 import type { CollaborativeUser } from "@/lib/types/collaboration";
-import { ChatInputArea, ChatMessage, ChatSessionDialog, ChatSessionDeleteDialog, ChatSidePanel, LoadingMessageRow, ProjectBadge, SessionSidePanel, UserPresenceAvatars, ShareNotificationMessage } from "@/lib/components/chat";
+import { AgentModeWelcome, ChatInputArea, ChatMessage, ChatSessionDialog, ChatSessionDeleteDialog, ChatSidePanel, LoadingMessageRow, ProjectBadge, SessionSidePanel, UserPresenceAvatars, ShareNotificationMessage } from "@/lib/components/chat";
 import { Button, ChatMessageList, CHAT_STYLES, ResizablePanelGroup, ResizablePanel, ResizableHandle, Spinner, Tooltip, TooltipContent, TooltipTrigger } from "@/lib/components/ui";
 import { PageLayout } from "@/lib/components/layout";
 import type { ChatMessageListRef } from "@/lib/components/ui/chat/chat-message-list";
@@ -621,9 +621,7 @@ export function ChatPage() {
                                     ) : agentMode && messages.length === 0 ? (
                                         // Agent Mode hero welcome — centered empty state for the pinned agent.
                                         <>
-                                            <div className="flex min-h-0 flex-1 items-center justify-center">
-                                                <p className="text-base text-(--secondary-text-wMain)">{configWelcomeMessage || "How can I help?"}</p>
-                                            </div>
+                                            <AgentModeWelcome message={configWelcomeMessage} />
                                             <div style={CHAT_STYLES}>
                                                 <ChatInputArea agents={agents} scrollToBottom={chatMessageListRef.current?.scrollToBottom} />
                                             </div>

--- a/client/webui/frontend/src/lib/components/pages/ChatPage.tsx
+++ b/client/webui/frontend/src/lib/components/pages/ChatPage.tsx
@@ -93,9 +93,10 @@ export function ChatPage() {
     // bad ?agent= (typo, down, or unauthorized) doesn't spin forever.
     const isAwaitingPinnedAgent = agentMode && messages.length === 0 && !selectedAgentName;
 
-    // Agent Mode hero heading. Match by displayName too: platform agents have a
-    // broker-safe UUID as the wire name while selectedAgentName is the displayName.
-    const welcomeAgent = useMemo(() => agents.find(a => a.name === selectedAgentName || a.displayName === selectedAgentName), [agents, selectedAgentName]);
+    // Agent Mode hero heading. Resolve the pinned agent by its wire name only —
+    // the same identifier ?agent= and message routing (agent_name) use — so the
+    // greeting label can never disagree with the agent that receives messages.
+    const welcomeAgent = useMemo(() => agents.find(a => a.name === selectedAgentName), [agents, selectedAgentName]);
     const heroMessage = configWelcomeMessage || (welcomeAgent ? `Hi, I'm ${welcomeAgent.displayName || welcomeAgent.name}. How can I help you?` : `Hi, I'm ${selectedAgentName}. How can I help you?`);
     const [pinnedAgentTimedOut, setPinnedAgentTimedOut] = useState(false);
     useEffect(() => {

--- a/client/webui/frontend/src/lib/components/pages/ChatPage.tsx
+++ b/client/webui/frontend/src/lib/components/pages/ChatPage.tsx
@@ -473,6 +473,8 @@ export function ChatPage() {
     );
 
     const handleViewProgressClick = useMemo(() => {
+        // Agent Mode hides the Activity panel, so don't surface a button that opens it.
+        if (agentMode) return undefined;
         if (inlineActivityTimelineEnabled) return undefined;
         if (!currentTaskId) return undefined;
 
@@ -480,7 +482,7 @@ export function ChatPage() {
             setTaskIdInSidePanel(currentTaskId);
             openSidePanelTab("activity");
         };
-    }, [currentTaskId, setTaskIdInSidePanel, openSidePanelTab, inlineActivityTimelineEnabled]);
+    }, [agentMode, currentTaskId, setTaskIdInSidePanel, openSidePanelTab, inlineActivityTimelineEnabled]);
 
     const lastMessageIndexByTaskId = useMemo(() => {
         const map = new Map<string, number>();

--- a/client/webui/frontend/src/lib/components/pages/ChatPage.tsx
+++ b/client/webui/frontend/src/lib/components/pages/ChatPage.tsx
@@ -6,7 +6,7 @@ import { PanelLeftIcon, Loader2, GitFork } from "lucide-react";
 import type { ImperativePanelHandle } from "react-resizable-panels";
 
 import { Header } from "@/lib/components/header";
-import { useChatContext, useIsAutoTitleGenerationEnabled, useIsNewNavigationEnabled, useTaskContext, useTitleAnimation, useIsChatSharingEnabled, useTurnDividerAnimation } from "@/lib/hooks";
+import { useChatContext, useConfigContext, useIsAutoTitleGenerationEnabled, useIsNewNavigationEnabled, useTaskContext, useTitleAnimation, useIsChatSharingEnabled, useTurnDividerAnimation } from "@/lib/hooks";
 import { SLIDE_OUT_DURATION_MS, FADE_OUT_DURATION_MS } from "@/lib/hooks/useTurnDividerAnimation";
 import { useProjectContext } from "@/lib/providers";
 import type { CollaborativeUser } from "@/lib/types/collaboration";
@@ -52,11 +52,13 @@ export function ChatPage() {
     const location = useLocation();
     const navigate = useNavigate();
     const { value: inlineActivityTimelineEnabled } = useBooleanFlagDetails("inline_activity_timeline", false);
+    const { agentMode, configWelcomeMessage } = useConfigContext();
     const {
         agents,
         agentsRefetch,
         sessionId,
         sessionName,
+        selectedAgentName,
         messages,
         isSidePanelCollapsed,
         setIsSidePanelCollapsed,
@@ -587,75 +589,89 @@ export function ChatPage() {
                                         </div>
                                     ) : (
                                         <>
-                                            <ChatMessageList className="text-base" ref={chatMessageListRef}>
-                                                {/* Old messages — slide out on new turn, collapsed after, expanded on scroll-up */}
-                                                {hasDivider && (
-                                                    <div style={isHistoryCollapsed ? COLLAPSED_STYLE : undefined}>
-                                                        {/* Show share notification for editor at the start */}
-                                                        {isCollaborativeSession && (
-                                                            <ShareNotificationMessage variant="shared-with-users" sharedBy={sessionOwnerName || "Someone"} sharedWith={["you"]} accessLevel="editor" timestamp={collaborativeTimestamp} />
-                                                        )}
-                                                        {messages.slice(0, collapseIdx).map((message, index) => {
-                                                            const isLastWithTaskId = !!(message.taskId && lastMessageIndexByTaskId.get(message.taskId) === index);
-                                                            const messageKey = message.metadata?.messageId || `temp-${index}`;
-                                                            return (
-                                                                <div key={messageKey} style={NO_OVERFLOW_ANCHOR_STYLE}>
-                                                                    <ChatMessage message={message} isLastWithTaskId={isLastWithTaskId} isStreaming={false} />
-                                                                    {renderShareNotifications(index)}
-                                                                </div>
-                                                            );
-                                                        })}
-                                                    </div>
-                                                )}
-                                                {/* Previous turn messages (between old and new divider) — slide up during exit */}
-                                                {hasDivider && collapseIdx < dividerIdx && (
-                                                    <div
-                                                        ref={prevTurnRef}
-                                                        style={{
-                                                            marginTop: isExitingHistory && prevTurnHeight > 0 ? `-${prevTurnHeight}px` : 0,
-                                                            opacity: isExitingHistory ? 0 : 1,
-                                                            transition: isExitingHistory ? `margin-top ${SLIDE_OUT_DURATION_MS}ms ease-out, opacity ${FADE_OUT_DURATION_MS}ms ease-in` : undefined,
-                                                            overflow: "hidden",
-                                                        }}
-                                                    >
-                                                        {messages.slice(collapseIdx, dividerIdx).map((message, i) => {
-                                                            const index = i + collapseIdx;
-                                                            const isLastWithTaskId = !!(message.taskId && lastMessageIndexByTaskId.get(message.taskId) === index);
-                                                            const messageKey = message.metadata?.messageId || `temp-${index}`;
-                                                            return (
-                                                                <div key={messageKey}>
-                                                                    <ChatMessage message={message} isLastWithTaskId={isLastWithTaskId} isStreaming={false} />
-                                                                    {renderShareNotifications(index)}
-                                                                </div>
-                                                            );
-                                                        })}
-                                                    </div>
-                                                )}
-                                                {/* New turn messages */}
-                                                {(hasDivider ? messages.slice(dividerIdx) : messages).map((message, i) => {
-                                                    const index = hasDivider ? i + dividerIdx : i;
-                                                    const isLastWithTaskId = !!(message.taskId && lastMessageIndexByTaskId.get(message.taskId) === index);
-                                                    const messageKey = message.metadata?.messageId || `temp-${index}`;
-                                                    const isLastMessage = index === messages.length - 1;
-                                                    const shouldStream = isLastMessage && isResponding && !message.isUser;
-                                                    const isNewTurnStart = hasDivider && i === 0;
-
-                                                    const showCollabBannerInNewSection = isCollaborativeSession && i === 0 && (!hasDivider || isHistoryCollapsed || isExitingHistory);
-
-                                                    return (
-                                                        <div key={messageKey} ref={isNewTurnStart ? newTurnAnchorRef : undefined} style={isNewTurnStart ? OVERFLOW_ANCHOR_AUTO_STYLE : undefined}>
-                                                            {showCollabBannerInNewSection && (
+                                            {agentMode && messages.length === 0 && !selectedAgentName ? (
+                                                // Agent Mode: pinned agent not resolved yet — connecting state.
+                                                <div className="flex min-h-0 flex-1 items-center justify-center">
+                                                    <Spinner size="medium" variant="primary">
+                                                        <p className="mt-4 text-sm text-(--secondary-text-wMain)">Connecting…</p>
+                                                    </Spinner>
+                                                </div>
+                                            ) : agentMode && messages.length === 0 && selectedAgentName ? (
+                                                // Agent Mode hero welcome — centered empty state for the pinned agent.
+                                                <div className="flex min-h-0 flex-1 items-center justify-center">
+                                                    <p className="text-base text-(--secondary-text-wMain)">{configWelcomeMessage || "How can I help?"}</p>
+                                                </div>
+                                            ) : (
+                                                <ChatMessageList className="text-base" ref={chatMessageListRef}>
+                                                    {/* Old messages — slide out on new turn, collapsed after, expanded on scroll-up */}
+                                                    {hasDivider && (
+                                                        <div style={isHistoryCollapsed ? COLLAPSED_STYLE : undefined}>
+                                                            {/* Show share notification for editor at the start */}
+                                                            {isCollaborativeSession && (
                                                                 <ShareNotificationMessage variant="shared-with-users" sharedBy={sessionOwnerName || "Someone"} sharedWith={["you"]} accessLevel="editor" timestamp={collaborativeTimestamp} />
                                                             )}
-                                                            <div>
-                                                                <ChatMessage message={message} isLastWithTaskId={isLastWithTaskId} isStreaming={shouldStream} />
-                                                            </div>
-                                                            {renderShareNotifications(index)}
+                                                            {messages.slice(0, collapseIdx).map((message, index) => {
+                                                                const isLastWithTaskId = !!(message.taskId && lastMessageIndexByTaskId.get(message.taskId) === index);
+                                                                const messageKey = message.metadata?.messageId || `temp-${index}`;
+                                                                return (
+                                                                    <div key={messageKey} style={NO_OVERFLOW_ANCHOR_STYLE}>
+                                                                        <ChatMessage message={message} isLastWithTaskId={isLastWithTaskId} isStreaming={false} />
+                                                                        {renderShareNotifications(index)}
+                                                                    </div>
+                                                                );
+                                                            })}
                                                         </div>
-                                                    );
-                                                })}
-                                                {isResponding && <LoadingMessageRow onViewWorkflow={handleViewProgressClick} />}
-                                            </ChatMessageList>
+                                                    )}
+                                                    {/* Previous turn messages (between old and new divider) — slide up during exit */}
+                                                    {hasDivider && collapseIdx < dividerIdx && (
+                                                        <div
+                                                            ref={prevTurnRef}
+                                                            style={{
+                                                                marginTop: isExitingHistory && prevTurnHeight > 0 ? `-${prevTurnHeight}px` : 0,
+                                                                opacity: isExitingHistory ? 0 : 1,
+                                                                transition: isExitingHistory ? `margin-top ${SLIDE_OUT_DURATION_MS}ms ease-out, opacity ${FADE_OUT_DURATION_MS}ms ease-in` : undefined,
+                                                                overflow: "hidden",
+                                                            }}
+                                                        >
+                                                            {messages.slice(collapseIdx, dividerIdx).map((message, i) => {
+                                                                const index = i + collapseIdx;
+                                                                const isLastWithTaskId = !!(message.taskId && lastMessageIndexByTaskId.get(message.taskId) === index);
+                                                                const messageKey = message.metadata?.messageId || `temp-${index}`;
+                                                                return (
+                                                                    <div key={messageKey}>
+                                                                        <ChatMessage message={message} isLastWithTaskId={isLastWithTaskId} isStreaming={false} />
+                                                                        {renderShareNotifications(index)}
+                                                                    </div>
+                                                                );
+                                                            })}
+                                                        </div>
+                                                    )}
+                                                    {/* New turn messages */}
+                                                    {(hasDivider ? messages.slice(dividerIdx) : messages).map((message, i) => {
+                                                        const index = hasDivider ? i + dividerIdx : i;
+                                                        const isLastWithTaskId = !!(message.taskId && lastMessageIndexByTaskId.get(message.taskId) === index);
+                                                        const messageKey = message.metadata?.messageId || `temp-${index}`;
+                                                        const isLastMessage = index === messages.length - 1;
+                                                        const shouldStream = isLastMessage && isResponding && !message.isUser;
+                                                        const isNewTurnStart = hasDivider && i === 0;
+
+                                                        const showCollabBannerInNewSection = isCollaborativeSession && i === 0 && (!hasDivider || isHistoryCollapsed || isExitingHistory);
+
+                                                        return (
+                                                            <div key={messageKey} ref={isNewTurnStart ? newTurnAnchorRef : undefined} style={isNewTurnStart ? OVERFLOW_ANCHOR_AUTO_STYLE : undefined}>
+                                                                {showCollabBannerInNewSection && (
+                                                                    <ShareNotificationMessage variant="shared-with-users" sharedBy={sessionOwnerName || "Someone"} sharedWith={["you"]} accessLevel="editor" timestamp={collaborativeTimestamp} />
+                                                                )}
+                                                                <div>
+                                                                    <ChatMessage message={message} isLastWithTaskId={isLastWithTaskId} isStreaming={shouldStream} />
+                                                                </div>
+                                                                {renderShareNotifications(index)}
+                                                            </div>
+                                                        );
+                                                    })}
+                                                    {isResponding && <LoadingMessageRow onViewWorkflow={handleViewProgressClick} />}
+                                                </ChatMessageList>
+                                            )}
                                             <div style={CHAT_STYLES}>
                                                 <ChatInputArea agents={agents} scrollToBottom={chatMessageListRef.current?.scrollToBottom} />
                                             </div>

--- a/client/webui/frontend/src/lib/components/pages/ChatPage.tsx
+++ b/client/webui/frontend/src/lib/components/pages/ChatPage.tsx
@@ -92,6 +92,11 @@ export function ChatPage() {
     // state, but fall back to a terminal "unavailable" message after a timeout so a
     // bad ?agent= (typo, down, or unauthorized) doesn't spin forever.
     const isAwaitingPinnedAgent = agentMode && messages.length === 0 && !selectedAgentName;
+
+    // Agent Mode hero heading. Match by displayName too: platform agents have a
+    // broker-safe UUID as the wire name while selectedAgentName is the displayName.
+    const welcomeAgent = useMemo(() => agents.find(a => a.name === selectedAgentName || a.displayName === selectedAgentName), [agents, selectedAgentName]);
+    const heroMessage = configWelcomeMessage || (welcomeAgent ? `Hi, I'm ${welcomeAgent.displayName || welcomeAgent.name}. How can I help you?` : `Hi, I'm ${selectedAgentName}. How can I help you?`);
     const [pinnedAgentTimedOut, setPinnedAgentTimedOut] = useState(false);
     useEffect(() => {
         if (!isAwaitingPinnedAgent) {
@@ -604,8 +609,8 @@ export function ChatPage() {
                                     ) : isAwaitingPinnedAgent ? (
                                         // Agent Mode: pinned agent not resolved. Show connecting, then a
                                         // terminal "unavailable" state if it never registers.
-                                        <>
-                                            <div className="flex min-h-0 flex-1 items-center justify-center">
+                                        <div className="flex min-h-0 flex-1 flex-col items-center justify-center px-4 pb-32">
+                                            <div className="flex flex-col items-center gap-6" style={{ maxWidth: "900px" }}>
                                                 {pinnedAgentTimedOut ? (
                                                     <p className="text-base text-(--secondary-text-wMain)">This agent is currently unavailable.</p>
                                                 ) : (
@@ -613,19 +618,21 @@ export function ChatPage() {
                                                         <p className="mt-4 text-sm text-(--secondary-text-wMain)">Connecting…</p>
                                                     </Spinner>
                                                 )}
+                                                <div className="mt-4 w-full" style={CHAT_STYLES}>
+                                                    <ChatInputArea agents={agents} scrollToBottom={chatMessageListRef.current?.scrollToBottom} />
+                                                </div>
                                             </div>
-                                            <div style={CHAT_STYLES}>
-                                                <ChatInputArea agents={agents} scrollToBottom={chatMessageListRef.current?.scrollToBottom} />
-                                            </div>
-                                        </>
+                                        </div>
                                     ) : agentMode && messages.length === 0 ? (
                                         // Agent Mode hero welcome — centered empty state for the pinned agent.
-                                        <>
-                                            <AgentModeWelcome message={configWelcomeMessage} />
-                                            <div style={CHAT_STYLES}>
-                                                <ChatInputArea agents={agents} scrollToBottom={chatMessageListRef.current?.scrollToBottom} />
+                                        <div className="flex min-h-0 flex-1 flex-col items-center justify-center px-4 pb-32">
+                                            <div className="flex flex-col items-center gap-6" style={{ maxWidth: "900px" }}>
+                                                <AgentModeWelcome message={heroMessage} />
+                                                <div className="mt-4 w-full" style={CHAT_STYLES}>
+                                                    <ChatInputArea agents={agents} scrollToBottom={chatMessageListRef.current?.scrollToBottom} />
+                                                </div>
                                             </div>
-                                        </>
+                                        </div>
                                     ) : (
                                         <>
                                             <ChatMessageList className="text-base" ref={chatMessageListRef}>

--- a/client/webui/frontend/src/lib/components/pages/ChatPage.tsx
+++ b/client/webui/frontend/src/lib/components/pages/ChatPage.tsx
@@ -87,6 +87,20 @@ export function ChatPage() {
     const [isSidePanelTransitioning, setIsSidePanelTransitioning] = useState(false);
     const [isForkingChat, setIsForkingChat] = useState(false);
     const [isShareDialogOpen, setIsShareDialogOpen] = useState(false);
+
+    // Agent Mode: the pinned agent hasn't resolved yet (still ""). Show a connecting
+    // state, but fall back to a terminal "unavailable" message after a timeout so a
+    // bad ?agent= (typo, down, or unauthorized) doesn't spin forever.
+    const isAwaitingPinnedAgent = agentMode && messages.length === 0 && !selectedAgentName;
+    const [pinnedAgentTimedOut, setPinnedAgentTimedOut] = useState(false);
+    useEffect(() => {
+        if (!isAwaitingPinnedAgent) {
+            setPinnedAgentTimedOut(false);
+            return;
+        }
+        const timer = setTimeout(() => setPinnedAgentTimedOut(true), 15000);
+        return () => clearTimeout(timer);
+    }, [isAwaitingPinnedAgent]);
     // Share notification data: each entry represents a share action (user added at a specific time)
     const [shareNotifications, setShareNotifications] = useState<
         Array<
@@ -587,91 +601,104 @@ export function ChatPage() {
                                                 <p className="mt-4 text-sm text-(--secondary-text-wMain)">Loading session...</p>
                                             </Spinner>
                                         </div>
-                                    ) : (
+                                    ) : isAwaitingPinnedAgent ? (
+                                        // Agent Mode: pinned agent not resolved. Show connecting, then a
+                                        // terminal "unavailable" state if it never registers.
                                         <>
-                                            {agentMode && messages.length === 0 && !selectedAgentName ? (
-                                                // Agent Mode: pinned agent not resolved yet — connecting state.
-                                                <div className="flex min-h-0 flex-1 items-center justify-center">
+                                            <div className="flex min-h-0 flex-1 items-center justify-center">
+                                                {pinnedAgentTimedOut ? (
+                                                    <p className="text-base text-(--secondary-text-wMain)">This agent is currently unavailable.</p>
+                                                ) : (
                                                     <Spinner size="medium" variant="primary">
                                                         <p className="mt-4 text-sm text-(--secondary-text-wMain)">Connecting…</p>
                                                     </Spinner>
-                                                </div>
-                                            ) : agentMode && messages.length === 0 && selectedAgentName ? (
-                                                // Agent Mode hero welcome — centered empty state for the pinned agent.
-                                                <div className="flex min-h-0 flex-1 items-center justify-center">
-                                                    <p className="text-base text-(--secondary-text-wMain)">{configWelcomeMessage || "How can I help?"}</p>
-                                                </div>
-                                            ) : (
-                                                <ChatMessageList className="text-base" ref={chatMessageListRef}>
-                                                    {/* Old messages — slide out on new turn, collapsed after, expanded on scroll-up */}
-                                                    {hasDivider && (
-                                                        <div style={isHistoryCollapsed ? COLLAPSED_STYLE : undefined}>
-                                                            {/* Show share notification for editor at the start */}
-                                                            {isCollaborativeSession && (
+                                                )}
+                                            </div>
+                                            <div style={CHAT_STYLES}>
+                                                <ChatInputArea agents={agents} scrollToBottom={chatMessageListRef.current?.scrollToBottom} />
+                                            </div>
+                                        </>
+                                    ) : agentMode && messages.length === 0 ? (
+                                        // Agent Mode hero welcome — centered empty state for the pinned agent.
+                                        <>
+                                            <div className="flex min-h-0 flex-1 items-center justify-center">
+                                                <p className="text-base text-(--secondary-text-wMain)">{configWelcomeMessage || "How can I help?"}</p>
+                                            </div>
+                                            <div style={CHAT_STYLES}>
+                                                <ChatInputArea agents={agents} scrollToBottom={chatMessageListRef.current?.scrollToBottom} />
+                                            </div>
+                                        </>
+                                    ) : (
+                                        <>
+                                            <ChatMessageList className="text-base" ref={chatMessageListRef}>
+                                                {/* Old messages — slide out on new turn, collapsed after, expanded on scroll-up */}
+                                                {hasDivider && (
+                                                    <div style={isHistoryCollapsed ? COLLAPSED_STYLE : undefined}>
+                                                        {/* Show share notification for editor at the start */}
+                                                        {isCollaborativeSession && (
+                                                            <ShareNotificationMessage variant="shared-with-users" sharedBy={sessionOwnerName || "Someone"} sharedWith={["you"]} accessLevel="editor" timestamp={collaborativeTimestamp} />
+                                                        )}
+                                                        {messages.slice(0, collapseIdx).map((message, index) => {
+                                                            const isLastWithTaskId = !!(message.taskId && lastMessageIndexByTaskId.get(message.taskId) === index);
+                                                            const messageKey = message.metadata?.messageId || `temp-${index}`;
+                                                            return (
+                                                                <div key={messageKey} style={NO_OVERFLOW_ANCHOR_STYLE}>
+                                                                    <ChatMessage message={message} isLastWithTaskId={isLastWithTaskId} isStreaming={false} />
+                                                                    {renderShareNotifications(index)}
+                                                                </div>
+                                                            );
+                                                        })}
+                                                    </div>
+                                                )}
+                                                {/* Previous turn messages (between old and new divider) — slide up during exit */}
+                                                {hasDivider && collapseIdx < dividerIdx && (
+                                                    <div
+                                                        ref={prevTurnRef}
+                                                        style={{
+                                                            marginTop: isExitingHistory && prevTurnHeight > 0 ? `-${prevTurnHeight}px` : 0,
+                                                            opacity: isExitingHistory ? 0 : 1,
+                                                            transition: isExitingHistory ? `margin-top ${SLIDE_OUT_DURATION_MS}ms ease-out, opacity ${FADE_OUT_DURATION_MS}ms ease-in` : undefined,
+                                                            overflow: "hidden",
+                                                        }}
+                                                    >
+                                                        {messages.slice(collapseIdx, dividerIdx).map((message, i) => {
+                                                            const index = i + collapseIdx;
+                                                            const isLastWithTaskId = !!(message.taskId && lastMessageIndexByTaskId.get(message.taskId) === index);
+                                                            const messageKey = message.metadata?.messageId || `temp-${index}`;
+                                                            return (
+                                                                <div key={messageKey}>
+                                                                    <ChatMessage message={message} isLastWithTaskId={isLastWithTaskId} isStreaming={false} />
+                                                                    {renderShareNotifications(index)}
+                                                                </div>
+                                                            );
+                                                        })}
+                                                    </div>
+                                                )}
+                                                {/* New turn messages */}
+                                                {(hasDivider ? messages.slice(dividerIdx) : messages).map((message, i) => {
+                                                    const index = hasDivider ? i + dividerIdx : i;
+                                                    const isLastWithTaskId = !!(message.taskId && lastMessageIndexByTaskId.get(message.taskId) === index);
+                                                    const messageKey = message.metadata?.messageId || `temp-${index}`;
+                                                    const isLastMessage = index === messages.length - 1;
+                                                    const shouldStream = isLastMessage && isResponding && !message.isUser;
+                                                    const isNewTurnStart = hasDivider && i === 0;
+
+                                                    const showCollabBannerInNewSection = isCollaborativeSession && i === 0 && (!hasDivider || isHistoryCollapsed || isExitingHistory);
+
+                                                    return (
+                                                        <div key={messageKey} ref={isNewTurnStart ? newTurnAnchorRef : undefined} style={isNewTurnStart ? OVERFLOW_ANCHOR_AUTO_STYLE : undefined}>
+                                                            {showCollabBannerInNewSection && (
                                                                 <ShareNotificationMessage variant="shared-with-users" sharedBy={sessionOwnerName || "Someone"} sharedWith={["you"]} accessLevel="editor" timestamp={collaborativeTimestamp} />
                                                             )}
-                                                            {messages.slice(0, collapseIdx).map((message, index) => {
-                                                                const isLastWithTaskId = !!(message.taskId && lastMessageIndexByTaskId.get(message.taskId) === index);
-                                                                const messageKey = message.metadata?.messageId || `temp-${index}`;
-                                                                return (
-                                                                    <div key={messageKey} style={NO_OVERFLOW_ANCHOR_STYLE}>
-                                                                        <ChatMessage message={message} isLastWithTaskId={isLastWithTaskId} isStreaming={false} />
-                                                                        {renderShareNotifications(index)}
-                                                                    </div>
-                                                                );
-                                                            })}
-                                                        </div>
-                                                    )}
-                                                    {/* Previous turn messages (between old and new divider) — slide up during exit */}
-                                                    {hasDivider && collapseIdx < dividerIdx && (
-                                                        <div
-                                                            ref={prevTurnRef}
-                                                            style={{
-                                                                marginTop: isExitingHistory && prevTurnHeight > 0 ? `-${prevTurnHeight}px` : 0,
-                                                                opacity: isExitingHistory ? 0 : 1,
-                                                                transition: isExitingHistory ? `margin-top ${SLIDE_OUT_DURATION_MS}ms ease-out, opacity ${FADE_OUT_DURATION_MS}ms ease-in` : undefined,
-                                                                overflow: "hidden",
-                                                            }}
-                                                        >
-                                                            {messages.slice(collapseIdx, dividerIdx).map((message, i) => {
-                                                                const index = i + collapseIdx;
-                                                                const isLastWithTaskId = !!(message.taskId && lastMessageIndexByTaskId.get(message.taskId) === index);
-                                                                const messageKey = message.metadata?.messageId || `temp-${index}`;
-                                                                return (
-                                                                    <div key={messageKey}>
-                                                                        <ChatMessage message={message} isLastWithTaskId={isLastWithTaskId} isStreaming={false} />
-                                                                        {renderShareNotifications(index)}
-                                                                    </div>
-                                                                );
-                                                            })}
-                                                        </div>
-                                                    )}
-                                                    {/* New turn messages */}
-                                                    {(hasDivider ? messages.slice(dividerIdx) : messages).map((message, i) => {
-                                                        const index = hasDivider ? i + dividerIdx : i;
-                                                        const isLastWithTaskId = !!(message.taskId && lastMessageIndexByTaskId.get(message.taskId) === index);
-                                                        const messageKey = message.metadata?.messageId || `temp-${index}`;
-                                                        const isLastMessage = index === messages.length - 1;
-                                                        const shouldStream = isLastMessage && isResponding && !message.isUser;
-                                                        const isNewTurnStart = hasDivider && i === 0;
-
-                                                        const showCollabBannerInNewSection = isCollaborativeSession && i === 0 && (!hasDivider || isHistoryCollapsed || isExitingHistory);
-
-                                                        return (
-                                                            <div key={messageKey} ref={isNewTurnStart ? newTurnAnchorRef : undefined} style={isNewTurnStart ? OVERFLOW_ANCHOR_AUTO_STYLE : undefined}>
-                                                                {showCollabBannerInNewSection && (
-                                                                    <ShareNotificationMessage variant="shared-with-users" sharedBy={sessionOwnerName || "Someone"} sharedWith={["you"]} accessLevel="editor" timestamp={collaborativeTimestamp} />
-                                                                )}
-                                                                <div>
-                                                                    <ChatMessage message={message} isLastWithTaskId={isLastWithTaskId} isStreaming={shouldStream} />
-                                                                </div>
-                                                                {renderShareNotifications(index)}
+                                                            <div>
+                                                                <ChatMessage message={message} isLastWithTaskId={isLastWithTaskId} isStreaming={shouldStream} />
                                                             </div>
-                                                        );
-                                                    })}
-                                                    {isResponding && <LoadingMessageRow onViewWorkflow={handleViewProgressClick} />}
-                                                </ChatMessageList>
-                                            )}
+                                                            {renderShareNotifications(index)}
+                                                        </div>
+                                                    );
+                                                })}
+                                                {isResponding && <LoadingMessageRow onViewWorkflow={handleViewProgressClick} />}
+                                            </ChatMessageList>
                                             <div style={CHAT_STYLES}>
                                                 <ChatInputArea agents={agents} scrollToBottom={chatMessageListRef.current?.scrollToBottom} />
                                             </div>

--- a/client/webui/frontend/src/lib/contexts/ConfigContext.ts
+++ b/client/webui/frontend/src/lib/contexts/ConfigContext.ts
@@ -17,6 +17,15 @@ export interface ConfigContextValue {
     configAuthLoginUrl: string;
     configUseAuthorization: boolean;
     configWelcomeMessage: string;
+    /**
+     * Agent Mode: chat-only, single-agent layout selected per Teams tab via the
+     * `agentMode=true` URL parameter, placed in the hash query after the route
+     * (`/#/chat?agentMode=true&agent=Foo`). URL-derived (synchronous read of the
+     * hash query via getHashQueryParams), not a server-sent flag — deliberately
+     * kept out of configFeatureEnablement and never persisted to localStorage so
+     * an admin on the same origin cannot inherit a sticky Agent Mode.
+     */
+    agentMode: boolean;
     configRedirectUrl: string;
     configCollectFeedback: boolean;
     configBotName: string;

--- a/client/webui/frontend/src/lib/providers/AuthProvider.tsx
+++ b/client/webui/frontend/src/lib/providers/AuthProvider.tsx
@@ -4,6 +4,7 @@ import { useQueryClient } from "@tanstack/react-query";
 import { api, scheduleProactiveRefresh, cancelProactiveRefresh } from "@/lib/api";
 import { AuthContext } from "@/lib/contexts/AuthContext";
 import { useConfigContext, useCsrfContext } from "@/lib/hooks";
+import { stashPostLoginRedirect } from "@/lib/utils/url";
 import { EmptyState } from "../components";
 
 interface AuthProviderProps {
@@ -81,6 +82,7 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
     }, [configUseAuthorization, configAuthLoginUrl, fetchCsrfToken]);
 
     const login = () => {
+        stashPostLoginRedirect();
         window.location.href = configAuthLoginUrl;
     };
 

--- a/client/webui/frontend/src/lib/providers/ChatProvider.tsx
+++ b/client/webui/frontend/src/lib/providers/ChatProvider.tsx
@@ -10,7 +10,7 @@ import { useAutoGenerateTitle } from "@/lib/hooks/useAutoGenerateTitle";
 import { useProjectContext, registerProjectDeletedCallback } from "@/lib/providers";
 import { processChatEvent, serializeChatMessage, deserializeChatMessages } from "@/lib/providers/chat";
 import type { ChatEffect } from "@/lib/providers/chat";
-import { getErrorMessage, fileToBase64, migrateTask, CURRENT_SCHEMA_VERSION, getApiBearerToken, internalToDisplayText, extractRagDataFromTasks, uuid, getHashQueryParams } from "@/lib/utils";
+import { getErrorMessage, fileToBase64, migrateTask, CURRENT_SCHEMA_VERSION, getApiBearerToken, internalToDisplayText, extractRagDataFromTasks, uuid, getHashQueryParams, selectInitialAgent } from "@/lib/utils";
 import { ConfirmationDialog } from "@/lib/components/common/ConfirmationDialog";
 
 import type {
@@ -26,7 +26,6 @@ import type {
     Task,
     TextPart,
     ArtifactPart,
-    AgentCardInfo,
     Project,
     StoredTaskData,
     RAGSearchResult,
@@ -1783,52 +1782,22 @@ export const ChatProvider: React.FC<ChatProviderProps> = ({ children }) => {
     useEffect(() => {
         // Don't show welcome message if we're loading a session
         if (!selectedAgentName && agents.length > 0 && messages.length === 0 && !isLoadingSession) {
-            // Priority order for agent selection:
-            // 1. URL parameter agent (?agent=AgentName)
-            // 2. Project's default agent (if in project context)
-            // 3. OrchestratorAgent (fallback)
-            // 4. First available agent
-            let selectedAgent = agents[0];
+            // Read the pinned agent from the hash query (/#/chat?agent=…), not
+            // window.location.search, so the URL structure matches v2 (Go).
+            const urlAgentName = getHashQueryParams().get("agent");
+            const { agent: selectedAgent, shouldSeedWelcome } = selectInitialAgent({
+                agents,
+                urlAgentName,
+                agentMode,
+                projectDefaultAgentId: activeProject?.defaultAgentId,
+            });
 
-            // Check URL parameter first. Read from the hash query (/#/chat?agent=…),
-            // not window.location.search, so the URL structure matches v2 (Go).
-            const urlParams = getHashQueryParams();
-            const urlAgentName = urlParams.get("agent");
-            let urlAgent: AgentCardInfo | undefined;
-
-            if (urlAgentName) {
-                urlAgent = agents.find(agent => agent.name === urlAgentName);
-                if (urlAgent) {
-                    selectedAgent = urlAgent;
-                    console.log(`Using URL parameter agent: ${selectedAgent.name}`);
-                } else {
-                    console.warn(`URL parameter agent "${urlAgentName}" not found in available agents, falling back to priority order`);
-                }
-            }
-
-            // Agent Mode: pin to the named agent or wait — never fall back.
-            // When the pinned ?agent= is set but not (yet) discovered, bail entirely:
-            // leave selectedAgentName="" so the input shows a connecting state. The
-            // effect re-fires as agents register (dep array) and resolves the instant
-            // the pinned agent appears.
-            if (agentMode && urlAgentName && !urlAgent) {
+            // Agent Mode pinned agent not yet discovered: bail and leave
+            // selectedAgentName="" so the input shows a connecting state. The effect
+            // re-fires as agents register (dep array) and resolves the instant the
+            // pinned agent appears.
+            if (!selectedAgent) {
                 return;
-            }
-
-            // If no URL agent found, follow existing priority order
-            if (!urlAgent) {
-                if (activeProject?.defaultAgentId) {
-                    const projectDefaultAgent = agents.find(agent => agent.name === activeProject.defaultAgentId);
-                    if (projectDefaultAgent) {
-                        selectedAgent = projectDefaultAgent;
-                        console.log(`Using project default agent: ${selectedAgent.name}`);
-                    } else {
-                        console.warn(`Project default agent "${activeProject.defaultAgentId}" not found, falling back to OrchestratorAgent`);
-                        selectedAgent = agents.find(agent => agent.name === "OrchestratorAgent") ?? agents[0];
-                    }
-                } else {
-                    selectedAgent = agents.find(agent => agent.name === "OrchestratorAgent") ?? agents[0];
-                }
             }
 
             setSelectedAgentName(selectedAgent.name);
@@ -1836,7 +1805,7 @@ export const ChatProvider: React.FC<ChatProviderProps> = ({ children }) => {
             // Agent Mode: skip the seeded welcome bubble so messages.length === 0
             // holds and the centered hero owns the empty state. Full UI keeps its
             // left-aligned seeded bubble.
-            if (agentMode) {
+            if (!shouldSeedWelcome) {
                 return;
             }
 

--- a/client/webui/frontend/src/lib/providers/ChatProvider.tsx
+++ b/client/webui/frontend/src/lib/providers/ChatProvider.tsx
@@ -10,7 +10,7 @@ import { useAutoGenerateTitle } from "@/lib/hooks/useAutoGenerateTitle";
 import { useProjectContext, registerProjectDeletedCallback } from "@/lib/providers";
 import { processChatEvent, serializeChatMessage, deserializeChatMessages } from "@/lib/providers/chat";
 import type { ChatEffect } from "@/lib/providers/chat";
-import { getErrorMessage, fileToBase64, migrateTask, CURRENT_SCHEMA_VERSION, getApiBearerToken, internalToDisplayText, extractRagDataFromTasks, uuid } from "@/lib/utils";
+import { getErrorMessage, fileToBase64, migrateTask, CURRENT_SCHEMA_VERSION, getApiBearerToken, internalToDisplayText, extractRagDataFromTasks, uuid, getHashQueryParams } from "@/lib/utils";
 import { ConfirmationDialog } from "@/lib/components/common/ConfirmationDialog";
 
 import type {
@@ -41,7 +41,7 @@ interface ChatProviderProps {
 
 export const ChatProvider: React.FC<ChatProviderProps> = ({ children }) => {
     // ============ Hooks ============
-    const { configWelcomeMessage, persistenceEnabled, configCollectFeedback, backgroundTasksEnabled, backgroundTasksDefaultTimeoutMs, configUseAuthorization } = useConfigContext();
+    const { configWelcomeMessage, persistenceEnabled, configCollectFeedback, backgroundTasksEnabled, backgroundTasksDefaultTimeoutMs, configUseAuthorization, agentMode } = useConfigContext();
     const { value: inlineActivityTimelineEnabled } = useBooleanFlagDetails("inline_activity_timeline", false);
     const { value: showThinkingContentEnabled } = useBooleanFlagDetails("show_thinking_content", false);
     const { activeProject, setActiveProject, projects } = useProjectContext();
@@ -1790,8 +1790,9 @@ export const ChatProvider: React.FC<ChatProviderProps> = ({ children }) => {
             // 4. First available agent
             let selectedAgent = agents[0];
 
-            // Check URL parameter first
-            const urlParams = new URLSearchParams(window.location.search);
+            // Check URL parameter first. Read from the hash query (/#/chat?agent=…),
+            // not window.location.search, so the URL structure matches v2 (Go).
+            const urlParams = getHashQueryParams();
             const urlAgentName = urlParams.get("agent");
             let urlAgent: AgentCardInfo | undefined;
 
@@ -1803,6 +1804,15 @@ export const ChatProvider: React.FC<ChatProviderProps> = ({ children }) => {
                 } else {
                     console.warn(`URL parameter agent "${urlAgentName}" not found in available agents, falling back to priority order`);
                 }
+            }
+
+            // Agent Mode: pin to the named agent or wait — never fall back.
+            // When the pinned ?agent= is set but not (yet) discovered, bail entirely:
+            // leave selectedAgentName="" so the input shows a connecting state. The
+            // effect re-fires as agents register (dep array) and resolves the instant
+            // the pinned agent appears.
+            if (agentMode && urlAgentName && !urlAgent) {
+                return;
             }
 
             // If no URL agent found, follow existing priority order
@@ -1823,6 +1833,13 @@ export const ChatProvider: React.FC<ChatProviderProps> = ({ children }) => {
 
             setSelectedAgentName(selectedAgent.name);
 
+            // Agent Mode: skip the seeded welcome bubble so messages.length === 0
+            // holds and the centered hero owns the empty state. Full UI keeps its
+            // left-aligned seeded bubble.
+            if (agentMode) {
+                return;
+            }
+
             const displayedText = configWelcomeMessage || `Hi! I'm the ${selectedAgent?.displayName}. How can I help?`;
             setMessages([
                 {
@@ -1837,7 +1854,7 @@ export const ChatProvider: React.FC<ChatProviderProps> = ({ children }) => {
                 },
             ]);
         }
-    }, [agents, configWelcomeMessage, messages.length, selectedAgentName, sessionId, isLoadingSession, activeProject, setMessages]);
+    }, [agents, configWelcomeMessage, messages.length, selectedAgentName, sessionId, isLoadingSession, activeProject, setMessages, agentMode]);
 
     // Store the latest handlers in refs so they can be accessed without triggering effect re-runs
     // Note: handleSseMessageRef is declared earlier (line ~103) for use in loadSessionTasks

--- a/client/webui/frontend/src/lib/providers/ChatProvider.tsx
+++ b/client/webui/frontend/src/lib/providers/ChatProvider.tsx
@@ -368,9 +368,13 @@ export const ChatProvider: React.FC<ChatProviderProps> = ({ children }) => {
                 setRagData(allRagData);
             }
 
-            // Set the agent name if found
+            // Set the agent name if found. In Agent Mode the surface is locked to
+            // the pinned ?agent=; never let a loaded session's stored agent override
+            // it, or the next message would silently route to an agent the URL never
+            // named (the agent selector is hidden, so the user couldn't detect it).
             if (agentName) {
-                setSelectedAgentName(agentName);
+                const pinnedAgent = agentMode ? getHashQueryParams().get("agent") : null;
+                setSelectedAgentName(pinnedAgent ?? agentName);
             }
 
             // Set taskIdInSidePanel to the most recent task for workflow visualization
@@ -546,7 +550,7 @@ export const ChatProvider: React.FC<ChatProviderProps> = ({ children }) => {
             // Collaborative session detection happens in switchSession via useCollaborativeSession hook.
             // Sender info in messages is kept for UI display purposes only.
         },
-        [backgroundTasksEnabled, setRagData, setMessages, saveTaskToBackend]
+        [backgroundTasksEnabled, setRagData, setMessages, saveTaskToBackend, agentMode]
     );
 
     // Background task monitoring

--- a/client/webui/frontend/src/lib/providers/ChatProvider.tsx
+++ b/client/webui/frontend/src/lib/providers/ChatProvider.tsx
@@ -368,10 +368,13 @@ export const ChatProvider: React.FC<ChatProviderProps> = ({ children }) => {
                 setRagData(allRagData);
             }
 
-            // Set the agent name if found. In Agent Mode the surface is locked to
-            // the pinned ?agent=; never let a loaded session's stored agent override
-            // it, or the next message would silently route to an agent the URL never
-            // named (the agent selector is hidden, so the user couldn't detect it).
+            // Set the agent name if found. In Agent Mode prefer the pinned ?agent=
+            // over the loaded session's stored agent, so a cross-agent session can't
+            // silently re-route the next message (the selector is hidden, so a user
+            // couldn't detect it). Best-effort only: in-app navigation (e.g. reopening
+            // a recent chat) can strip the hash query, in which case ?agent= is absent
+            // here and we fall back to the stored agent — harmless in practice because
+            // an Agent Mode tab always pins, so the stored agent is the pinned one.
             if (agentName) {
                 const pinnedAgent = agentMode ? getHashQueryParams().get("agent") : null;
                 setSelectedAgentName(pinnedAgent ?? agentName);
@@ -1787,7 +1790,7 @@ export const ChatProvider: React.FC<ChatProviderProps> = ({ children }) => {
         // Don't show welcome message if we're loading a session
         if (!selectedAgentName && agents.length > 0 && messages.length === 0 && !isLoadingSession) {
             // Read the pinned agent from the hash query (/#/chat?agent=…), not
-            // window.location.search, so the URL structure matches v2 (Go).
+            // window.location.search, so the param travels with the hash route.
             const urlAgentName = getHashQueryParams().get("agent");
             const { agent: selectedAgent, shouldSeedWelcome } = selectInitialAgent({
                 agents,

--- a/client/webui/frontend/src/lib/providers/ConfigProvider.tsx
+++ b/client/webui/frontend/src/lib/providers/ConfigProvider.tsx
@@ -3,6 +3,7 @@ import { ConfigContext, type ConfigContextValue } from "../contexts";
 import { useCsrfContext } from "../hooks/useCsrfContext";
 import { EmptyState } from "../components";
 import { api } from "../api";
+import { getHashQueryParams } from "../utils/url";
 
 interface BackendConfig {
     frontend_server_url: string;
@@ -115,6 +116,7 @@ export function ConfigProvider({ children }: Readonly<ConfigProviderProps>) {
                     configAuthLoginUrl: data.frontend_auth_login_url,
                     configUseAuthorization: effectiveUseAuthorization,
                     configWelcomeMessage: data.frontend_welcome_message,
+                    agentMode: getHashQueryParams().get("agentMode") === "true",
                     configRedirectUrl: data.frontend_redirect_url,
                     configCollectFeedback: data.frontend_collect_feedback,
                     configBotName: data.frontend_bot_name,

--- a/client/webui/frontend/src/lib/utils/agentUtils.ts
+++ b/client/webui/frontend/src/lib/utils/agentUtils.ts
@@ -35,6 +35,47 @@ export interface WorkflowNodeConfig {
     delay?: string;
 }
 
+export interface InitialAgentSelection {
+    /** The agent to select, or null to bail (Agent Mode pinned agent not yet available). */
+    agent: AgentCardInfo | null;
+    /** Whether the caller should seed the welcome bubble. Always false in Agent Mode. */
+    shouldSeedWelcome: boolean;
+}
+
+/**
+ * Decide which agent to pin when a chat opens with no agent yet selected.
+ *
+ * Priority: URL ?agent= param, then project default, then OrchestratorAgent,
+ * then first available. In Agent Mode a pinned ?agent= that isn't available yet
+ * bails (agent === null) so the caller waits for it to register, and the welcome
+ * bubble is never seeded.
+ *
+ * Callers must guarantee `agents` is non-empty.
+ */
+export function selectInitialAgent({ agents, urlAgentName, agentMode, projectDefaultAgentId }: { agents: AgentCardInfo[]; urlAgentName: string | null; agentMode: boolean; projectDefaultAgentId?: string | null }): InitialAgentSelection {
+    let selectedAgent = agents[0];
+
+    const urlAgent = urlAgentName ? agents.find(agent => agent.name === urlAgentName) : undefined;
+    if (urlAgent) {
+        selectedAgent = urlAgent;
+    }
+
+    // Agent Mode: pin to the named agent or wait — never fall back.
+    if (agentMode && urlAgentName && !urlAgent) {
+        return { agent: null, shouldSeedWelcome: false };
+    }
+
+    if (!urlAgent) {
+        if (projectDefaultAgentId) {
+            selectedAgent = agents.find(agent => agent.name === projectDefaultAgentId) ?? agents.find(agent => agent.name === "OrchestratorAgent") ?? agents[0];
+        } else {
+            selectedAgent = agents.find(agent => agent.name === "OrchestratorAgent") ?? agents[0];
+        }
+    }
+
+    return { agent: selectedAgent, shouldSeedWelcome: !agentMode };
+}
+
 /**
  * Extract agent type from agent card extensions
  */

--- a/client/webui/frontend/src/lib/utils/url.test.ts
+++ b/client/webui/frontend/src/lib/utils/url.test.ts
@@ -1,5 +1,7 @@
 import { describe, it, expect, afterEach } from "vitest";
-import { getHashQueryParams } from "./url";
+import { getHashQueryParams, stashPostLoginRedirect, consumePostLoginRedirect } from "./url";
+
+const POST_LOGIN_REDIRECT_KEY = "sam_post_login_redirect";
 
 describe("getHashQueryParams", () => {
     afterEach(() => {
@@ -29,5 +31,45 @@ describe("getHashQueryParams", () => {
         const params = getHashQueryParams();
         expect(params.get("agentMode")).toBeNull();
         expect(params.get("agent")).toBeNull();
+    });
+});
+
+describe("post-login redirect stash/restore", () => {
+    afterEach(() => {
+        localStorage.removeItem(POST_LOGIN_REDIRECT_KEY);
+        window.history.replaceState({}, "", "/");
+    });
+
+    it("stashes the current URL and restores it once", () => {
+        window.history.replaceState({}, "", "/#/chat?agentMode=true&agent=Foo");
+        stashPostLoginRedirect();
+        expect(localStorage.getItem(POST_LOGIN_REDIRECT_KEY)).toContain("agentMode=true");
+
+        const restored = consumePostLoginRedirect();
+        expect(restored).toContain("/#/chat?agentMode=true&agent=Foo");
+    });
+
+    it("is one-shot — the key is cleared after the first read", () => {
+        window.history.replaceState({}, "", "/#/chat?agentMode=true&agent=Foo");
+        stashPostLoginRedirect();
+
+        consumePostLoginRedirect();
+        expect(localStorage.getItem(POST_LOGIN_REDIRECT_KEY)).toBeNull();
+        // A second consume has nothing to restore and falls back to "/".
+        expect(consumePostLoginRedirect()).toBe("/");
+    });
+
+    it("falls back to / when nothing was stashed", () => {
+        expect(consumePostLoginRedirect()).toBe("/");
+    });
+
+    it("rejects a cross-origin stashed value (open-redirect guard)", () => {
+        localStorage.setItem(POST_LOGIN_REDIRECT_KEY, "https://evil.example.com/#/chat?agentMode=true");
+        expect(consumePostLoginRedirect()).toBe("/");
+    });
+
+    it("rejects an unparseable stashed value", () => {
+        localStorage.setItem(POST_LOGIN_REDIRECT_KEY, "not-a-url");
+        expect(consumePostLoginRedirect()).toBe("/");
     });
 });

--- a/client/webui/frontend/src/lib/utils/url.test.ts
+++ b/client/webui/frontend/src/lib/utils/url.test.ts
@@ -1,0 +1,33 @@
+import { describe, it, expect, afterEach } from "vitest";
+import { getHashQueryParams } from "./url";
+
+describe("getHashQueryParams", () => {
+    afterEach(() => {
+        // Reset both search and hash so cases don't bleed into each other.
+        window.history.replaceState({}, "", "/");
+    });
+
+    it("parses the query segment that follows the hash route", () => {
+        window.history.replaceState({}, "", "/#/chat?agentMode=true&agent=Foo");
+        const params = getHashQueryParams();
+        expect(params.get("agentMode")).toBe("true");
+        expect(params.get("agent")).toBe("Foo");
+    });
+
+    it("returns no params when the hash route carries no query", () => {
+        window.history.replaceState({}, "", "/#/chat");
+        const params = getHashQueryParams();
+        expect(params.get("agentMode")).toBeNull();
+        expect(params.get("agent")).toBeNull();
+    });
+
+    it("ignores a real query string before the hash (reads hash, not search)", () => {
+        // This is the whole reason the helper exists: params in window.location.search
+        // (the rejected before-# form) must NOT activate Agent Mode.
+        window.history.replaceState({}, "", "/?agentMode=true&agent=Foo#/chat");
+        expect(window.location.search).toBe("?agentMode=true&agent=Foo"); // precondition
+        const params = getHashQueryParams();
+        expect(params.get("agentMode")).toBeNull();
+        expect(params.get("agent")).toBeNull();
+    });
+});

--- a/client/webui/frontend/src/lib/utils/url.ts
+++ b/client/webui/frontend/src/lib/utils/url.ts
@@ -31,3 +31,17 @@ export function getCleanDomain(url: string): string {
 export function getFaviconUrl(domain: string, size: number = 32): string {
     return `https://www.google.com/s2/favicons?domain=${domain}&sz=${size}`;
 }
+
+/**
+ * Agent Mode params live in the query segment of the hash route, after the
+ * route path: `/#/chat?agentMode=true&agent=Foo`. We read them from
+ * window.location.hash (not window.location.search) so the URL structure stays
+ * identical to v2 (Go), where the same query attaches to a real path:
+ * `/chat?agentMode=true&agent=Foo`. Migrating v1→v2 is then just dropping the
+ * `#`. Synchronous + read-once-at-load, so no Full-UI flash.
+ */
+export function getHashQueryParams(): URLSearchParams {
+    const hash = window.location.hash;
+    const queryIndex = hash.indexOf("?");
+    return new URLSearchParams(queryIndex >= 0 ? hash.slice(queryIndex + 1) : "");
+}

--- a/client/webui/frontend/src/lib/utils/url.ts
+++ b/client/webui/frontend/src/lib/utils/url.ts
@@ -45,3 +45,41 @@ export function getHashQueryParams(): URLSearchParams {
     const queryIndex = hash.indexOf("?");
     return new URLSearchParams(queryIndex >= 0 ? hash.slice(queryIndex + 1) : "");
 }
+
+const POST_LOGIN_REDIRECT_KEY = "sam_post_login_redirect";
+
+/**
+ * Remember the current URL before leaving the SPA for the IdP, so the Agent Mode
+ * params (which the login round-trip would otherwise drop) can be restored after
+ * the callback. Written at every exit-to-login site.
+ */
+export function stashPostLoginRedirect(): void {
+    try {
+        localStorage.setItem(POST_LOGIN_REDIRECT_KEY, window.location.href);
+    } catch {
+        // localStorage unavailable (private mode / disabled) — restore falls back to "/".
+    }
+}
+
+/**
+ * Read and clear the stashed post-login URL. One-shot (deleted on read) and
+ * same-origin checked so a poisoned key cannot drive an open redirect. Falls back
+ * to "/" when absent, unparseable, or cross-origin.
+ */
+export function consumePostLoginRedirect(): string {
+    let stashed: string | null = null;
+    try {
+        stashed = localStorage.getItem(POST_LOGIN_REDIRECT_KEY);
+        localStorage.removeItem(POST_LOGIN_REDIRECT_KEY);
+    } catch {
+        return "/";
+    }
+    if (!stashed) return "/";
+    try {
+        const url = new URL(stashed);
+        if (url.origin === window.location.origin) return url.href;
+    } catch {
+        // Not an absolute same-origin URL — ignore.
+    }
+    return "/";
+}

--- a/client/webui/frontend/src/lib/utils/url.ts
+++ b/client/webui/frontend/src/lib/utils/url.ts
@@ -35,10 +35,8 @@ export function getFaviconUrl(domain: string, size: number = 32): string {
 /**
  * Agent Mode params live in the query segment of the hash route, after the
  * route path: `/#/chat?agentMode=true&agent=Foo`. We read them from
- * window.location.hash (not window.location.search) so the URL structure stays
- * identical to v2 (Go), where the same query attaches to a real path:
- * `/chat?agentMode=true&agent=Foo`. Migrating v1→v2 is then just dropping the
- * `#`. Synchronous + read-once-at-load, so no Full-UI flash.
+ * window.location.hash (not window.location.search) so the params travel with
+ * the hash route. Synchronous + read-once-at-load, so no Full-UI flash.
  */
 export function getHashQueryParams(): URLSearchParams {
     const hash = window.location.hash;

--- a/client/webui/frontend/src/stories/chat/AgentModeWelcome.test.tsx
+++ b/client/webui/frontend/src/stories/chat/AgentModeWelcome.test.tsx
@@ -1,0 +1,29 @@
+/// <reference types="@testing-library/jest-dom" />
+import { render, screen } from "@testing-library/react";
+import { describe, test, expect } from "vitest";
+import * as matchers from "@testing-library/jest-dom/matchers";
+
+import { AgentModeWelcome } from "@/lib/components/chat/AgentModeWelcome";
+
+expect.extend(matchers);
+
+describe("AgentModeWelcome", () => {
+    test("renders the default prompt when no message is provided", () => {
+        render(<AgentModeWelcome />);
+
+        expect(screen.getByText("How can I help?")).toBeInTheDocument();
+    });
+
+    test("renders the provided message instead of the default", () => {
+        render(<AgentModeWelcome message="Ask me anything" />);
+
+        expect(screen.getByText("Ask me anything")).toBeInTheDocument();
+        expect(screen.queryByText("How can I help?")).not.toBeInTheDocument();
+    });
+
+    test("falls back to the default prompt for an empty message", () => {
+        render(<AgentModeWelcome message="" />);
+
+        expect(screen.getByText("How can I help?")).toBeInTheDocument();
+    });
+});

--- a/client/webui/frontend/src/stories/chat/AgentModeWelcome.test.tsx
+++ b/client/webui/frontend/src/stories/chat/AgentModeWelcome.test.tsx
@@ -8,22 +8,14 @@ import { AgentModeWelcome } from "@/lib/components/chat/AgentModeWelcome";
 expect.extend(matchers);
 
 describe("AgentModeWelcome", () => {
-    test("renders the default prompt when no message is provided", () => {
-        render(<AgentModeWelcome />);
-
-        expect(screen.getByText("How can I help?")).toBeInTheDocument();
-    });
-
-    test("renders the provided message instead of the default", () => {
-        render(<AgentModeWelcome message="Ask me anything" />);
-
+    test("renders the provided message, falling back to the default when absent or empty", () => {
+        const { rerender } = render(<AgentModeWelcome message="Ask me anything" />);
         expect(screen.getByText("Ask me anything")).toBeInTheDocument();
-        expect(screen.queryByText("How can I help?")).not.toBeInTheDocument();
-    });
 
-    test("falls back to the default prompt for an empty message", () => {
-        render(<AgentModeWelcome message="" />);
+        rerender(<AgentModeWelcome message="" />);
+        expect(screen.getByText("How can I help?")).toBeInTheDocument();
 
+        rerender(<AgentModeWelcome />);
         expect(screen.getByText("How can I help?")).toBeInTheDocument();
     });
 });

--- a/client/webui/frontend/src/stories/chat/ArtifactsPage.test.tsx
+++ b/client/webui/frontend/src/stories/chat/ArtifactsPage.test.tsx
@@ -22,6 +22,7 @@ const mockConfig: ConfigContextValue = {
     configAuthLoginUrl: "",
     configUseAuthorization: false,
     configWelcomeMessage: "",
+    agentMode: false,
     configRedirectUrl: "",
     configCollectFeedback: false,
     configBotName: "",

--- a/client/webui/frontend/src/stories/chat/ChatInputArea.test.tsx
+++ b/client/webui/frontend/src/stories/chat/ChatInputArea.test.tsx
@@ -555,3 +555,34 @@ describe("Agent Mode no-agent-no-send guard", () => {
         });
     });
 });
+
+// ---------------------------------------------------------------------------
+// Agent Mode: agent selector hidden
+// ---------------------------------------------------------------------------
+
+describe("Agent Mode hides the agent selector", () => {
+    test("the agent selector is not rendered in Agent Mode", () => {
+        const firstAgent = mockAgents[0];
+        render(
+            <MemoryRouter>
+                <StoryProvider chatContextValues={{ selectedAgentName: firstAgent.name }} configContextValues={{ agentMode: true }}>
+                    <ChatInputArea agents={mockAgents} />
+                </StoryProvider>
+            </MemoryRouter>
+        );
+        expect(screen.queryByText("Select an agent...")).not.toBeInTheDocument();
+        expect(screen.queryByText("Agent:")).not.toBeInTheDocument();
+    });
+
+    test("the agent selector is rendered in Full UI", () => {
+        const firstAgent = mockAgents[0];
+        render(
+            <MemoryRouter>
+                <StoryProvider chatContextValues={{ selectedAgentName: firstAgent.name }} configContextValues={{ agentMode: false }}>
+                    <ChatInputArea agents={mockAgents} />
+                </StoryProvider>
+            </MemoryRouter>
+        );
+        expect(screen.getByText(firstAgent.displayName ?? firstAgent.name ?? "")).toBeInTheDocument();
+    });
+});

--- a/client/webui/frontend/src/stories/chat/ChatInputArea.test.tsx
+++ b/client/webui/frontend/src/stories/chat/ChatInputArea.test.tsx
@@ -514,3 +514,44 @@ describe("form submission", () => {
         expect(handleCancel).toHaveBeenCalled();
     });
 });
+
+// ---------------------------------------------------------------------------
+// Agent Mode: no agent, no send
+// ---------------------------------------------------------------------------
+
+describe("Agent Mode no-agent-no-send guard", () => {
+    test("send stays disabled with text while the pinned agent is unresolved", async () => {
+        renderComponent({ isResponding: false, selectedAgentName: "" }, { agentMode: true });
+
+        const input = screen.getByTestId("chat-input");
+        await userEvent.click(input);
+        await userEvent.keyboard("Hello");
+
+        // Text is present, but Agent Mode blocks sending until an agent resolves.
+        expect(screen.getByTestId("sendMessage")).toBeDisabled();
+    });
+
+    test("send enables with text once the pinned agent resolves", async () => {
+        renderComponent({ isResponding: false, selectedAgentName: "Foo" }, { agentMode: true });
+
+        const input = screen.getByTestId("chat-input");
+        await userEvent.click(input);
+        await userEvent.keyboard("Hello");
+
+        await waitFor(() => {
+            expect(screen.getByTestId("sendMessage")).toBeEnabled();
+        });
+    });
+
+    test("Full UI does not gate sending on a selected agent", async () => {
+        renderComponent({ isResponding: false, selectedAgentName: "" }, { agentMode: false });
+
+        const input = screen.getByTestId("chat-input");
+        await userEvent.click(input);
+        await userEvent.keyboard("Hello");
+
+        await waitFor(() => {
+            expect(screen.getByTestId("sendMessage")).toBeEnabled();
+        });
+    });
+});

--- a/client/webui/frontend/src/stories/chat/ChatInputArea.test.tsx
+++ b/client/webui/frontend/src/stories/chat/ChatInputArea.test.tsx
@@ -447,6 +447,25 @@ describe("prompt command trigger", () => {
             expect(screen.getByTestId("promptCommand")).toBeInTheDocument();
         });
     });
+
+    test("Agent Mode never opens the prompts popup when '/' is typed", async () => {
+        renderComponent({ selectedAgentName: mockAgents[0].name }, { agentMode: true });
+        const input = screen.getByTestId("chat-input");
+
+        await userEvent.click(input);
+        await userEvent.keyboard("/");
+
+        // Prompts are disallowed in Agent Mode — the popup must not appear.
+        expect(screen.queryByTestId("promptCommand")).not.toBeInTheDocument();
+    });
+
+    test("Agent Mode placeholder omits the 'insert a prompt' hint", () => {
+        renderComponent({ selectedAgentName: mockAgents[0].name }, { agentMode: true });
+        const placeholder = screen.getByTestId("chat-input").getAttribute("data-placeholder") || "";
+
+        expect(placeholder).toContain("How can I help you today?");
+        expect(placeholder).not.toContain("insert a prompt");
+    });
 });
 
 // ---------------------------------------------------------------------------

--- a/client/webui/frontend/src/stories/chat/ChatPage.stories.tsx
+++ b/client/webui/frontend/src/stories/chat/ChatPage.stories.tsx
@@ -69,6 +69,34 @@ export const Default: Story = {
     },
 };
 
+export const AgentMode: Story = {
+    parameters: {
+        chatContext: {
+            sessionId: "mock-session-id",
+            messages: [],
+            isResponding: false,
+            isCancelling: false,
+            selectedAgentName: "OrchestratorAgent",
+            isSidePanelCollapsed: true,
+            activeSidePanelTab: "files",
+        },
+        configContext: {
+            persistenceEnabled: false,
+            agentMode: true,
+        },
+    },
+    play: async ({ canvasElement }) => {
+        const canvas = within(canvasElement);
+
+        // The hero welcome owns the empty state, the input is ready to send.
+        await canvas.findByText("How can I help?");
+        await canvas.findByTestId("sendMessage");
+
+        // Agent Mode chrome: the agent selector is hidden.
+        expect(canvas.queryByText("Select an agent...")).toBeNull();
+    },
+};
+
 export const WithLoadingMessage: Story = {
     parameters: {
         chatContext: {

--- a/client/webui/frontend/src/stories/chat/ChatPage.stories.tsx
+++ b/client/webui/frontend/src/stories/chat/ChatPage.stories.tsx
@@ -89,7 +89,8 @@ export const AgentMode: Story = {
         const canvas = within(canvasElement);
 
         // The hero welcome owns the empty state, the input is ready to send.
-        await canvas.findByText("How can I help?");
+        // No configured welcome message → per-agent greeting from the selected agent.
+        await canvas.findByText(/^Hi, I'm .+\. How can I help you\?$/);
         await canvas.findByTestId("sendMessage");
 
         // Agent Mode chrome: the agent selector is hidden.

--- a/client/webui/frontend/src/stories/chat/ChatPage.stories.tsx
+++ b/client/webui/frontend/src/stories/chat/ChatPage.stories.tsx
@@ -101,6 +101,65 @@ export const AgentMode: Story = {
     },
 };
 
+// A single completed agent message carrying a taskId — the shape that renders the
+// "View Activity" affordance (ViewWorkflowButton) under the message.
+const completedAgentMessage: MessageFE = {
+    isUser: false,
+    parts: [{ kind: "text", text: "Here is your poem." }],
+    isComplete: true,
+    taskId: "task-1",
+    metadata: { sessionId: "mock-session-id", lastProcessedEventSequence: 0, messageId: "m1" },
+};
+
+export const AgentModeHidesViewActivity: Story = {
+    parameters: {
+        chatContext: {
+            sessionId: "mock-session-id",
+            messages: [completedAgentMessage],
+            isResponding: false,
+            isCancelling: false,
+            selectedAgentName: "OrchestratorAgent",
+            isSidePanelCollapsed: true,
+            activeSidePanelTab: "files",
+        },
+        configContext: {
+            persistenceEnabled: false,
+            agentMode: true,
+        },
+    },
+    play: async ({ canvasElement }) => {
+        const canvas = within(canvasElement);
+
+        // The message rendered, but the View Activity button is hidden because the
+        // Activity panel it opens is unavailable in Agent Mode.
+        await canvas.findByText("Here is your poem.");
+        expect(canvas.queryByTestId("viewActivity")).toBeNull();
+    },
+};
+
+export const ViewActivityVisibleInFullUI: Story = {
+    parameters: {
+        chatContext: {
+            sessionId: "mock-session-id",
+            messages: [completedAgentMessage],
+            isResponding: false,
+            isCancelling: false,
+            selectedAgentName: "OrchestratorAgent",
+            isSidePanelCollapsed: true,
+            activeSidePanelTab: "files",
+        },
+        configContext: {
+            persistenceEnabled: false,
+        },
+    },
+    play: async ({ canvasElement }) => {
+        const canvas = within(canvasElement);
+
+        // Control for AgentModeHidesViewActivity: the same message shows the button in Full UI.
+        await canvas.findByTestId("viewActivity");
+    },
+};
+
 export const WithLoadingMessage: Story = {
     parameters: {
         chatContext: {

--- a/client/webui/frontend/src/stories/chat/ChatPage.stories.tsx
+++ b/client/webui/frontend/src/stories/chat/ChatPage.stories.tsx
@@ -83,6 +83,9 @@ export const AgentMode: Story = {
         configContext: {
             persistenceEnabled: false,
             agentMode: true,
+            // Empty so the hero falls through to the per-agent greeting rather than
+            // the mock provider's default configWelcomeMessage.
+            configWelcomeMessage: "",
         },
     },
     play: async ({ canvasElement }) => {

--- a/client/webui/frontend/src/stories/chat/ChatPage.test.tsx
+++ b/client/webui/frontend/src/stories/chat/ChatPage.test.tsx
@@ -155,6 +155,7 @@ describe("ChatPage", () => {
         }));
 
         vi.doMock("@/lib/components/chat", () => ({
+            AgentModeWelcome: ({ message }: { message?: string }) => React.createElement("div", { "data-testid": "agent-mode-welcome" }, message || "How can I help?"),
             ChatMessage: ({ message }: { message: { parts: Array<{ text?: string }> } }) => React.createElement("div", { "data-testid": "chat-message" }, message.parts?.[0]?.text || ""),
             ChatSessionDialog: () => React.createElement("div", { "data-testid": "chat-session-dialog" }),
             ChatSessionDeleteDialog: () => React.createElement("div", { "data-testid": "chat-session-delete-dialog" }),

--- a/client/webui/frontend/src/stories/chat/ChatPage.test.tsx
+++ b/client/webui/frontend/src/stories/chat/ChatPage.test.tsx
@@ -261,4 +261,46 @@ describe("ChatPage", () => {
         // Share button should NOT be present for collaborative sessions
         expect(screen.queryByTestId("share-button")).not.toBeInTheDocument();
     });
+
+    describe("Agent Mode empty state", () => {
+        test("shows the connecting state when the pinned agent is not yet resolved", () => {
+            mockUseConfigContext.mockReturnValue({ agentMode: true });
+            mockUseChatContext.mockReturnValue(makeDefaultChatContext({ messages: [], selectedAgentName: "" }));
+
+            renderPage();
+            expect(screen.getByText("Connecting…")).toBeInTheDocument();
+            // The hero and the message list must not own the empty state while connecting.
+            expect(screen.queryByTestId("chat-message-list")).not.toBeInTheDocument();
+            expect(screen.queryByText("How can I help?")).not.toBeInTheDocument();
+        });
+
+        test("shows the hero welcome once the pinned agent resolves", () => {
+            mockUseConfigContext.mockReturnValue({ agentMode: true });
+            mockUseChatContext.mockReturnValue(makeDefaultChatContext({ messages: [], selectedAgentName: "Foo" }));
+
+            renderPage();
+            expect(screen.getByText("How can I help?")).toBeInTheDocument();
+            expect(screen.queryByText("Connecting…")).not.toBeInTheDocument();
+            // Hero owns the empty state — no message list (and thus no seeded bubble).
+            expect(screen.queryByTestId("chat-message-list")).not.toBeInTheDocument();
+        });
+
+        test("hero uses configWelcomeMessage when provided", () => {
+            mockUseConfigContext.mockReturnValue({ agentMode: true, configWelcomeMessage: "Ask me anything" });
+            mockUseChatContext.mockReturnValue(makeDefaultChatContext({ messages: [], selectedAgentName: "Foo" }));
+
+            renderPage();
+            expect(screen.getByText("Ask me anything")).toBeInTheDocument();
+        });
+
+        test("Full UI empty state renders the message list, not the Agent Mode hero", () => {
+            mockUseConfigContext.mockReturnValue({ agentMode: false });
+            mockUseChatContext.mockReturnValue(makeDefaultChatContext({ messages: [], selectedAgentName: "" }));
+
+            renderPage();
+            expect(screen.getByTestId("chat-message-list")).toBeInTheDocument();
+            expect(screen.queryByText("Connecting…")).not.toBeInTheDocument();
+            expect(screen.queryByText("How can I help?")).not.toBeInTheDocument();
+        });
+    });
 });

--- a/client/webui/frontend/src/stories/chat/ChatPage.test.tsx
+++ b/client/webui/frontend/src/stories/chat/ChatPage.test.tsx
@@ -1,6 +1,6 @@
 /// <reference types="@testing-library/jest-dom" />
 import React from "react";
-import { render, screen } from "@testing-library/react";
+import { render, screen, act } from "@testing-library/react";
 import { describe, test, expect, vi, beforeEach } from "vitest";
 import * as matchers from "@testing-library/jest-dom/matchers";
 import { MemoryRouter } from "react-router-dom";
@@ -291,6 +291,27 @@ describe("ChatPage", () => {
 
             renderPage();
             expect(screen.getByText("Ask me anything")).toBeInTheDocument();
+        });
+
+        test("falls back to an unavailable message if the pinned agent never resolves", () => {
+            vi.useFakeTimers();
+            try {
+                mockUseConfigContext.mockReturnValue({ agentMode: true });
+                mockUseChatContext.mockReturnValue(makeDefaultChatContext({ messages: [], selectedAgentName: "" }));
+
+                renderPage();
+                // Starts on the connecting spinner...
+                expect(screen.getByText("Connecting…")).toBeInTheDocument();
+
+                // ...and after the timeout shows a terminal state instead of spinning forever.
+                act(() => {
+                    vi.advanceTimersByTime(15000);
+                });
+                expect(screen.getByText("This agent is currently unavailable.")).toBeInTheDocument();
+                expect(screen.queryByText("Connecting…")).not.toBeInTheDocument();
+            } finally {
+                vi.useRealTimers();
+            }
         });
 
         test("Full UI empty state renders the message list, not the Agent Mode hero", () => {

--- a/client/webui/frontend/src/stories/chat/ChatPage.test.tsx
+++ b/client/webui/frontend/src/stories/chat/ChatPage.test.tsx
@@ -280,10 +280,38 @@ describe("ChatPage", () => {
             mockUseChatContext.mockReturnValue(makeDefaultChatContext({ messages: [], selectedAgentName: "Foo" }));
 
             renderPage();
-            expect(screen.getByText("How can I help?")).toBeInTheDocument();
+            // No configured welcome message and no matching agent card → per-agent greeting from selectedAgentName.
+            expect(screen.getByText("Hi, I'm Foo. How can I help you?")).toBeInTheDocument();
             expect(screen.queryByText("Connecting…")).not.toBeInTheDocument();
             // Hero owns the empty state — no message list (and thus no seeded bubble).
             expect(screen.queryByTestId("chat-message-list")).not.toBeInTheDocument();
+        });
+
+        test("hero greeting uses the matched agent's displayName", () => {
+            mockUseConfigContext.mockReturnValue({ agentMode: true });
+            mockUseChatContext.mockReturnValue(
+                makeDefaultChatContext({
+                    messages: [],
+                    selectedAgentName: "agent-uuid-123",
+                    agents: [{ name: "agent-uuid-123", displayName: "Weather Agent" }],
+                })
+            );
+
+            renderPage();
+            expect(screen.getByText("Hi, I'm Weather Agent. How can I help you?")).toBeInTheDocument();
+        });
+
+        test("renders the chat input within the centered welcome group, not bottom-docked", () => {
+            mockUseConfigContext.mockReturnValue({ agentMode: true });
+            mockUseChatContext.mockReturnValue(makeDefaultChatContext({ messages: [], selectedAgentName: "Foo" }));
+
+            renderPage();
+            const welcome = screen.getByTestId("agent-mode-welcome");
+            const input = screen.getByTestId("chat-input-area");
+            // The 900px-capped group centers the hero and holds the input as a sibling.
+            const group = welcome.parentElement as HTMLElement;
+            expect(group).toHaveStyle({ maxWidth: "900px" });
+            expect(group.contains(input)).toBe(true);
         });
 
         test("hero uses configWelcomeMessage when provided", () => {

--- a/client/webui/frontend/src/stories/chat/ChatSidePanel.test.tsx
+++ b/client/webui/frontend/src/stories/chat/ChatSidePanel.test.tsx
@@ -65,3 +65,52 @@ describe("projectIndexing feature flag", () => {
         expect(screen.queryByText(/6 Sources/)).not.toBeInTheDocument();
     });
 });
+
+describe("Agent Mode hides the Activity tab", () => {
+    const taskContext = {
+        isReconnecting: false,
+        isTaskMonitorConnecting: false,
+        isTaskMonitorConnected: true,
+        monitoredTasks: {},
+        loadTaskFromBackend: vi.fn().mockResolvedValue(null),
+    };
+
+    test("expanded panel hides the Activity tab in Agent Mode but keeps Files", () => {
+        render(
+            <MemoryRouter>
+                <StoryProvider chatContextValues={{ activeSidePanelTab: "files" as const }} taskContextValues={taskContext} configContextValues={{ agentMode: true }}>
+                    <ChatSidePanel onCollapsedToggle={vi.fn()} isSidePanelCollapsed={false} setIsSidePanelCollapsed={vi.fn()} />
+                </StoryProvider>
+            </MemoryRouter>
+        );
+
+        expect(screen.getByTitle("Files")).toBeInTheDocument();
+        expect(screen.queryByTitle("Activity")).not.toBeInTheDocument();
+    });
+
+    test("expanded panel shows the Activity tab in Full UI", () => {
+        render(
+            <MemoryRouter>
+                <StoryProvider chatContextValues={{ activeSidePanelTab: "files" as const }} taskContextValues={taskContext} configContextValues={{ agentMode: false }}>
+                    <ChatSidePanel onCollapsedToggle={vi.fn()} isSidePanelCollapsed={false} setIsSidePanelCollapsed={vi.fn()} />
+                </StoryProvider>
+            </MemoryRouter>
+        );
+
+        expect(screen.getByTitle("Files")).toBeInTheDocument();
+        expect(screen.getByTitle("Activity")).toBeInTheDocument();
+    });
+
+    test("collapsed panel hides the Activity icon in Agent Mode", () => {
+        render(
+            <MemoryRouter>
+                <StoryProvider chatContextValues={{ activeSidePanelTab: "files" as const }} taskContextValues={taskContext} configContextValues={{ agentMode: true }}>
+                    <ChatSidePanel onCollapsedToggle={vi.fn()} isSidePanelCollapsed={true} setIsSidePanelCollapsed={vi.fn()} />
+                </StoryProvider>
+            </MemoryRouter>
+        );
+
+        expect(screen.getByLabelText("Files")).toBeInTheDocument();
+        expect(screen.queryByLabelText("Activity")).not.toBeInTheDocument();
+    });
+});

--- a/client/webui/frontend/src/stories/chat/SessionActionMenu.test.tsx
+++ b/client/webui/frontend/src/stories/chat/SessionActionMenu.test.tsx
@@ -1,0 +1,63 @@
+/// <reference types="@testing-library/jest-dom" />
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, test, expect, vi } from "vitest";
+import * as matchers from "@testing-library/jest-dom/matchers";
+
+import { SessionActionMenu } from "@/lib/components/chat/SessionActionMenu";
+import { StoryProvider } from "../mocks/StoryProvider";
+import type { Session } from "@/lib/types";
+
+expect.extend(matchers);
+
+const session: Session = {
+    id: "s1",
+    createdTime: "2024-01-01T00:00:00Z",
+    updatedTime: "2024-01-01T00:00:00Z",
+    name: "Session One",
+    projectId: "p1",
+    projectName: "Project One",
+};
+
+const renderMenu = (agentMode: boolean) =>
+    render(
+        <StoryProvider configContextValues={{ agentMode }}>
+            <SessionActionMenu
+                session={session}
+                onRename={vi.fn()}
+                onRenameWithAI={vi.fn()}
+                onMove={vi.fn()}
+                onDelete={vi.fn()}
+                onGoToProject={vi.fn()}
+                onShare={vi.fn()}
+            />
+        </StoryProvider>
+    );
+
+describe("SessionActionMenu Agent Mode", () => {
+    test("shows only Rename, Rename with AI, and Delete in Agent Mode", async () => {
+        const user = userEvent.setup();
+        renderMenu(true);
+
+        await user.click(screen.getByRole("button"));
+
+        expect(await screen.findByText("Rename")).toBeInTheDocument();
+        expect(screen.getByText("Rename with AI")).toBeInTheDocument();
+        expect(screen.getByText("Delete")).toBeInTheDocument();
+
+        expect(screen.queryByText("Move to Project")).not.toBeInTheDocument();
+        expect(screen.queryByText("Go to Project")).not.toBeInTheDocument();
+        expect(screen.queryByText("Share")).not.toBeInTheDocument();
+    });
+
+    test("shows project and share actions in Full UI", async () => {
+        const user = userEvent.setup();
+        renderMenu(false);
+
+        await user.click(screen.getByRole("button"));
+
+        expect(await screen.findByText("Move to Project")).toBeInTheDocument();
+        expect(screen.getByText("Go to Project")).toBeInTheDocument();
+        expect(screen.getByText("Share")).toBeInTheDocument();
+    });
+});

--- a/client/webui/frontend/src/stories/hooks/useIsChatSharingEnabled.test.tsx
+++ b/client/webui/frontend/src/stories/hooks/useIsChatSharingEnabled.test.tsx
@@ -16,6 +16,7 @@ function makeConfigValue(overrides: Partial<ConfigContextValue> = {}): ConfigCon
         configAuthLoginUrl: "",
         configUseAuthorization: false,
         configWelcomeMessage: "",
+        agentMode: false,
         configRedirectUrl: "",
         configCollectFeedback: false,
         configBotName: "",

--- a/client/webui/frontend/src/stories/layout/AppLayout.test.tsx
+++ b/client/webui/frontend/src/stories/layout/AppLayout.test.tsx
@@ -33,6 +33,22 @@ beforeEach(() => {
     vi.spyOn(modelsApi, "useModelConfigStatus").mockImplementation((() => mockModelConfigStatus()) as unknown as typeof modelsApi.useModelConfigStatus);
 });
 
+describe("AppLayout navigation sidebar (old nav)", () => {
+    beforeEach(() => {
+        mockModelConfigStatus.mockReturnValue({ data: { configured: true } });
+    });
+
+    test("renders the navigation sidebar in Full UI", async () => {
+        await renderWithProviders(<AppLayout />, { configContextValues: { agentMode: false } });
+        expect(screen.getByTestId("navigation-sidebar")).toBeInTheDocument();
+    });
+
+    test("hides the navigation sidebar in Agent Mode", async () => {
+        await renderWithProviders(<AppLayout />, { configContextValues: { agentMode: true } });
+        expect(screen.queryByTestId("navigation-sidebar")).not.toBeInTheDocument();
+    });
+});
+
 describe("AppLayout model warning banner", () => {
     describe("when model_config_ui flag is disabled", () => {
         beforeEach(() => {

--- a/client/webui/frontend/src/stories/mocks/MockConfigProvider.tsx
+++ b/client/webui/frontend/src/stories/mocks/MockConfigProvider.tsx
@@ -9,6 +9,7 @@ const defaultMockConfigContext: ConfigContextValue = {
     configAuthLoginUrl: "http://localhost:8000/auth/login",
     configUseAuthorization: false,
     configWelcomeMessage: "Welcome to the mock Solace Agent Mesh!",
+    agentMode: false,
     configRedirectUrl: "http://localhost:3000",
     configCollectFeedback: false,
     configBotName: "Mock Bot",

--- a/client/webui/frontend/src/stories/utils/agentUtils.test.ts
+++ b/client/webui/frontend/src/stories/utils/agentUtils.test.ts
@@ -1,0 +1,79 @@
+import { describe, test, expect } from "vitest";
+import { selectInitialAgent } from "@/lib/utils/agentUtils";
+import type { AgentCardInfo } from "@/lib/types";
+
+const agent = (name: string): AgentCardInfo => ({ name, displayName: name }) as unknown as AgentCardInfo;
+
+const orchestrator = agent("OrchestratorAgent");
+const alpha = agent("AlphaAgent");
+const beta = agent("BetaAgent");
+
+describe("selectInitialAgent — pinned agent (Agent Mode)", () => {
+    test("selects the URL agent and never seeds the welcome bubble", () => {
+        const result = selectInitialAgent({ agents: [orchestrator, alpha], urlAgentName: "AlphaAgent", agentMode: true });
+
+        expect(result.agent).toBe(alpha);
+        expect(result.shouldSeedWelcome).toBe(false);
+    });
+
+    test("bails when the pinned agent is not yet available", () => {
+        const result = selectInitialAgent({ agents: [orchestrator], urlAgentName: "AlphaAgent", agentMode: true });
+
+        expect(result.agent).toBeNull();
+        expect(result.shouldSeedWelcome).toBe(false);
+    });
+
+    test("falls through priority order (OrchestratorAgent) when no ?agent= is given", () => {
+        const result = selectInitialAgent({ agents: [alpha, orchestrator], urlAgentName: null, agentMode: true });
+
+        expect(result.agent).toBe(orchestrator);
+        expect(result.shouldSeedWelcome).toBe(false);
+    });
+
+    test("pins to the first agent when no ?agent= and no OrchestratorAgent", () => {
+        const result = selectInitialAgent({ agents: [alpha, beta], urlAgentName: null, agentMode: true });
+
+        expect(result.agent).toBe(alpha);
+        expect(result.shouldSeedWelcome).toBe(false);
+    });
+});
+
+describe("selectInitialAgent — priority order (Full UI)", () => {
+    test("URL agent wins and the welcome bubble is seeded", () => {
+        const result = selectInitialAgent({ agents: [orchestrator, alpha], urlAgentName: "AlphaAgent", agentMode: false });
+
+        expect(result.agent).toBe(alpha);
+        expect(result.shouldSeedWelcome).toBe(true);
+    });
+
+    test("falls back to priority order when the URL agent is unknown", () => {
+        const result = selectInitialAgent({ agents: [alpha, orchestrator], urlAgentName: "GhostAgent", agentMode: false });
+
+        expect(result.agent).toBe(orchestrator);
+        expect(result.shouldSeedWelcome).toBe(true);
+    });
+
+    test("uses the project default agent when present", () => {
+        const result = selectInitialAgent({ agents: [orchestrator, alpha, beta], urlAgentName: null, agentMode: false, projectDefaultAgentId: "BetaAgent" });
+
+        expect(result.agent).toBe(beta);
+    });
+
+    test("falls back to OrchestratorAgent when the project default is missing", () => {
+        const result = selectInitialAgent({ agents: [alpha, orchestrator], urlAgentName: null, agentMode: false, projectDefaultAgentId: "GhostAgent" });
+
+        expect(result.agent).toBe(orchestrator);
+    });
+
+    test("prefers OrchestratorAgent over the first agent when no project default", () => {
+        const result = selectInitialAgent({ agents: [alpha, orchestrator], urlAgentName: null, agentMode: false });
+
+        expect(result.agent).toBe(orchestrator);
+    });
+
+    test("falls back to the first agent when OrchestratorAgent is absent", () => {
+        const result = selectInitialAgent({ agents: [alpha, beta], urlAgentName: null, agentMode: false });
+
+        expect(result.agent).toBe(alpha);
+    });
+});

--- a/client/webui/frontend/src/stories/utils/agentUtils.test.ts
+++ b/client/webui/frontend/src/stories/utils/agentUtils.test.ts
@@ -36,6 +36,23 @@ describe("selectInitialAgent — pinned agent (Agent Mode)", () => {
         expect(result.agent).toBe(alpha);
         expect(result.shouldSeedWelcome).toBe(false);
     });
+
+    test("pins by wire name only — a shared displayName cannot misroute", () => {
+        // Two agents collide on displayName but have distinct wire names. ?agent=
+        // must resolve against the unique wire name, never the ambiguous label.
+        const first = { name: "agent-uuid-1", displayName: "Weather Agent" } as unknown as AgentCardInfo;
+        const second = { name: "agent-uuid-2", displayName: "Weather Agent" } as unknown as AgentCardInfo;
+        const result = selectInitialAgent({ agents: [first, second], urlAgentName: "agent-uuid-2", agentMode: true });
+
+        expect(result.agent).toBe(second);
+    });
+
+    test("does not resolve a ?agent= that matches only a displayName", () => {
+        const platform = { name: "agent-uuid-1", displayName: "Weather Agent" } as unknown as AgentCardInfo;
+        const result = selectInitialAgent({ agents: [platform], urlAgentName: "Weather Agent", agentMode: true });
+
+        expect(result.agent).toBeNull();
+    });
 });
 
 describe("selectInitialAgent — priority order (Full UI)", () => {


### PR DESCRIPTION
## Summary
Adds **Agent Mode**: a focused, chat-only rendering of the web UI locked to a single
agent, activated via hash-route query params:

    /#/chat?agentMode=true&agent=<agentName>

When active, the UI pins the conversation to the named agent and presents a
stripped-down chat surface (no agent picker / navigation chrome), suitable for
embedding a single agent's chat experience.

## What changed

- **URL-param entry point** — `getHashQueryParams()` reads Agent Mode params from
  the hash query (not `window.location.search`) so they travel with the hash
  route. `agentMode` is surfaced on the config context and never persisted.
- **Pinned-agent selection** — `selectInitialAgent` extracted as a pure helper
  covering pinned vs priority-order selection. An unresolved `?agent=` shows a
  "Connecting…" state rather than silently falling back to another agent, and
  sending is gated until the pinned agent resolves.
- **Deterministic pinning by wire name** — `?agent=` and message routing resolve
  the agent by its unique wire name only (no `displayName` fallback), so two
  agents sharing a display name can't mislabel the hero or misroute messages.
- **Re-pin on session load** — loading a session no longer lets its stored agent
  override the pinned `?agent=` (the selector is hidden, so a silent re-route
  would be undetectable). Falls back to the stored agent only when the hash query
  is absent.
- **Timeout fallback** — a bad `?agent=` shows a terminal "unavailable" state
  after 15s instead of spinning forever.
- **Chrome stripped in Agent Mode** — Activity panel hidden (with a fallback to
  the Files tab when Activity was active), session move/share actions removed,
  a centered per-agent greeting hero replaces the welcome bubble, and contextual
  prompts are disabled.
- **Neutral login screen** — the login view now shows a bare centered Login
  button with no product branding, so white-labeled deployments stay unbranded
  through the auth flow.

## Tests

- `getHashQueryParams` parsing, including ignoring `window.location.search`
- `selectInitialAgent` pinned vs priority-order coverage; `?agent=` pins by wire
  name even on a shared display name and never resolves a display-name-only match
- ChatPage empty states (connecting / unavailable / ready) with a Full-UI control
- ChatInputArea no-agent-no-send gate
- Nav-hiding tests covering Full UI vs Agent Mode
- AgentModeWelcome hero, session action allowlist