### PR TITLE
fix: bump vitest stack to 4.1.6+ for CVE-2026-47428

### DIFF
--- a/client/webui/frontend/package-lock.json
+++ b/client/webui/frontend/package-lock.json
@@ -71,8 +71,8 @@
                 "@types/react-dom": "19.0.0",
                 "@types/react-pdf": "7.0.0",
                 "@vitejs/plugin-react": "^4.4.1",
-                "@vitest/browser-playwright": "^4.0.8",
-                "@vitest/coverage-v8": "^4.0.8",
+                "@vitest/browser-playwright": "^4.1.6",
+                "@vitest/coverage-v8": "^4.1.6",
                 "cypress": "^14.5.4",
                 "eslint": "^9.25.0",
                 "eslint-plugin-react-hooks": "^5.2.0",
@@ -92,7 +92,7 @@
                 "typescript": "~5.8.3",
                 "typescript-eslint": "^8.30.1",
                 "vite": "^6.4.2",
-                "vitest": "^4.0.8"
+                "vitest": "^4.1.6"
             },
             "engines": {
                 "node": ">=25.5.0 <26"
@@ -4994,15 +4994,15 @@
             }
         },
         "node_modules/@vitest/browser": {
-            "version": "4.1.5",
-            "resolved": "https://registry.npmjs.org/@vitest/browser/-/browser-4.1.5.tgz",
-            "integrity": "sha512-iCDGI8c4yg+xmjUg2VsygdAUSIIB4x5Rht/P68OXy1hPELKXHDkzh87lkuTcdYmemRChDkEpB426MmDjzC0ziA==",
+            "version": "4.1.8",
+            "resolved": "https://registry.npmjs.org/@vitest/browser/-/browser-4.1.8.tgz",
+            "integrity": "sha512-u21VzX07HzlJYpFgkxmjEXar/tG2UqWGgyGG/46SrrPc7rSdCTPw5vuowopO9CIqF8UCUQzDFdbVnNpw6N0BfQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@blazediff/core": "1.9.1",
-                "@vitest/mocker": "4.1.5",
-                "@vitest/utils": "4.1.5",
+                "@vitest/mocker": "4.1.8",
+                "@vitest/utils": "4.1.8",
                 "magic-string": "^0.30.21",
                 "pngjs": "^7.0.0",
                 "sirv": "^3.0.2",
@@ -5013,18 +5013,18 @@
                 "url": "https://opencollective.com/vitest"
             },
             "peerDependencies": {
-                "vitest": "4.1.5"
+                "vitest": "4.1.8"
             }
         },
         "node_modules/@vitest/browser-playwright": {
-            "version": "4.1.5",
-            "resolved": "https://registry.npmjs.org/@vitest/browser-playwright/-/browser-playwright-4.1.5.tgz",
-            "integrity": "sha512-CWy0lBQJq97nionyJJdnaU4961IXTl43a7UCu5nHy51IoKxAt6PVIJLo+76rVl7KOOgcWHNkG4kbJu/pW7knvA==",
+            "version": "4.1.8",
+            "resolved": "https://registry.npmjs.org/@vitest/browser-playwright/-/browser-playwright-4.1.8.tgz",
+            "integrity": "sha512-SR7FqgegaexEg73xvf3ArtygXegagMdXnL0EZMpxrWvvhQxvicD/E8p0ib0J91riPRtQUViyh67Xjw3NqvyhVg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@vitest/browser": "4.1.5",
-                "@vitest/mocker": "4.1.5",
+                "@vitest/browser": "4.1.8",
+                "@vitest/mocker": "4.1.8",
                 "tinyrainbow": "^3.1.0"
             },
             "funding": {
@@ -5032,7 +5032,7 @@
             },
             "peerDependencies": {
                 "playwright": "*",
-                "vitest": "4.1.5"
+                "vitest": "4.1.8"
             },
             "peerDependenciesMeta": {
                 "playwright": {
@@ -5041,14 +5041,14 @@
             }
         },
         "node_modules/@vitest/coverage-v8": {
-            "version": "4.1.5",
-            "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-4.1.5.tgz",
-            "integrity": "sha512-38C0/Ddb7HcRG0Z4/DUem8x57d2p9jYgp18mkaYswEOQBGsI1CG4f/hjm0ZCeaJfWhSZ4k7jgs29V1Zom7Ki9A==",
+            "version": "4.1.8",
+            "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-4.1.8.tgz",
+            "integrity": "sha512-lt3kovsyHwYe00wq4D1ti0Z974fWj4NLp6siqiyEufUpyFwK9Yhi7rBhac9JL5aA0zoMrJqc4vYPZRUnI7l7nw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@bcoe/v8-coverage": "^1.0.2",
-                "@vitest/utils": "4.1.5",
+                "@vitest/utils": "4.1.8",
                 "ast-v8-to-istanbul": "^1.0.0",
                 "istanbul-lib-coverage": "^3.2.2",
                 "istanbul-lib-report": "^3.0.1",
@@ -5062,8 +5062,8 @@
                 "url": "https://opencollective.com/vitest"
             },
             "peerDependencies": {
-                "@vitest/browser": "4.1.5",
-                "vitest": "4.1.5"
+                "@vitest/browser": "4.1.8",
+                "vitest": "4.1.8"
             },
             "peerDependenciesMeta": {
                 "@vitest/browser": {
@@ -5140,13 +5140,13 @@
             }
         },
         "node_modules/@vitest/mocker": {
-            "version": "4.1.5",
-            "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.5.tgz",
-            "integrity": "sha512-/x2EmFC4mT4NNzqvC3fmesuV97w5FC903KPmey4gsnJiMQ3Be1IlDKVaDaG8iqaLFHqJ2FVEkxZk5VmeLjIItw==",
+            "version": "4.1.8",
+            "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.8.tgz",
+            "integrity": "sha512-LEiN/xe4OSIbKe9HQIp5OC24agGD9J5CnmMgsLohVVoOPWL9a2sBoR6VBx43jQZb7Kr1l4RCuyCJzcAa0+dojw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@vitest/spy": "4.1.5",
+                "@vitest/spy": "4.1.8",
                 "estree-walker": "^3.0.3",
                 "magic-string": "^0.30.21"
             },
@@ -5177,9 +5177,9 @@
             }
         },
         "node_modules/@vitest/pretty-format": {
-            "version": "4.1.5",
-            "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.5.tgz",
-            "integrity": "sha512-7I3q6l5qr03dVfMX2wCo9FxwSJbPdwKjy2uu/YPpU3wfHvIL4QHwVRp57OfGrDFeUJ8/8QdfBKIV12FTtLn00g==",
+            "version": "4.1.8",
+            "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.8.tgz",
+            "integrity": "sha512-9GasEBxpZ1VYIpqHf/0+YGg121uSNwCKOJqIrTwWP/TB7DmFCiaBpNl3aPZzoLWfWkuqhbH8vJIVobZkvdo2cA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -5190,13 +5190,13 @@
             }
         },
         "node_modules/@vitest/runner": {
-            "version": "4.1.5",
-            "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.5.tgz",
-            "integrity": "sha512-2D+o7Pr82IEO46YPpoA/YU0neeyr6FTerQb5Ro7BUnBuv6NQtT/kmVnczngiMEBhzgqz2UZYl5gArejsyERDSQ==",
+            "version": "4.1.8",
+            "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.8.tgz",
+            "integrity": "sha512-EmVxeBAfMJvycdjd6Hm+RbFBbA9fKvo0Kx37hNpBYoYeavH3RNsBXWDooR1mgD52dCrxIIuP7UotpfiwOikvcg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@vitest/utils": "4.1.5",
+                "@vitest/utils": "4.1.8",
                 "pathe": "^2.0.3"
             },
             "funding": {
@@ -5204,14 +5204,14 @@
             }
         },
         "node_modules/@vitest/snapshot": {
-            "version": "4.1.5",
-            "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.5.tgz",
-            "integrity": "sha512-zypXEt4KH/XgKGPUz4eC2AvErYx0My5hfL8oDb1HzGFpEk1P62bxSohdyOmvz+d9UJwanI68MKwr2EquOaOgMQ==",
+            "version": "4.1.8",
+            "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.8.tgz",
+            "integrity": "sha512-acfZboRmAIf05DEKcBQy33VXojFJjtUdLyo7oOmV9kebb2xdU01UknNiPuPZoJZQyO7DF0gZdTGTpeAzET9QPQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@vitest/pretty-format": "4.1.5",
-                "@vitest/utils": "4.1.5",
+                "@vitest/pretty-format": "4.1.8",
+                "@vitest/utils": "4.1.8",
                 "magic-string": "^0.30.21",
                 "pathe": "^2.0.3"
             },
@@ -5220,9 +5220,9 @@
             }
         },
         "node_modules/@vitest/spy": {
-            "version": "4.1.5",
-            "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.5.tgz",
-            "integrity": "sha512-2lNOsh6+R2Idnf1TCZqSwYlKN2E/iDlD8sgU59kYVl+OMDmvldO1VDk39smRfpUNwYpNRVn3w4YfuC7KfbBnkQ==",
+            "version": "4.1.8",
+            "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.8.tgz",
+            "integrity": "sha512-6EevtBp6OZOPF7bmz36HrGMeP3txgVSrgebWxHOafDXGkhIzfXK14f8KF6MuFfgXXUeHxmpD3BQxkV00/3s5mA==",
             "dev": true,
             "license": "MIT",
             "funding": {
@@ -5230,13 +5230,13 @@
             }
         },
         "node_modules/@vitest/utils": {
-            "version": "4.1.5",
-            "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.5.tgz",
-            "integrity": "sha512-76wdkrmfXfqGjueGgnb45ITPyUi1ycZ4IHgC2bhPDUfWHklY/q3MdLOAB+TF1e6xfl8NxNY0ZYaPCFNWSsw3Ug==",
+            "version": "4.1.8",
+            "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.8.tgz",
+            "integrity": "sha512-uOJamYALNhfJ6iolExyQM40yIQwDqYnkKtQ5VCiSe17E33H0aQ/u+1GlRuz4LZBk6Mm3sg90G9hEbmEt37C1Zg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@vitest/pretty-format": "4.1.5",
+                "@vitest/pretty-format": "4.1.8",
                 "convert-source-map": "^2.0.0",
                 "tinyrainbow": "^3.1.0"
             },
@@ -5472,9 +5472,9 @@
             }
         },
         "node_modules/ast-v8-to-istanbul": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/ast-v8-to-istanbul/-/ast-v8-to-istanbul-1.0.0.tgz",
-            "integrity": "sha512-1fSfIwuDICFA4LKkCzRPO7F0hzFf0B7+Xqrl27ynQaa+Rh0e1Es0v6kWHPott3lU10AyAr7oKHa65OppjLn3Rg==",
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/ast-v8-to-istanbul/-/ast-v8-to-istanbul-1.0.3.tgz",
+            "integrity": "sha512-jCMQ6ZylLPudp0CDfBmQBZUsrh1/8psbmu9ibeVWKuHWD0YrH9YABwlKu5kVEFoT0GCQQW9Z/SxfuEbbkGQCRg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -5657,9 +5657,9 @@
             "license": "MIT"
         },
         "node_modules/brace-expansion": {
-            "version": "5.0.5",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
-            "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+            "version": "5.0.6",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+            "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -10087,13 +10087,13 @@
             }
         },
         "node_modules/magicast": {
-            "version": "0.5.2",
-            "resolved": "https://registry.npmjs.org/magicast/-/magicast-0.5.2.tgz",
-            "integrity": "sha512-E3ZJh4J3S9KfwdjZhe2afj6R9lGIN5Pher1pF39UGrXRqq/VDaGVIGN13BjHd2u8B61hArAGOnso7nBOouW3TQ==",
+            "version": "0.5.3",
+            "resolved": "https://registry.npmjs.org/magicast/-/magicast-0.5.3.tgz",
+            "integrity": "sha512-pVKE4UdSQ7DvHzivsCIFx2BJn1mHG6KsyrFcaxFx6tONdneEuThrDx0Cj3AMg58KyN4pzYT+LHOotxDQDjNvkw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@babel/parser": "^7.29.0",
+                "@babel/parser": "^7.29.3",
                 "@babel/types": "^7.29.0",
                 "source-map-js": "^1.2.1"
             }
@@ -12796,9 +12796,9 @@
             "license": "MIT"
         },
         "node_modules/tmp": {
-            "version": "0.2.5",
-            "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.5.tgz",
-            "integrity": "sha512-voyz6MApa1rQGUxT3E+BK7/ROe8itEx7vD8/HEvt4xwXucvQ5G5oeEiHkmHZJuBO21RpOf+YYm9MOivj709jow==",
+            "version": "0.2.7",
+            "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.7.tgz",
+            "integrity": "sha512-e0votIpp4Uo2AJYSzVHV6xCcawuiez3DzqDAbrTc3YxBkplN6e+dM13ZeIcZnDg/QpSuU2zfZ3rzwY8ukEnaXw==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -13752,19 +13752,19 @@
             }
         },
         "node_modules/vitest": {
-            "version": "4.1.5",
-            "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.5.tgz",
-            "integrity": "sha512-9Xx1v3/ih3m9hN+SbfkUyy0JAs72ap3r7joc87XL6jwF0jGg6mFBvQ1SrwaX+h8BlkX6Hz9shdd1uo6AF+ZGpg==",
+            "version": "4.1.8",
+            "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.8.tgz",
+            "integrity": "sha512-flY6ScbCIt9HThs+C5HS7jvGOB560DJtk/Z15IQROTA6zEy49Nh8T/dofWTQL+n3vswqn87sbJNiuqw1SDp5Ig==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@vitest/expect": "4.1.5",
-                "@vitest/mocker": "4.1.5",
-                "@vitest/pretty-format": "4.1.5",
-                "@vitest/runner": "4.1.5",
-                "@vitest/snapshot": "4.1.5",
-                "@vitest/spy": "4.1.5",
-                "@vitest/utils": "4.1.5",
+                "@vitest/expect": "4.1.8",
+                "@vitest/mocker": "4.1.8",
+                "@vitest/pretty-format": "4.1.8",
+                "@vitest/runner": "4.1.8",
+                "@vitest/snapshot": "4.1.8",
+                "@vitest/spy": "4.1.8",
+                "@vitest/utils": "4.1.8",
                 "es-module-lexer": "^2.0.0",
                 "expect-type": "^1.3.0",
                 "magic-string": "^0.30.21",
@@ -13792,12 +13792,12 @@
                 "@edge-runtime/vm": "*",
                 "@opentelemetry/api": "^1.9.0",
                 "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
-                "@vitest/browser-playwright": "4.1.5",
-                "@vitest/browser-preview": "4.1.5",
-                "@vitest/browser-webdriverio": "4.1.5",
-                "@vitest/coverage-istanbul": "4.1.5",
-                "@vitest/coverage-v8": "4.1.5",
-                "@vitest/ui": "4.1.5",
+                "@vitest/browser-playwright": "4.1.8",
+                "@vitest/browser-preview": "4.1.8",
+                "@vitest/browser-webdriverio": "4.1.8",
+                "@vitest/coverage-istanbul": "4.1.8",
+                "@vitest/coverage-v8": "4.1.8",
+                "@vitest/ui": "4.1.8",
                 "happy-dom": "*",
                 "jsdom": "*",
                 "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
@@ -13842,16 +13842,16 @@
             }
         },
         "node_modules/vitest/node_modules/@vitest/expect": {
-            "version": "4.1.5",
-            "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.5.tgz",
-            "integrity": "sha512-PWBaRY5JoKuRnHlUHfpV/KohFylaDZTupcXN1H9vYryNLOnitSw60Mw9IAE2r67NbwwzBw/Cc/8q9BK3kIX8Kw==",
+            "version": "4.1.8",
+            "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.8.tgz",
+            "integrity": "sha512-h3nDO677RDLEGlBxyQ5CW8RlMThSKSRLUePLOx09gNIWRL40edgA1GCZSZgf1W55MFAG6/Sw14KeaAnqv0NKdQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@standard-schema/spec": "^1.1.0",
                 "@types/chai": "^5.2.2",
-                "@vitest/spy": "4.1.5",
-                "@vitest/utils": "4.1.5",
+                "@vitest/spy": "4.1.8",
+                "@vitest/utils": "4.1.8",
                 "chai": "^6.2.2",
                 "tinyrainbow": "^3.1.0"
             },
@@ -14029,9 +14029,9 @@
             "license": "ISC"
         },
         "node_modules/ws": {
-            "version": "8.20.0",
-            "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.0.tgz",
-            "integrity": "sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==",
+            "version": "8.21.0",
+            "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
+            "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
             "dev": true,
             "license": "MIT",
             "engines": {

--- a/client/webui/frontend/package.json
+++ b/client/webui/frontend/package.json
@@ -120,10 +120,10 @@
     },
     "devDependencies": {
         "@a2a-js/sdk": "^0.3.2",
+        "@eslint/js": "^9.25.0",
         "@openfeature/core": "^1.9.2",
         "@openfeature/react-sdk": "^1.2.1",
         "@openfeature/web-sdk": "^1.7.3",
-        "@eslint/js": "^9.25.0",
         "@storybook/addon-vitest": "^10.2.10",
         "@storybook/react": "^10.2.10",
         "@storybook/react-vite": "^10.2.10",
@@ -139,8 +139,8 @@
         "@types/react-dom": "19.0.0",
         "@types/react-pdf": "7.0.0",
         "@vitejs/plugin-react": "^4.4.1",
-        "@vitest/browser-playwright": "^4.0.8",
-        "@vitest/coverage-v8": "^4.0.8",
+        "@vitest/browser-playwright": "^4.1.6",
+        "@vitest/coverage-v8": "^4.1.6",
         "cypress": "^14.5.4",
         "eslint": "^9.25.0",
         "eslint-plugin-react-hooks": "^5.2.0",
@@ -160,7 +160,7 @@
         "typescript": "~5.8.3",
         "typescript-eslint": "^8.30.1",
         "vite": "^6.4.2",
-        "vitest": "^4.0.8"
+        "vitest": "^4.1.6"
     },
     "optionalDependencies": {
         "@esbuild/darwin-arm64": "0.25.5",


### PR DESCRIPTION
## Summary
- Bumps direct vitest devDependencies (`vitest`, `@vitest/browser-playwright`, `@vitest/coverage-v8`) from `^4.0.8` to `^4.1.6` so that the transitive `@vitest/browser` peer resolves to a non-vulnerable version (lockfile lands on `4.1.8`).
- Clears **CVE-2026-47428** (`@vitest/browser` critical, fixed in 4.1.6).
- `npm audit fix` additionally resolved three transitive advisories:
  - `tmp <0.2.6` — path traversal (high)
  - `brace-expansion 5.0.2-5.0.5` — DoS (moderate, CVE-2026-45149)
  - `ws 8.0.0-8.20.0` — uninitialized memory disclosure (moderate)

## Out of scope
6 remaining `npm audit` findings all chain to `@cypress/request <4.0.0` and require a cypress 14 → 15 major bump. Deferred to a separate decision.

## Test plan
- [ ] CI passes (lint, type-check, vitest unit, vitest storybook, storybook build)
- [ ] `npm run test:unit` passes locally
- [ ] `npm run ci:storybook` passes locally
- [ ] `npm audit` shows the three fixed advisories gone and no new criticals/highs introduced

🤖 Generated with [Claude Code](https://claude.com/claude-code)