### PR TITLE
fix(security): fail-open auth — set authenticated=False in dev mode

### DIFF
--- a/src/solace_agent_mesh/shared/auth/middleware.py
+++ b/src/solace_agent_mesh/shared/auth/middleware.py
@@ -299,10 +299,13 @@ def create_oauth_middleware(component):
                     "id": "sam_dev_user",
                     "name": "Sam Dev User",
                     "email": "sam@dev.local",
-                    "authenticated": True,
+                    "authenticated": False,
                     "auth_method": "development",
                 }
-                log.debug("AuthMiddleware: Set development user (frontend_use_authorization=false)")
+                log.warning(
+                    "AuthMiddleware: Development mode active — requests treated as unauthenticated. "
+                    "Set frontend_use_authorization=true for production."
+                )
 
             await self.app(scope, receive, send)
 


### PR DESCRIPTION
## Summary

When frontend_use_authorization=false (default), the auth middleware sets authenticated=True for all requests, making downstream auth checks trivially bypassed. Any unauthenticated request is treated as the sam_dev_user with full authenticated privileges. This changes the dev-mode identity to authenticated=False and adds a startup warning.

## Vulnerability

**Severity:** Critical
**CWE:** CWE-306 (Missing Authentication for Critical Function)
**Location:** src/solace_agent_mesh/shared/auth/middleware.py:299

The AuthMiddleware.__call__() checks frontend_use_authorization config. When False (default), it sets request.state.user to {"id": "sam_dev_user", "authenticated": True, "auth_method": "development"}. All downstream route handlers see authenticated=True and proceed without restriction.

An unauthenticated attacker can: list/create/delete sessions, send messages to agents (consuming LLM API credits), read/write artifacts, access admin config endpoints, and exfiltrate any data the agents have access to.

## Fix

Change authenticated: True to authenticated: False in the dev-mode branch and add a log.warning(). Downstream code that checks authenticated will correctly reject unauthenticated requests. Dev mode still works for local testing but does not lie about authentication status.

## Test Plan

- [ ] With frontend_use_authorization=false, request.state.user.authenticated is False
- [ ] With frontend_use_authorization=true, normal OAuth flow works
- [ ] Warning log emitted in dev mode
- [ ] Existing tests pass