### PR TITLE
fix(security): XSS in OAuth callback — escape error parameters

### DIFF
--- a/src/solace_agent_mesh/gateway/http_sse/routers/auth.py
+++ b/src/solace_agent_mesh/gateway/http_sse/routers/auth.py
@@ -3,6 +3,7 @@ Router for handling authentication-related endpoints.
 """
 from __future__ import annotations
 
+import html
 import logging
 import secrets
 
@@ -208,8 +209,8 @@ async def auth_tool_callback(
                 </head>
                 <body>
                     <h2>Authorization Error</h2>
-                    <p>Error: {error}</p>
-                    <p>Description: {error_description or 'No description provided'}</p>
+                    <p>Error: {html.escape(error)}</p>
+                    <p>Description: {html.escape(error_description or 'No description provided')}</p>
                     <p>Please close this window and try again.</p>
                 </body>
             </html>


### PR DESCRIPTION
## Summary

The OAuth2 tool callback handler at /api/v1/auth/callback interpolates query parameters error and error_description directly into HTML without escaping, enabling reflected XSS. Use html.escape() to sanitize.

## Vulnerability

**Severity:** High
**CWE:** CWE-79 (Cross-site Scripting — Reflected)
**Location:** src/solace_agent_mesh/gateway/http_sse/routers/auth.py:204

An attacker crafts: /api/v1/auth/callback?error=<script>alert(document.cookie)</script>. The f-string interpolation produces <p>Error: <script>alert(document.cookie)</script></p> with no escaping. HTMLResponse returns text/html, so the browser executes the script in the gateway origin.

Impact: session hijacking, CSRF token theft, arbitrary API calls as the victim.

## Fix

Add import html and replace {error} with {html.escape(error)} and {error_description} with {html.escape(error_description or "No description provided")}.

## Test Plan

- [ ] /api/v1/auth/callback?error=<script>alert(1)</script> returns escaped HTML
- [ ] Normal error messages render correctly
- [ ] No CSP needed as defense-in-depth (optional follow-up)