### PR TITLE
feat(DATAGO-138153): Adding embedded agent mode

### DIFF
--- a/client/webui/frontend/src/App.tsx
+++ b/client/webui/frontend/src/App.tsx
@@ -1,7 +1,7 @@
 import { RouterProvider } from "react-router-dom";
 
 import { TextSelectionProvider } from "@/lib/components/chat/selection";
-import { AuthProvider, ConfigProvider, CsrfProvider, FeatureFlagProvider, ProjectProvider, TaskProvider, ThemeProvider, AudioSettingsProvider, QueryProvider, SSEProvider } from "@/lib/providers";
+import { AuthProvider, ChatSurfaceProvider, ConfigProvider, CsrfProvider, FeatureFlagProvider, ProjectProvider, TaskProvider, ThemeProvider, AudioSettingsProvider, QueryProvider, SSEProvider } from "@/lib/providers";
 
 import { createRouter } from "./router";
 
@@ -16,19 +16,21 @@ function App() {
                 <CsrfProvider>
                     <FeatureFlagProvider>
                         <ConfigProvider>
-                            <AuthProvider>
-                                <SSEProvider>
-                                    <ProjectProvider>
-                                        <AudioSettingsProvider>
-                                            <TaskProvider>
-                                                <TextSelectionProvider>
-                                                    <AppContent />
-                                                </TextSelectionProvider>
-                                            </TaskProvider>
-                                        </AudioSettingsProvider>
-                                    </ProjectProvider>
-                                </SSEProvider>
-                            </AuthProvider>
+                            <ChatSurfaceProvider>
+                                <AuthProvider>
+                                    <SSEProvider>
+                                        <ProjectProvider>
+                                            <AudioSettingsProvider>
+                                                <TaskProvider>
+                                                    <TextSelectionProvider>
+                                                        <AppContent />
+                                                    </TextSelectionProvider>
+                                                </TaskProvider>
+                                            </AudioSettingsProvider>
+                                        </ProjectProvider>
+                                    </SSEProvider>
+                                </AuthProvider>
+                            </ChatSurfaceProvider>
                         </ConfigProvider>
                     </FeatureFlagProvider>
                 </CsrfProvider>

--- a/client/webui/frontend/src/AppLayout.tsx
+++ b/client/webui/frontend/src/AppLayout.tsx
@@ -3,6 +3,7 @@ import { Outlet, useLocation, useNavigate } from "react-router-dom";
 
 import { NavigationSidebar, CollapsibleNavigationSidebar, ToastContainer, bottomNavigationItems, getTopNavigationItems, EmptyState } from "@/lib/components";
 import { Button } from "@/lib/components/ui/button";
+import { EmbeddedRouteGuard } from "@/lib/components/navigation/EmbeddedRouteGuard";
 import { SelectionContextMenu, useTextSelection } from "@/lib/components/chat/selection";
 import { MoveSessionDialog } from "@/lib/components/chat/MoveSessionDialog";
 import { ModelSetupDialog } from "@/lib/components/models/ModelSetupDialog";
@@ -151,6 +152,8 @@ function AppLayoutContent() {
 
     return (
         <div className={`relative flex h-screen`}>
+            {/* Keeps the embedded surface locked to /embed/* (redirects any drift back). No-op in full UI. */}
+            <EmbeddedRouteGuard />
             {/* surface.showNav gates BOTH nav variants, so the embedded surface is chat-only
                 (no sidebar) regardless of the new_navigation flag. */}
             {surface.showNav &&

--- a/client/webui/frontend/src/AppLayout.tsx
+++ b/client/webui/frontend/src/AppLayout.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState, useCallback } from "react";
 import { Outlet, useLocation, useNavigate } from "react-router-dom";
 
 import { NavigationSidebar, CollapsibleNavigationSidebar, ToastContainer, bottomNavigationItems, getTopNavigationItems, EmptyState } from "@/lib/components";
+import { Button } from "@/lib/components/ui/button";
 import { SelectionContextMenu, useTextSelection } from "@/lib/components/chat/selection";
 import { MoveSessionDialog } from "@/lib/components/chat/MoveSessionDialog";
 import { ModelSetupDialog } from "@/lib/components/models/ModelSetupDialog";
@@ -9,7 +10,7 @@ import { ModelWarningBanner } from "@/lib/components/models/ModelWarningBanner";
 import { SettingsDialog } from "@/lib/components/settings/SettingsDialog";
 import { ChatProvider } from "@/lib/providers";
 import { useBooleanFlagDetails } from "@openfeature/react-sdk";
-import { useAuthContext, useBeforeUnload, useConfigContext, useChatContext, useNavigationItems, useLocalStorage, useMoveSession, useIsNewNavigationEnabled } from "@/lib/hooks";
+import { useAuthContext, useBeforeUnload, useChatSurface, useConfigContext, useChatContext, useNavigationItems, useLocalStorage, useMoveSession, useIsNewNavigationEnabled } from "@/lib/hooks";
 import { useNotificationSSE } from "@/lib/hooks/useNotificationSSE";
 import { useModelConfigStatus } from "@/lib/api/models";
 
@@ -18,6 +19,10 @@ function AppLayoutContent() {
     const navigate = useNavigate();
     const { isAuthenticated, login, logout, useAuthorization } = useAuthContext();
     const { configFeatureEnablement } = useConfigContext();
+    const surface = useChatSurface();
+    const showNewChatNav = surface.navigation.includes("newChat");
+    const showAppNav = surface.navigation.includes("appNav");
+    const showRecentChatsNav = surface.navigation.includes("recentChats");
     const { value: modelConfigUiEnabled } = useBooleanFlagDetails("model_config_ui", false);
     const { isMenuOpen, menuPosition, selectedText, sourceTaskId, clearSelection } = useTextSelection();
     const { hasModelConfigWrite } = useChatContext();
@@ -97,7 +102,7 @@ function AppLayoutContent() {
 
     const getActiveItem = () => {
         const path = location.pathname;
-        if (path === "/" || path.startsWith("/chat") || path.startsWith("/recent-chats")) return "chat";
+        if (path === "/" || path.startsWith("/chat") || path.startsWith("/embed/chat") || path.startsWith("/recent-chats")) return "chat";
         if (path.startsWith("/projects")) return "projects";
         if (path.startsWith("/artifacts")) return "artifacts";
         if (path.startsWith("/prompts")) return "prompts";
@@ -106,6 +111,17 @@ function AppLayoutContent() {
     };
 
     if (useAuthorization && !isAuthenticated) {
+        // The embedded surface is a bare chat panel (often in an iframe/tab), so it
+        // shows just a Login button rather than the full "Welcome to SAM" splash.
+        if (surface.variant === "embedded") {
+            return (
+                <div className="flex h-screen w-screen items-center justify-center">
+                    <Button testid="Login" title="Login" variant="default" onClick={() => login()}>
+                        Login
+                    </Button>
+                </div>
+            );
+        }
         return (
             <EmptyState
                 variant="noImage"
@@ -138,11 +154,14 @@ function AppLayoutContent() {
 
     return (
         <div className={`relative flex h-screen`}>
+            {/* surface.navigation lists which sidebar sections to expose. The new nav renders
+                each allowed section (header always kept); the legacy icon rail is pure app-nav,
+                so it shows only when "appNav" is allowed. An empty list renders no sidebar. */}
             {useNewNav ? (
-                <CollapsibleNavigationSidebar items={items} activeItemId={activeItemId} showNewChatButton showRecentChats />
-            ) : (
+                surface.navigation.length > 0 && <CollapsibleNavigationSidebar items={showAppNav ? items : []} activeItemId={activeItemId} showNewChatButton={showNewChatNav} showRecentChats={showRecentChatsNav} />
+            ) : showAppNav ? (
                 <NavigationSidebar items={topNavItems} bottomItems={bottomNavigationItems} activeItem={getActiveItem()} onItemChange={handleNavItemChange} onHeaderClick={handleHeaderClick} />
-            )}
+            ) : null}
             <main className="flex h-full w-full min-w-0 flex-1 flex-col">
                 <ModelWarningBanner />
                 <Outlet />

--- a/client/webui/frontend/src/AppLayout.tsx
+++ b/client/webui/frontend/src/AppLayout.tsx
@@ -20,9 +20,6 @@ function AppLayoutContent() {
     const { isAuthenticated, login, logout, useAuthorization } = useAuthContext();
     const { configFeatureEnablement } = useConfigContext();
     const surface = useChatSurface();
-    const showNewChatNav = surface.navigation.includes("newChat");
-    const showAppNav = surface.navigation.includes("appNav");
-    const showRecentChatsNav = surface.navigation.includes("recentChats");
     const { value: modelConfigUiEnabled } = useBooleanFlagDetails("model_config_ui", false);
     const { isMenuOpen, menuPosition, selectedText, sourceTaskId, clearSelection } = useTextSelection();
     const { hasModelConfigWrite } = useChatContext();
@@ -154,14 +151,14 @@ function AppLayoutContent() {
 
     return (
         <div className={`relative flex h-screen`}>
-            {/* surface.navigation lists which sidebar sections to expose. The new nav renders
-                each allowed section (header always kept); the legacy icon rail is pure app-nav,
-                so it shows only when "appNav" is allowed. An empty list renders no sidebar. */}
-            {useNewNav ? (
-                surface.navigation.length > 0 && <CollapsibleNavigationSidebar items={showAppNav ? items : []} activeItemId={activeItemId} showNewChatButton={showNewChatNav} showRecentChats={showRecentChatsNav} />
-            ) : showAppNav ? (
-                <NavigationSidebar items={topNavItems} bottomItems={bottomNavigationItems} activeItem={getActiveItem()} onItemChange={handleNavItemChange} onHeaderClick={handleHeaderClick} />
-            ) : null}
+            {/* surface.showNav gates BOTH nav variants, so the embedded surface is chat-only
+                (no sidebar) regardless of the new_navigation flag. */}
+            {surface.showNav &&
+                (useNewNav ? (
+                    <CollapsibleNavigationSidebar items={items} activeItemId={activeItemId} showNewChatButton showRecentChats />
+                ) : (
+                    <NavigationSidebar items={topNavItems} bottomItems={bottomNavigationItems} activeItem={getActiveItem()} onItemChange={handleNavItemChange} onHeaderClick={handleHeaderClick} />
+                ))}
             <main className="flex h-full w-full min-w-0 flex-1 flex-col">
                 <ModelWarningBanner />
                 <Outlet />

--- a/client/webui/frontend/src/auth/authCallback.tsx
+++ b/client/webui/frontend/src/auth/authCallback.tsx
@@ -1,5 +1,7 @@
 import { useEffect } from "react";
 
+import { consumePostLoginRedirect } from "@/lib/utils/url";
+
 function AuthCallback() {
     useEffect(() => {
         const hash = window.location.hash.substring(1);
@@ -16,8 +18,9 @@ function AuthCallback() {
             if (refreshToken) {
                 localStorage.setItem("refresh_token", refreshToken);
             }
-            // Redirect to the main application page
-            window.location.href = "/";
+            // Redirect back to the URL the user left from (restores embedded-chat
+            // params dropped by the IdP round-trip), or "/" if none was stashed.
+            window.location.href = consumePostLoginRedirect();
         } else {
             console.error("AuthCallback: No access token found in URL hash.");
         }

--- a/client/webui/frontend/src/lib/api/client.ts
+++ b/client/webui/frontend/src/lib/api/client.ts
@@ -1,4 +1,5 @@
 import { getApiBearerToken, getSamAccessToken } from "@/lib/utils/api";
+import { stashPostLoginRedirect } from "@/lib/utils/url";
 
 interface RequestOptions {
     headers?: HeadersInit;
@@ -167,6 +168,7 @@ const refreshToken = async () => {
         }
 
         clearTokens();
+        stashPostLoginRedirect();
         globalThis.location.href = "/api/v1/auth/login";
         return null;
     })()
@@ -274,6 +276,7 @@ const authenticatedFetch = async (url: string, options: RequestInit = {}) => {
             // Redirect to login to break any external retry loop.
             if (retryResponse.status === 401) {
                 clearTokens();
+                stashPostLoginRedirect();
                 globalThis.location.href = "/api/v1/auth/login";
                 // Navigation is async — return the 401 as-is; the page will
                 // navigate away before callers can act on it.

--- a/client/webui/frontend/src/lib/api/sessions/hooks.ts
+++ b/client/webui/frontend/src/lib/api/sessions/hooks.ts
@@ -14,24 +14,24 @@ import { useCacheUserId } from "@/lib/hooks/useCacheUserId";
  * Hook to fetch recent sessions for the navigation sidebar.
  * Automatically invalidates on session events (new session, session updated, session moved, title updated).
  */
-export function useRecentSessions(maxItems: number = MAX_RECENT_CHATS) {
+export function useRecentSessions(maxItems: number = MAX_RECENT_CHATS, agentId?: string) {
     const queryClient = useQueryClient();
     const userId = useCacheUserId();
 
     // Set up event listeners for automatic invalidation
     useEffect(() => {
         const handleSessionEvent = () => {
-            queryClient.invalidateQueries({ queryKey: sessionKeys.recent(userId, maxItems) });
+            queryClient.invalidateQueries({ queryKey: sessionKeys.recent(userId, maxItems, agentId) });
         };
 
         const events = ["new-chat-session", "session-updated", "session-title-updated", "background-task-completed"];
         events.forEach(e => window.addEventListener(e, handleSessionEvent));
         return () => events.forEach(e => window.removeEventListener(e, handleSessionEvent));
-    }, [maxItems, queryClient, userId]);
+    }, [maxItems, agentId, queryClient, userId]);
 
     return useQuery({
-        queryKey: sessionKeys.recent(userId, maxItems),
-        queryFn: () => sessionService.getRecentSessions(maxItems),
+        queryKey: sessionKeys.recent(userId, maxItems, agentId),
+        queryFn: () => sessionService.getRecentSessions(maxItems, agentId),
         refetchOnMount: "always",
     });
 }
@@ -40,10 +40,11 @@ export function useRecentSessions(maxItems: number = MAX_RECENT_CHATS) {
  * Hook to fetch paginated sessions with infinite scroll support.
  * Automatically invalidates on session events (new session, session updated, title updated, background task completed).
  */
-export function useInfiniteSessions(pageSize: number = 20, source?: string, options?: { enabled?: boolean }) {
+export function useInfiniteSessions(pageSize: number = 20, source?: string, options?: { enabled?: boolean; agentId?: string }) {
     const queryClient = useQueryClient();
     const userId = useCacheUserId();
     const enabled = options?.enabled ?? true;
+    const agentId = options?.agentId;
 
     useEffect(() => {
         if (!enabled) return;
@@ -54,8 +55,8 @@ export function useInfiniteSessions(pageSize: number = 20, source?: string, opti
     }, [queryClient, enabled]);
 
     return useInfiniteQuery({
-        queryKey: sessionKeys.infinite(userId, pageSize, source),
-        queryFn: ({ pageParam }) => sessionService.getPaginatedSessions(pageParam, pageSize, source),
+        queryKey: sessionKeys.infinite(userId, pageSize, source, agentId),
+        queryFn: ({ pageParam }) => sessionService.getPaginatedSessions(pageParam, pageSize, source, agentId),
         getNextPageParam: lastPage => lastPage.meta.pagination.nextPage ?? undefined,
         initialPageParam: 1,
         refetchOnMount: "always",

--- a/client/webui/frontend/src/lib/api/sessions/keys.ts
+++ b/client/webui/frontend/src/lib/api/sessions/keys.ts
@@ -9,8 +9,8 @@
 export const sessionKeys = {
     all: ["sessions"] as const,
     lists: () => [...sessionKeys.all, "list"] as const,
-    recent: (userId: string, maxItems: number) => [...sessionKeys.lists(), "recent", userId, maxItems] as const,
-    infinite: (userId: string, pageSize: number, source?: string) => [...sessionKeys.lists(), "infinite", userId, pageSize, source] as const,
+    recent: (userId: string, maxItems: number, agentId?: string) => [...sessionKeys.lists(), "recent", userId, maxItems, agentId ?? null] as const,
+    infinite: (userId: string, pageSize: number, source?: string, agentId?: string) => [...sessionKeys.lists(), "infinite", userId, pageSize, source, agentId ?? null] as const,
     details: () => [...sessionKeys.all, "detail"] as const,
     detail: (id: string) => [...sessionKeys.details(), id] as const,
     chatTasks: (id: string) => [...sessionKeys.detail(id), "chat-tasks"] as const,

--- a/client/webui/frontend/src/lib/api/sessions/service.ts
+++ b/client/webui/frontend/src/lib/api/sessions/service.ts
@@ -14,14 +14,17 @@ export interface PaginatedSessionsResponse {
     };
 }
 
-export const getRecentSessions = async (maxItems: number): Promise<Session[]> => {
-    const result = await api.webui.get<PaginatedSessionsResponse>(`/api/v1/sessions?pageNumber=1&pageSize=${maxItems}`);
+export const getRecentSessions = async (maxItems: number, agentId?: string): Promise<Session[]> => {
+    let url = `/api/v1/sessions?pageNumber=1&pageSize=${maxItems}`;
+    if (agentId) url += `&agent_id=${encodeURIComponent(agentId)}`;
+    const result = await api.webui.get<PaginatedSessionsResponse>(url);
     return result.data || [];
 };
 
-export const getPaginatedSessions = async (pageNumber: number = 1, pageSize: number = 20, source?: string): Promise<PaginatedSessionsResponse> => {
+export const getPaginatedSessions = async (pageNumber: number = 1, pageSize: number = 20, source?: string, agentId?: string): Promise<PaginatedSessionsResponse> => {
     let url = `/api/v1/sessions?pageNumber=${pageNumber}&pageSize=${pageSize}`;
     if (source) url += `&source=${source}`;
+    if (agentId) url += `&agent_id=${encodeURIComponent(agentId)}`;
     return api.webui.get(url);
 };
 

--- a/client/webui/frontend/src/lib/components/chat/ChatInputArea.tsx
+++ b/client/webui/frontend/src/lib/components/chat/ChatInputArea.tsx
@@ -9,7 +9,7 @@ import type { AttachedArtifactRef } from "@/lib/types";
 import { MessageBanner } from "@/lib/components/common";
 import { MentionContentEditable } from "@/lib/components/ui/chat/MentionContentEditable";
 import { useBooleanFlagDetails } from "@openfeature/react-sdk";
-import { useChatContext, useDragAndDrop, useAgentSelection, useAudioSettings, useConfigContext, useIsMentionsEnabled } from "@/lib/hooks";
+import { useChatContext, useChatSurface, useDragAndDrop, useAgentSelection, useAudioSettings, useConfigContext, useIsMentionsEnabled } from "@/lib/hooks";
 import { useModelConfigStatus } from "@/lib/api/models";
 import type { AgentCardInfo, Person } from "@/lib/types";
 import type { PromptGroup } from "@/lib/types/prompts";
@@ -84,6 +84,7 @@ export const ChatInputArea: React.FC<{ agents: AgentCardInfo[]; scrollToBottom?:
     const { handleAgentSelection } = useAgentSelection();
     const { settings } = useAudioSettings();
     const { configFeatureEnablement } = useConfigContext();
+    const surface = useChatSurface();
     const { value: modelConfigUiEnabled } = useBooleanFlagDetails("model_config_ui", false);
     const { value: artifactAttachmentEnabled } = useBooleanFlagDetails("artifact_attachment", false);
     const { data: modelConfigStatus } = useModelConfigStatus();
@@ -417,8 +418,11 @@ export const ChatInputArea: React.FC<{ agents: AgentCardInfo[]; scrollToBottom?:
     }, [selectedArtifactRefs.length]);
 
     const isSubmittingEnabled = useMemo(
-        () => !isResponding && !modelNotConfigured && (inputValue?.trim() || selectedFiles.length !== 0 || pendingPastedTextItems.length !== 0 || selectedArtifactRefs.length !== 0),
-        [isResponding, modelNotConfigured, inputValue, selectedFiles, pendingPastedTextItems, selectedArtifactRefs]
+        // Embedded surface: no agent, no send. Until the pinned agent resolves
+        // (selectedAgentName === ""), block sending into a void. UX-only — the
+        // provider re-guards on send.
+        () => !isResponding && !modelNotConfigured && (surface.variant !== "embedded" || !!selectedAgentName) && (inputValue?.trim() || selectedFiles.length !== 0 || pendingPastedTextItems.length !== 0 || selectedArtifactRefs.length !== 0),
+        [isResponding, modelNotConfigured, surface.variant, selectedAgentName, inputValue, selectedFiles, pendingPastedTextItems, selectedArtifactRefs]
     );
 
     const onSubmit = async (event: FormEvent) => {
@@ -669,8 +673,9 @@ export const ChatInputArea: React.FC<{ agents: AgentCardInfo[]; scrollToBottom?:
         const textBeforeCursor = value.substring(0, cursorPosition);
 
         // Check if "/" is typed as the first character (position 0)
-        // Only trigger prompt popover when "/" is at the very start of the input
-        if (textBeforeCursor === "/") {
+        // Only trigger prompt popover when "/" is at the very start of the input.
+        // The embedded surface never invokes prompts.
+        if (surface.allowPrompts && textBeforeCursor === "/") {
             setShowPromptsCommand(true);
             setShowMentionsCommand(false); // Close mentions if open
         } else if (showPromptsCommand && !textBeforeCursor.startsWith("/")) {
@@ -811,6 +816,9 @@ export const ChatInputArea: React.FC<{ agents: AgentCardInfo[]; scrollToBottom?:
     let inputPlaceholder: string;
     if (isRecording) {
         inputPlaceholder = "Recording...";
+    } else if (!surface.allowPrompts) {
+        // Embedded surface disallows prompts, so the "/" hint is omitted.
+        inputPlaceholder = mentionsEnabled && surface.allowMentions ? "How can I help you today? (Type '@' to mention someone)" : "How can I help you today?";
     } else if (mentionsEnabled) {
         inputPlaceholder = "How can I help you today? (Type '/' to insert a prompt, '@' to mention someone)";
     } else {
@@ -1157,27 +1165,31 @@ export const ChatInputArea: React.FC<{ agents: AgentCardInfo[]; scrollToBottom?:
                     </Button>
                 )}
 
-                <div className="hidden @[480px]:block">Agent: </div>
-                <Select
-                    value={selectedAgentName}
-                    onValueChange={agentName => {
-                        handleAgentSelection(agentName);
-                    }}
-                    disabled={isResponding || agents.length === 0}
-                >
-                    <SelectTrigger className="w-[250px]">
-                        <SelectValue placeholder="Select an agent..." />
-                    </SelectTrigger>
-                    <SelectContent>
-                        {agents
-                            .filter(agent => !agent.isWorkflow)
-                            .map(agent => (
-                                <SelectItem key={agent.name} value={agent.name}>
-                                    {agent.displayName || agent.name}
-                                </SelectItem>
-                            ))}
-                    </SelectContent>
-                </Select>
+                {surface.showAgentSelector && (
+                    <>
+                        <div className="hidden @[480px]:block">Agent: </div>
+                        <Select
+                            value={selectedAgentName}
+                            onValueChange={agentName => {
+                                handleAgentSelection(agentName);
+                            }}
+                            disabled={isResponding || agents.length === 0}
+                        >
+                            <SelectTrigger className="w-[250px]">
+                                <SelectValue placeholder="Select an agent..." />
+                            </SelectTrigger>
+                            <SelectContent>
+                                {agents
+                                    .filter(agent => !agent.isWorkflow)
+                                    .map(agent => (
+                                        <SelectItem key={agent.name} value={agent.name}>
+                                            {agent.displayName || agent.name}
+                                        </SelectItem>
+                                    ))}
+                            </SelectContent>
+                        </Select>
+                    </>
+                )}
 
                 {/* Spacer to push buttons to the right */}
                 <div className="flex-1" />

--- a/client/webui/frontend/src/lib/components/chat/ChatMessage.tsx
+++ b/client/webui/frontend/src/lib/components/chat/ChatMessage.tsx
@@ -7,7 +7,7 @@ import { useBooleanFlagDetails } from "@openfeature/react-sdk";
 import { ChatBubble, ChatBubbleMessage, MarkdownHTMLConverter, MarkdownWrapper, MessageBanner } from "@/lib/components";
 import { Button } from "@/lib/components/ui";
 import { ViewWorkflowButton } from "@/lib/components/ui/ViewWorkflowButton";
-import { useChatContext, useCitationClick } from "@/lib/hooks";
+import { useChatContext, useChatSurface, useCitationClick } from "@/lib/hooks";
 import type { ArtifactInfo, ArtifactPart, DataPart, FileAttachment, FilePart, MessageFE, RAGSearchResult, TextPart } from "@/lib/types";
 import type { ChatContextValue } from "@/lib/contexts";
 import { InlineResearchProgress, type ResearchProgressData } from "@/lib/components/research/InlineResearchProgress";
@@ -627,7 +627,8 @@ const getChatBubble = (
     reportContentOverride?: string,
     highlightedText?: string | null,
     inlineActivityTimelineEnabled?: boolean,
-    showThinkingContentEnabled?: boolean
+    showThinkingContentEnabled?: boolean,
+    showActivityPanel?: boolean
 ): React.ReactNode => {
     const { openSidePanelTab, setTaskIdInSidePanel, ragData, currentUserEmail } = chatContext;
 
@@ -678,7 +679,7 @@ const getChatBubble = (
         return (
             <>
                 {progressBlock}
-                {getChatBubble(messageWithoutProgress, chatContext, isLastWithTaskId, undefined, undefined, undefined, undefined, undefined, undefined, inlineActivityTimelineEnabled, showThinkingContentEnabled)}
+                {getChatBubble(messageWithoutProgress, chatContext, isLastWithTaskId, undefined, undefined, undefined, undefined, undefined, undefined, inlineActivityTimelineEnabled, showThinkingContentEnabled, showActivityPanel)}
             </>
         );
     }
@@ -720,8 +721,10 @@ const getChatBubble = (
     // For alignment: current user's messages are right-aligned, other users' and agent messages are left-aligned
     const isRightAligned = message.isUser && !isOtherUser;
     // Only show workflow button in MessageActions if there are no inline progress updates
-    // (when progress updates exist and inline timeline is enabled, the button is shown in the InlineProgressUpdates header instead)
-    const showWorkflowButton = !message.isUser && message.isComplete && !!message.taskId && !!isLastWithTaskId && !hasProgressUpdates;
+    // (when progress updates exist and inline timeline is enabled, the button is shown in the InlineProgressUpdates header instead).
+    // The embedded surface hides the Activity panel this button opens, so suppress it there too
+    // (showActivityPanel === undefined means "not constrained" → keep showing).
+    const showWorkflowButton = !message.isUser && message.isComplete && !!message.taskId && !!isLastWithTaskId && !hasProgressUpdates && showActivityPanel !== false;
     const showFeedbackActions = !message.isUser && message.isComplete && !!message.taskId && !!isLastWithTaskId;
 
     // Debug logging for error messages
@@ -904,6 +907,7 @@ export const ChatMessage: React.FC<{ message: MessageFE; isLastWithTaskId?: bool
     const { ragData, openSidePanelTab, setTaskIdInSidePanel, artifacts, sessionId, isCollaborativeSession, hasSharedEditors, currentUserEmail, agentNameDisplayNameMap } = chatContext;
     const { value: inlineActivityTimelineEnabled } = useBooleanFlagDetails("inline_activity_timeline", false);
     const { value: showThinkingContentEnabled } = useBooleanFlagDetails("show_thinking_content", false);
+    const surface = useChatSurface();
 
     // Determine if this is another user's message (for uploaded files alignment)
     const isOtherUser = message.isUser && isOtherUserMessage(message, currentUserEmail);
@@ -1175,7 +1179,8 @@ export const ChatMessage: React.FC<{ message: MessageFE; isLastWithTaskId?: bool
                     highlightedText,
                     // Feature flags
                     inlineActivityTimelineEnabled,
-                    showThinkingContentEnabled
+                    showThinkingContentEnabled,
+                    surface.showActivityPanel
                 )}
 
                 {/* Render images separately at the end for web search */}

--- a/client/webui/frontend/src/lib/components/chat/ChatSidePanel.tsx
+++ b/client/webui/frontend/src/lib/components/chat/ChatSidePanel.tsx
@@ -3,10 +3,10 @@ import React, { useState, useEffect, useMemo } from "react";
 import { PanelRightIcon, FileText, Network, RefreshCw, Link2 } from "lucide-react";
 
 import { Button, Tabs, TabsList, TabsTrigger, TabsContent } from "@/lib/components/ui";
-import { useTaskContext, useChatContext, useIsProjectIndexingEnabled } from "@/lib/hooks";
+import { useTaskContext, useChatContext, useChatSurface, useIsProjectIndexingEnabled } from "@/lib/hooks";
 import { FlowChartPanel, processTaskForVisualization } from "@/lib/components/activities";
 import type { VisualizedTask } from "@/lib/types";
-import { hasSourcesWithUrls, hasDocumentSearchResults } from "@/lib/utils";
+import { cn, hasSourcesWithUrls, hasDocumentSearchResults } from "@/lib/utils";
 
 import { ArtifactPanel } from "./artifact/ArtifactPanel";
 import { FlowChartDetails } from "../activities/FlowChartDetails";
@@ -21,6 +21,7 @@ interface ChatSidePanelProps {
 
 export const ChatSidePanel: React.FC<ChatSidePanelProps> = ({ onCollapsedToggle, isSidePanelCollapsed, setIsSidePanelCollapsed }) => {
     const { activeSidePanelTab, setActiveSidePanelTab, setPreviewArtifact, taskIdInSidePanel, ragData, ragEnabled } = useChatContext();
+    const surface = useChatSurface();
     const { isReconnecting, isTaskMonitorConnecting, isTaskMonitorConnected, monitoredTasks, connectTaskMonitorStream, loadTaskFromBackend } = useTaskContext();
     const isProjectIndexingEnabled = useIsProjectIndexingEnabled();
     const [visualizedTask, setVisualizedTask] = useState<VisualizedTask | null>(null);
@@ -42,6 +43,13 @@ export const ChatSidePanel: React.FC<ChatSidePanelProps> = ({ onCollapsedToggle,
         // Also check for document search results
         return hasDocumentSearchResults(ragData);
     }, [ragData]);
+
+    // The embedded surface hides the Activity tab; fall back to Files so the panel never lands on a hidden tab.
+    useEffect(() => {
+        if (!surface.showActivityPanel && activeSidePanelTab === "activity") {
+            setActiveSidePanelTab("files");
+        }
+    }, [surface.showActivityPanel, activeSidePanelTab, setActiveSidePanelTab]);
 
     // Process task data for visualization when the selected activity task ID changes
     // or when monitoredTasks is updated with new data.
@@ -168,9 +176,11 @@ export const ChatSidePanel: React.FC<ChatSidePanelProps> = ({ onCollapsedToggle,
                     <FileText className="size-5" />
                 </Button>
 
-                <Button variant="ghost" size="sm" onClick={() => handleIconClick("activity")} className={hasSourcesInSession ? "mb-2 h-10 w-10 p-0" : "h-10 w-10 p-0"} tooltip="Activity">
-                    <Network className="size-5" />
-                </Button>
+                {surface.showActivityPanel && (
+                    <Button variant="ghost" size="sm" onClick={() => handleIconClick("activity")} className={hasSourcesInSession ? "mb-2 h-10 w-10 p-0" : "h-10 w-10 p-0"} tooltip="Activity">
+                        <Network className="size-5" />
+                    </Button>
+                )}
 
                 {hasSourcesInSession && (
                     <Button variant="ghost" size="sm" onClick={() => handleIconClick("rag")} className="h-10 w-10 p-0" tooltip="Sources">
@@ -191,14 +201,16 @@ export const ChatSidePanel: React.FC<ChatSidePanelProps> = ({ onCollapsedToggle,
                             <PanelRightIcon className="size-5" />
                         </Button>
                         <TabsList className="flex min-w-0 flex-1 bg-transparent p-0">
-                            <TabsTrigger value="files" title="Files" className="relative min-w-0 flex-1 rounded-none rounded-l-md px-2 data-[state=active]:z-10" onClick={() => setPreviewArtifact(null)}>
+                            <TabsTrigger value="files" title="Files" className={cn("relative min-w-0 flex-1 rounded-none rounded-l-md px-2 data-[state=active]:z-10", !surface.showActivityPanel && !hasSourcesInSession && "rounded-r-md border-r")} onClick={() => setPreviewArtifact(null)}>
                                 <FileText className="h-4 w-4 shrink-0" />
                                 <span className="ml-1.5 hidden truncate @[240px]:inline">Files</span>
                             </TabsTrigger>
-                            <TabsTrigger value="activity" title="Activity" className={`relative min-w-0 flex-1 rounded-none border-x-0 border-y px-2 data-[state=active]:z-10 ${!hasSourcesInSession ? "rounded-r-md border-r" : ""}`}>
-                                <Network className="h-4 w-4 shrink-0" />
-                                <span className="ml-1.5 hidden truncate @[240px]:inline">Activity</span>
-                            </TabsTrigger>
+                            {surface.showActivityPanel && (
+                                <TabsTrigger value="activity" title="Activity" className={cn("relative min-w-0 flex-1 rounded-none border-x-0 border-y px-2 data-[state=active]:z-10", !hasSourcesInSession && "rounded-r-md border-r")}>
+                                    <Network className="h-4 w-4 shrink-0" />
+                                    <span className="ml-1.5 hidden truncate @[240px]:inline">Activity</span>
+                                </TabsTrigger>
+                            )}
                             {hasSourcesInSession && (
                                 <TabsTrigger value="rag" title="Sources" className="relative min-w-0 flex-1 rounded-none rounded-r-md px-2 data-[state=active]:z-10">
                                     <Link2 className="h-4 w-4 shrink-0" />
@@ -214,44 +226,46 @@ export const ChatSidePanel: React.FC<ChatSidePanelProps> = ({ onCollapsedToggle,
                             </div>
                         </TabsContent>
 
-                        <TabsContent value="activity" className="m-0 h-full">
-                            <div className="h-full">
-                                {(() => {
-                                    const emptyStateContent = getActivityPanelContent();
+                        {surface.showActivityPanel && (
+                            <TabsContent value="activity" className="m-0 h-full">
+                                <div className="h-full">
+                                    {(() => {
+                                        const emptyStateContent = getActivityPanelContent();
 
-                                    if (!emptyStateContent && visualizedTask) {
+                                        if (!emptyStateContent && visualizedTask) {
+                                            return (
+                                                <div className="flex h-full flex-col">
+                                                    <FlowChartDetails task={visualizedTask} />
+                                                    <FlowChartPanel processedSteps={visualizedTask.steps || []} isRightPanelVisible={false} />
+                                                </div>
+                                            );
+                                        }
+
                                         return (
-                                            <div className="flex h-full flex-col">
-                                                <FlowChartDetails task={visualizedTask} />
-                                                <FlowChartPanel processedSteps={visualizedTask.steps || []} isRightPanelVisible={false} />
+                                            <div className="flex h-full items-center justify-center p-4">
+                                                <div className="text-center text-(--secondary-text-wMain)">
+                                                    <Network className="mx-auto mb-4 h-12 w-12" />
+                                                    <div className="text-lg font-medium">Activity</div>
+                                                    <div className="mt-2 text-sm">{emptyStateContent?.message}</div>
+                                                    {emptyStateContent?.showButton && (
+                                                        <div className="mt-4">
+                                                            <Button onClick={emptyStateContent.buttonAction}>
+                                                                {emptyStateContent.buttonIcon &&
+                                                                    (() => {
+                                                                        const ButtonIcon = emptyStateContent.buttonIcon;
+                                                                        return <ButtonIcon className="h-4 w-4" />;
+                                                                    })()}
+                                                                {emptyStateContent.buttonText}
+                                                            </Button>
+                                                        </div>
+                                                    )}
+                                                </div>
                                             </div>
                                         );
-                                    }
-
-                                    return (
-                                        <div className="flex h-full items-center justify-center p-4">
-                                            <div className="text-center text-(--secondary-text-wMain)">
-                                                <Network className="mx-auto mb-4 h-12 w-12" />
-                                                <div className="text-lg font-medium">Activity</div>
-                                                <div className="mt-2 text-sm">{emptyStateContent?.message}</div>
-                                                {emptyStateContent?.showButton && (
-                                                    <div className="mt-4">
-                                                        <Button onClick={emptyStateContent.buttonAction}>
-                                                            {emptyStateContent.buttonIcon &&
-                                                                (() => {
-                                                                    const ButtonIcon = emptyStateContent.buttonIcon;
-                                                                    return <ButtonIcon className="h-4 w-4" />;
-                                                                })()}
-                                                            {emptyStateContent.buttonText}
-                                                        </Button>
-                                                    </div>
-                                                )}
-                                            </div>
-                                        </div>
-                                    );
-                                })()}
-                            </div>
-                        </TabsContent>
+                                    })()}
+                                </div>
+                            </TabsContent>
+                        )}
 
                         {hasSourcesInSession && (
                             <TabsContent value="rag" className="m-0 h-full">

--- a/client/webui/frontend/src/lib/components/chat/EmbeddedChatWelcome.tsx
+++ b/client/webui/frontend/src/lib/components/chat/EmbeddedChatWelcome.tsx
@@ -1,0 +1,9 @@
+import React from "react";
+
+interface EmbeddedChatWelcomeProps {
+    message?: string;
+}
+
+export const EmbeddedChatWelcome: React.FC<EmbeddedChatWelcomeProps> = ({ message }) => {
+    return <h1 className="text-foreground text-center text-3xl font-semibold tracking-tight">{message || "How can I help?"}</h1>;
+};

--- a/client/webui/frontend/src/lib/components/chat/InlineProgressUpdates.tsx
+++ b/client/webui/frontend/src/lib/components/chat/InlineProgressUpdates.tsx
@@ -12,6 +12,7 @@ import { ChevronDown, ChevronRight, ChevronUp, Loader2 } from "lucide-react";
 import { Button } from "@/lib/components/ui";
 import { ViewWorkflowButton } from "@/lib/components/ui/ViewWorkflowButton";
 import { MarkdownWrapper } from "@/lib/components";
+import { useChatSurface } from "@/lib/hooks";
 import { cn } from "@/lib/utils";
 import type { ProgressUpdate } from "@/lib/types";
 
@@ -32,6 +33,8 @@ export const InlineProgressUpdates = ({ updates, isActive = false, onViewWorkflo
     const [isListExpanded, setIsListExpanded] = useState(false);
     const [expandedThinkingIds, setExpandedThinkingIds] = useState<Set<number>>(new Set());
     const hasAutoCollapsed = useRef(false);
+    // Embedded surface hides the Activity panel, so the inline activity timeline is removed entirely.
+    const { showActivityPanel } = useChatSurface();
 
     // Auto-collapse timeline when task completes
     useEffect(() => {
@@ -40,6 +43,9 @@ export const InlineProgressUpdates = ({ updates, isActive = false, onViewWorkflo
             setIsTimelineOpen(false);
         }
     }, [isActive, updates.length]);
+
+    // Embedded surface: no inline activity timeline at all.
+    if (!showActivityPanel) return null;
 
     // No updates yet — the inline breathing indicator under the message provides feedback.
     if (!updates || updates.length === 0) return null;

--- a/client/webui/frontend/src/lib/components/chat/RecentChatsList.tsx
+++ b/client/webui/frontend/src/lib/components/chat/RecentChatsList.tsx
@@ -6,7 +6,7 @@ import { MessageCircle, CalendarDays, Share2 } from "lucide-react";
 import { useMarkSessionViewed, useRecentSessions } from "@/lib/api/sessions";
 import { useSharedWithMe } from "@/lib/api/share";
 import { MAX_RECENT_CHATS } from "@/lib/constants/ui";
-import { useChatContext, useConfigContext, useIsAutoTitleGenerationEnabled, useIsChatSharingEnabled, useTitleAnimation } from "@/lib/hooks";
+import { useChatContext, useChatRoute, useConfigContext, useIsAutoTitleGenerationEnabled, useIsChatSharingEnabled, useTitleAnimation } from "@/lib/hooks";
 import { Spinner, Tooltip, TooltipContent, TooltipTrigger } from "@/lib/components/ui";
 import type { Session } from "@/lib/types";
 import type { SharedWithMeItem } from "@/lib/types/share";
@@ -87,19 +87,26 @@ function SessionName({ session, respondingSessionId, isActive, hasRunningBackgro
 
 interface RecentChatsListProps {
     maxItems?: number;
+    /**
+     * When set, scope the list to a single agent (server-side filter) and omit the
+     * cross-agent "shared with me" entries. Used by the embedded surface.
+     */
+    agentId?: string;
 }
 
 type SessionEntry = { kind: "session"; timestamp: number; session: Session };
 type SharedEntry = { kind: "shared"; timestamp: number; shared: SharedWithMeItem };
 type Entry = SessionEntry | SharedEntry;
 
-export function RecentChatsList({ maxItems = MAX_RECENT_CHATS }: RecentChatsListProps) {
+export function RecentChatsList({ maxItems = MAX_RECENT_CHATS, agentId }: RecentChatsListProps) {
     const navigate = useNavigate();
     const { sessionId, handleSwitchSession, currentTaskId } = useChatContext();
     const { persistenceEnabled } = useConfigContext();
     const chatSharingEnabled = useIsChatSharingEnabled();
+    // Keep navigation on the embedded route (with ?agent=) so the URL stays embedded.
+    const chatRoute = useChatRoute();
 
-    const { data: sessionsData, isLoading, isFetching } = useRecentSessions(maxItems);
+    const { data: sessionsData, isLoading, isFetching } = useRecentSessions(maxItems, agentId);
     const sessions = useMemo(() => sessionsData ?? [], [sessionsData]);
     const { data: sharedItems = [] } = useSharedWithMe();
     const markViewedMutation = useMarkSessionViewed();
@@ -156,14 +163,15 @@ export function RecentChatsList({ maxItems = MAX_RECENT_CHATS }: RecentChatsList
             session,
         }));
 
-        const sharedEntries: Entry[] = chatSharingEnabled ? sharedItems.map(shared => ({ kind: "shared", timestamp: shared.sharedAt || 0, shared })) : [];
+        // Shared-with-me items aren't agent-scoped, so omit them when filtering to one agent.
+        const sharedEntries: Entry[] = chatSharingEnabled && !agentId ? sharedItems.map(shared => ({ kind: "shared", timestamp: shared.sharedAt || 0, shared })) : [];
 
         return [...sessionEntries, ...sharedEntries].sort((a, b) => b.timestamp - a.timestamp).slice(0, maxItems);
-    }, [sessions, sharedItems, chatSharingEnabled, maxItems]);
+    }, [sessions, sharedItems, chatSharingEnabled, maxItems, agentId]);
 
     const handleSessionClick = async (clickedSession: Session) => {
         // Navigate to chat page first, then switch session
-        navigate("/chat");
+        navigate(chatRoute);
         await handleSwitchSession(clickedSession.id);
         // Mark viewed AFTER switch completes — switching can trigger SSE
         // replay / save_task calls that advance the session's updated_time
@@ -174,7 +182,7 @@ export function RecentChatsList({ maxItems = MAX_RECENT_CHATS }: RecentChatsList
     const handleSharedClick = async (item: SharedWithMeItem) => {
         const isEditor = item.accessLevel === "RESOURCE_EDITOR" && item.sessionId;
         if (isEditor && item.sessionId) {
-            navigate("/chat");
+            navigate(chatRoute);
             await handleSwitchSession(item.sessionId);
         } else {
             navigate(`/shared-chat/${item.shareId}`);

--- a/client/webui/frontend/src/lib/components/chat/RecentChatsSidePanel.tsx
+++ b/client/webui/frontend/src/lib/components/chat/RecentChatsSidePanel.tsx
@@ -1,0 +1,47 @@
+import React, { useState } from "react";
+import { Link } from "react-router-dom";
+import { User } from "lucide-react";
+
+import { RecentChatsList } from "./RecentChatsList";
+import { MAX_RECENT_CHATS } from "@/lib/constants/ui";
+import { useChatSurface } from "@/lib/hooks";
+import { navButtonStyles, iconWrapperStyles, iconStyles, navTextStyles } from "@/lib/components/navigation/navigationStyles";
+import { SettingsDialog } from "@/lib/components/settings/SettingsDialog";
+
+/**
+ * Embedded-only left drawer listing the pinned agent's recent chats, with the same
+ * bottom User Account section as the navigation sidebar. Dark-themed to match the
+ * navigation surface. Toggled from the chat header (left of New Chat).
+ */
+export const RecentChatsSidePanel: React.FC = () => {
+    const { pinnedAgent } = useChatSurface();
+    const [isSettingsOpen, setIsSettingsOpen] = useState(false);
+
+    const viewAllTo = pinnedAgent ? `/embed/recent-chats?agent=${encodeURIComponent(pinnedAgent)}` : "/embed/recent-chats";
+
+    return (
+        <div className="flex h-full w-100 flex-col border-r border-(--darkSurface-border) bg-(--darkSurface-bg)">
+            <div className="mb-2 flex h-20 items-center justify-between border-b px-6 pt-6 pb-2">
+                <span className="text-sm font-bold text-(--darkSurface-textMuted)">Recent Chats</span>
+                <Link to={viewAllTo} className="cursor-pointer text-sm font-bold text-(--darkSurface-buttonText) no-underline hover:text-(--darkSurface-buttonTextHover)">
+                    View All
+                </Link>
+            </div>
+            <div className="scrollbar-subtle min-h-0 flex-1 overflow-y-auto">
+                <RecentChatsList maxItems={MAX_RECENT_CHATS} agentId={pinnedAgent ?? undefined} />
+            </div>
+
+            {/* User Account section — mirrors the navigation sidebar's bottom item. */}
+            <div className="mt-auto border-t border-(--secondary-w70) py-3">
+                <button onClick={() => setIsSettingsOpen(true)} className={navButtonStyles()}>
+                    <div className={iconWrapperStyles({ active: false, withMargin: true })}>
+                        <User className={iconStyles({ active: false })} />
+                    </div>
+                    <span className={navTextStyles()}>User Account</span>
+                </button>
+            </div>
+
+            <SettingsDialog open={isSettingsOpen} onOpenChange={setIsSettingsOpen} />
+        </div>
+    );
+};

--- a/client/webui/frontend/src/lib/components/chat/SessionActionMenu.tsx
+++ b/client/webui/frontend/src/lib/components/chat/SessionActionMenu.tsx
@@ -3,6 +3,7 @@ import { Trash2, Pencil, FolderInput, MoreHorizontal, PanelsTopLeft, Sparkles, S
 
 import { cn } from "@/lib/utils";
 import { Button, DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuSeparator, DropdownMenuTrigger } from "@/lib/components/ui";
+import { useChatSurface } from "@/lib/hooks";
 import type { Session } from "@/lib/types";
 
 export interface SessionActionMenuProps {
@@ -19,6 +20,14 @@ export interface SessionActionMenuProps {
 }
 
 export const SessionActionMenu: React.FC<SessionActionMenuProps> = ({ session, onRename, onRenameWithAI, onMove, onDelete, onGoToProject, onShare, isRegeneratingTitle = false, triggerClassName }) => {
+    const surface = useChatSurface();
+    // Which items appear is driven by the surface allowlist (in canonical order),
+    // so a new action is added once here — there's no separate per-surface branch to keep in sync.
+    const allows = surface.sessionActions;
+
+    const showGoToProject = allows.includes("goToProject") && !!session.projectId && !!onGoToProject;
+    const showShare = allows.includes("share") && !!onShare;
+
     return (
         <DropdownMenu>
             <DropdownMenuTrigger asChild>
@@ -27,12 +36,12 @@ export const SessionActionMenu: React.FC<SessionActionMenuProps> = ({ session, o
                 </Button>
             </DropdownMenuTrigger>
             <DropdownMenuContent align="end" className="w-48">
-                {session.projectId && onGoToProject && (
+                {showGoToProject && (
                     <>
                         <DropdownMenuItem
                             onClick={e => {
                                 e.stopPropagation();
-                                onGoToProject(session);
+                                onGoToProject?.(session);
                             }}
                         >
                             <PanelsTopLeft size={16} className="mr-2" />
@@ -41,55 +50,65 @@ export const SessionActionMenu: React.FC<SessionActionMenuProps> = ({ session, o
                         <DropdownMenuSeparator />
                     </>
                 )}
-                <DropdownMenuItem
-                    onClick={e => {
-                        e.stopPropagation();
-                        onRename(session);
-                    }}
-                >
-                    <Pencil size={16} className="mr-2" />
-                    Rename
-                </DropdownMenuItem>
-                <DropdownMenuItem
-                    onClick={e => {
-                        e.stopPropagation();
-                        onRenameWithAI(session);
-                    }}
-                    disabled={isRegeneratingTitle}
-                >
-                    <Sparkles size={16} className={cn("mr-2", isRegeneratingTitle && "animate-pulse")} />
-                    Rename with AI
-                </DropdownMenuItem>
-                <DropdownMenuItem
-                    onClick={e => {
-                        e.stopPropagation();
-                        onMove(session);
-                    }}
-                >
-                    <FolderInput size={16} className="mr-2" />
-                    Move to Project
-                </DropdownMenuItem>
-                {onShare && (
+                {allows.includes("rename") && (
                     <DropdownMenuItem
                         onClick={e => {
                             e.stopPropagation();
-                            onShare(session);
+                            onRename(session);
+                        }}
+                    >
+                        <Pencil size={16} className="mr-2" />
+                        Rename
+                    </DropdownMenuItem>
+                )}
+                {allows.includes("renameWithAI") && (
+                    <DropdownMenuItem
+                        onClick={e => {
+                            e.stopPropagation();
+                            onRenameWithAI(session);
+                        }}
+                        disabled={isRegeneratingTitle}
+                    >
+                        <Sparkles size={16} className={cn("mr-2", isRegeneratingTitle && "animate-pulse")} />
+                        Rename with AI
+                    </DropdownMenuItem>
+                )}
+                {allows.includes("move") && (
+                    <DropdownMenuItem
+                        onClick={e => {
+                            e.stopPropagation();
+                            onMove(session);
+                        }}
+                    >
+                        <FolderInput size={16} className="mr-2" />
+                        Move to Project
+                    </DropdownMenuItem>
+                )}
+                {showShare && (
+                    <DropdownMenuItem
+                        onClick={e => {
+                            e.stopPropagation();
+                            onShare?.(session);
                         }}
                     >
                         <Share2 size={16} className="mr-2" />
                         Share
                     </DropdownMenuItem>
                 )}
-                <DropdownMenuSeparator />
-                <DropdownMenuItem
-                    onClick={e => {
-                        e.stopPropagation();
-                        onDelete(session);
-                    }}
-                >
-                    <Trash2 size={16} className="mr-2" />
-                    Delete
-                </DropdownMenuItem>
+                {allows.includes("delete") && (
+                    <>
+                        <DropdownMenuSeparator />
+                        <DropdownMenuItem
+                            onClick={e => {
+                                e.stopPropagation();
+                                onDelete(session);
+                            }}
+                        >
+                            <Trash2 size={16} className="mr-2" />
+                            Delete
+                        </DropdownMenuItem>
+                    </>
+                )}
             </DropdownMenuContent>
         </DropdownMenu>
     );

--- a/client/webui/frontend/src/lib/components/chat/SessionSearch.tsx
+++ b/client/webui/frontend/src/lib/components/chat/SessionSearch.tsx
@@ -11,6 +11,8 @@ import type { Session } from "@/lib/types";
 interface SessionSearchProps {
     onSessionSelect: (sessionId: string) => void;
     projectId?: string | null;
+    /** When set, scope search results to a single agent (embedded surface). */
+    agentId?: string | null;
 }
 
 interface SearchResult {
@@ -23,7 +25,7 @@ interface SearchResult {
     };
 }
 
-export const SessionSearch = ({ onSessionSelect, projectId }: SessionSearchProps) => {
+export const SessionSearch = ({ onSessionSelect, projectId, agentId }: SessionSearchProps) => {
     const [searchQuery, setSearchQuery] = useState("");
     const [searchResults, setSearchResults] = useState<Session[]>([]);
     const [isSearching, setIsSearching] = useState(false);
@@ -52,7 +54,7 @@ export const SessionSearch = ({ onSessionSelect, projectId }: SessionSearchProps
         idPrefix: "session-search-",
     });
 
-    const performSearch = useCallback(async (query: string, currentProjectId: string | null | undefined) => {
+    const performSearch = useCallback(async (query: string, currentProjectId: string | null | undefined, currentAgentId: string | null | undefined) => {
         if (!query.trim()) {
             setSearchResults([]);
             setShowResults(false);
@@ -71,6 +73,10 @@ export const SessionSearch = ({ onSessionSelect, projectId }: SessionSearchProps
                 params.append("projectId", currentProjectId);
             }
 
+            if (currentAgentId) {
+                params.append("agent_id", currentAgentId);
+            }
+
             const data: SearchResult = await api.webui.get(`/api/v1/sessions/search?${params.toString()}`);
             setSearchResults(data.data || []);
             setShowResults(true);
@@ -83,8 +89,8 @@ export const SessionSearch = ({ onSessionSelect, projectId }: SessionSearchProps
     }, []);
 
     useEffect(() => {
-        performSearch(debouncedSearchQuery, projectId);
-    }, [debouncedSearchQuery, projectId, performSearch]);
+        performSearch(debouncedSearchQuery, projectId, agentId);
+    }, [debouncedSearchQuery, projectId, agentId, performSearch]);
 
     const placeholder = "Search chats by title";
 

--- a/client/webui/frontend/src/lib/components/chat/index.ts
+++ b/client/webui/frontend/src/lib/components/chat/index.ts
@@ -21,6 +21,7 @@ export { MessageAttribution } from "./MessageAttribution";
 export { CollaborativeUserMessage } from "./CollaborativeUserMessage";
 export { InlineProgressUpdates } from "./InlineProgressUpdates";
 export { ContextUsageIndicator } from "./ContextUsageIndicator";
+export { EmbeddedChatWelcome } from "./EmbeddedChatWelcome";
 export * from "./file";
 export * from "./selection";
 

--- a/client/webui/frontend/src/lib/components/chat/index.ts
+++ b/client/webui/frontend/src/lib/components/chat/index.ts
@@ -9,6 +9,7 @@ export { LoadingMessageRow } from "./LoadingMessageRow";
 export { SessionSidePanel } from "./SessionSidePanel";
 export { MoveSessionDialog } from "./MoveSessionDialog";
 export { RecentChatsList } from "./RecentChatsList";
+export { RecentChatsSidePanel } from "./RecentChatsSidePanel";
 export { VariableDialog } from "./VariableDialog";
 export { SessionSearch } from "./SessionSearch";
 export { MessageHoverButtons } from "./MessageHoverButtons";

--- a/client/webui/frontend/src/lib/components/chat/useChatAttachments.ts
+++ b/client/webui/frontend/src/lib/components/chat/useChatAttachments.ts
@@ -4,6 +4,7 @@ import type { NavigateFunction } from "react-router-dom";
 import { api, getErrorFromResponse } from "@/lib/api";
 import { type ArtifactWithSession, getArtifactApiUrl } from "@/lib/api/artifacts";
 import { getErrorMessage } from "@/lib/utils";
+import { useChatRoute } from "@/lib/hooks/useChatRoute";
 import type { PasteMetadata, PastedTextItem } from "./paste";
 
 interface UseChatAttachmentsOptions {
@@ -78,6 +79,8 @@ export interface UseChatAttachmentsResult {
  * `restoreFromCapture`.
  */
 export function useChatAttachments({ addNotification, displayError, handleSwitchSession, navigate }: UseChatAttachmentsOptions): UseChatAttachmentsResult {
+    // Embedded-aware chat route so "Go to Chat" keeps the /embed/chat?agent= URL.
+    const chatRoute = useChatRoute();
     const [selectedFiles, setSelectedFiles] = useState<File[]>([]);
     const [selectedArtifactRefs, setSelectedArtifactRefs] = useState<ArtifactWithSession[]>([]);
     const [pendingPastedTextItems, setPendingPastedTextItems] = useState<PastedTextItem[]>([]);
@@ -179,9 +182,9 @@ export function useChatAttachments({ addNotification, displayError, handleSwitch
         async (artifact: ArtifactWithSession) => {
             setPreviewingArtifact(null);
             await handleSwitchSession(artifact.sessionId);
-            navigate("/chat");
+            navigate(chatRoute);
         },
-        [handleSwitchSession, navigate]
+        [handleSwitchSession, navigate, chatRoute]
     );
 
     const handlePreviewGoToProject = useCallback(

--- a/client/webui/frontend/src/lib/components/navigation/CollapsibleNavigationSidebar.tsx
+++ b/client/webui/frontend/src/lib/components/navigation/CollapsibleNavigationSidebar.tsx
@@ -200,7 +200,7 @@ export const CollapsibleNavigationSidebar = ({
     const textAnimBase = "overflow-hidden whitespace-nowrap transition-[opacity,max-width] duration-200";
 
     return (
-        <nav className={cn("navigation-sidebar flex h-full flex-col overflow-visible border-r bg-(--darkSurface-bg) transition-[width] duration-200 ease-out", isCollapsed ? "w-20" : "w-64")}>
+        <nav data-testid="collapsible-navigation-sidebar" className={cn("navigation-sidebar flex h-full flex-col overflow-visible border-r bg-(--darkSurface-bg) transition-[width] duration-200 ease-out", isCollapsed ? "w-20" : "w-64")}>
             {/* Header */}
             <div className="relative flex min-h-[80px] w-full items-center border-b border-(--secondary-w70) py-3 pr-4 pl-7">
                 <div className="flex items-center gap-2">{renderHeader()}</div>

--- a/client/webui/frontend/src/lib/components/navigation/CollapsibleNavigationSidebar.tsx
+++ b/client/webui/frontend/src/lib/components/navigation/CollapsibleNavigationSidebar.tsx
@@ -200,7 +200,7 @@ export const CollapsibleNavigationSidebar = ({
     const textAnimBase = "overflow-hidden whitespace-nowrap transition-[opacity,max-width] duration-200";
 
     return (
-        <nav data-testid="collapsible-navigation-sidebar" className={cn("navigation-sidebar flex h-full flex-col overflow-visible border-r bg-(--darkSurface-bg) transition-[width] duration-200 ease-out", isCollapsed ? "w-20" : "w-64")}>
+        <nav className={cn("navigation-sidebar flex h-full flex-col overflow-visible border-r bg-(--darkSurface-bg) transition-[width] duration-200 ease-out", isCollapsed ? "w-20" : "w-64")}>
             {/* Header */}
             <div className="relative flex min-h-[80px] w-full items-center border-b border-(--secondary-w70) py-3 pr-4 pl-7">
                 <div className="flex items-center gap-2">{renderHeader()}</div>

--- a/client/webui/frontend/src/lib/components/navigation/EmbeddedRouteGuard.tsx
+++ b/client/webui/frontend/src/lib/components/navigation/EmbeddedRouteGuard.tsx
@@ -1,0 +1,36 @@
+import { useEffect } from "react";
+import { useLocation, useNavigate } from "react-router-dom";
+
+import { useChatSurface } from "@/lib/hooks";
+
+/**
+ * Keeps the embedded surface "locked" to the `/embed/*` routes. If an in-app navigation
+ * drifts off the embed routes — or lands on an embed route that dropped the pinned `?agent=`
+ * — it redirects back to `/embed/chat?agent=<pinned>`. This is a backstop for any link or
+ * `navigate(...)` not already routed through `useChatRoute()`; it does NOT affect full-page
+ * navigations (e.g. the IdP login round-trip), which reload and re-derive the surface.
+ *
+ * Renders nothing. No-op outside the embedded surface.
+ */
+export const EmbeddedRouteGuard = () => {
+    const surface = useChatSurface();
+    const location = useLocation();
+    const navigate = useNavigate();
+
+    useEffect(() => {
+        if (surface.variant !== "embedded") return;
+
+        const offEmbed = !location.pathname.startsWith("/embed/");
+        // Only enforce agent presence when there's a pinned agent to re-append — otherwise a
+        // genuine no-agent embed (`/embed/chat` with no ?agent=) would redirect to itself forever.
+        const lostAgent = !!surface.pinnedAgent && !new URLSearchParams(location.search).get("agent");
+
+        if (offEmbed || lostAgent) {
+            const target = surface.pinnedAgent ? `/embed/chat?agent=${encodeURIComponent(surface.pinnedAgent)}` : "/embed/chat";
+            console.warn("Embedded surface: blocked navigation off the embedded route, returning to", target);
+            navigate(target, { replace: true });
+        }
+    }, [location, surface, navigate]);
+
+    return null;
+};

--- a/client/webui/frontend/src/lib/components/navigation/NavigationSidebar.tsx
+++ b/client/webui/frontend/src/lib/components/navigation/NavigationSidebar.tsx
@@ -20,7 +20,7 @@ export const NavigationSidebar: React.FC<NavigationSidebarProps> = ({ items, bot
     const filteredBottomItems = bottomItems?.filter(item => item.id !== "theme-toggle");
 
     return (
-        <aside className="flex h-screen w-[100px] flex-col overflow-y-auto border-r border-(--darkSurface-border) bg-(--darkSurface-bg)">
+        <aside data-testid="navigation-sidebar" className="flex h-screen w-[100px] flex-col overflow-y-auto border-r border-(--darkSurface-border) bg-(--darkSurface-bg)">
             <NavigationHeader onClick={onHeaderClick} />
             <NavigationList items={items} bottomItems={filteredBottomItems} activeItem={activeItem} onItemClick={handleItemClick} />
         </aside>

--- a/client/webui/frontend/src/lib/components/pages/ChatPage.tsx
+++ b/client/webui/frontend/src/lib/components/pages/ChatPage.tsx
@@ -39,6 +39,8 @@ const COLLAPSED_STYLE = { height: 0, overflow: "hidden" } as const;
 const NO_OVERFLOW_ANCHOR_STYLE = { overflowAnchor: "none" } as const;
 const OVERFLOW_ANCHOR_AUTO_STYLE = { overflowAnchor: "auto" } as const;
 const HERO_MAX_WIDTH_STYLE = { maxWidth: "900px" } as const;
+// Optimistic grace period before an embedded pinned agent that hasn't resolved
+const PINNED_AGENT_GRACE_MS = 10000;
 // Constants for sidepanel behavior
 const COLLAPSED_SIZE = 4; // icon-only mode size
 const PANEL_SIZES_CLOSED = {
@@ -71,7 +73,6 @@ export function ChatPage() {
     const { configWelcomeMessage } = useConfigContext();
     const {
         agents,
-        agentsLoading,
         agentsRefetch,
         sessionId,
         sessionName,
@@ -111,17 +112,19 @@ export function ChatPage() {
     // show a terminal error rather than guessing an agent (the selector is hidden).
     const noAgentSpecified = isEmbedded && !surface.pinnedAgent && messages.length === 0;
 
-    // A named pinned agent hasn't resolved yet (selectedAgentName still ""). Show a
-    // connecting state until the agent cards have loaded; if the load completes and the
-    // pinned agent still isn't among them, it's a bad ?agent= (typo/down/unauthorized).
+    // A named pinned agent hasn't resolved yet (selectedAgentName still "")
     const isAwaitingPinnedAgent = isEmbedded && !!surface.pinnedAgent && messages.length === 0 && !selectedAgentName;
-    // Agent cards are a one-shot fetch, so once loaded with agents present and the pinned
-    // one absent, it won't appear — no timer needed. (agents.length > 0 avoids a first-paint flash.)
-    const pinnedAgentMissing = isAwaitingPinnedAgent && !agentsLoading && agents.length > 0;
+    // Dead-end recovery: if it's still unresolved after a short grace period, conclude the agent doesn't exist
+    const [pinnedAgentTimedOut, setPinnedAgentTimedOut] = useState(false);
+    useEffect(() => {
+        if (!isAwaitingPinnedAgent) {
+            setPinnedAgentTimedOut(false);
+            return;
+        }
+        const timer = setTimeout(() => setPinnedAgentTimedOut(true), PINNED_AGENT_GRACE_MS);
+        return () => clearTimeout(timer);
+    }, [isAwaitingPinnedAgent]);
 
-    // Embedded hero heading. Resolve the pinned agent by its wire name only — the same
-    // identifier ?agent= and message routing (agent_name) use — so the greeting label
-    // can never disagree with the agent that receives messages.
     const welcomeAgent = useMemo(() => agents.find(a => a.name === selectedAgentName), [agents, selectedAgentName]);
     const heroMessage = configWelcomeMessage || (welcomeAgent ? `Hi, I'm ${welcomeAgent.displayName || welcomeAgent.name}. How can I help you?` : `Hi, I'm ${selectedAgentName}. How can I help you?`);
 
@@ -667,7 +670,7 @@ export function ChatPage() {
                                     ) : isAwaitingPinnedAgent ? (
                                         // Embedded: named agent not resolved yet. Show connecting, then a terminal
                                         // "unavailable" error if it never registers.
-                                        pinnedAgentMissing ? (
+                                        pinnedAgentTimedOut ? (
                                             <EmptyState variant="error" title="Agent unavailable" subtitle="This agent does not exist or is currently unavailable." />
                                         ) : (
                                             renderEmbeddedEmptyState(<EmptyState variant="loading" title="Agent connecting..." />)

--- a/client/webui/frontend/src/lib/components/pages/ChatPage.tsx
+++ b/client/webui/frontend/src/lib/components/pages/ChatPage.tsx
@@ -38,9 +38,6 @@ import { ShareDialog } from "@/lib/components/share/ShareDialog";
 const COLLAPSED_STYLE = { height: 0, overflow: "hidden" } as const;
 const NO_OVERFLOW_ANCHOR_STYLE = { overflowAnchor: "none" } as const;
 const OVERFLOW_ANCHOR_AUTO_STYLE = { overflowAnchor: "auto" } as const;
-// How long the embedded surface waits for its pinned ?agent= to register before
-// showing a terminal "unavailable" message instead of spinning forever.
-const PINNED_AGENT_TIMEOUT_MS = 15000;
 const HERO_MAX_WIDTH_STYLE = { maxWidth: "900px" } as const;
 // Constants for sidepanel behavior
 const COLLAPSED_SIZE = 4; // icon-only mode size
@@ -74,6 +71,7 @@ export function ChatPage() {
     const { configWelcomeMessage } = useConfigContext();
     const {
         agents,
+        agentsLoading,
         agentsRefetch,
         sessionId,
         sessionName,
@@ -114,24 +112,18 @@ export function ChatPage() {
     const noAgentSpecified = isEmbedded && !surface.pinnedAgent && messages.length === 0;
 
     // A named pinned agent hasn't resolved yet (selectedAgentName still ""). Show a
-    // connecting state, falling back to a terminal "unavailable" error after a timeout
-    // so a bad ?agent= (typo, down, or unauthorized) doesn't spin forever.
+    // connecting state until the agent cards have loaded; if the load completes and the
+    // pinned agent still isn't among them, it's a bad ?agent= (typo/down/unauthorized).
     const isAwaitingPinnedAgent = isEmbedded && !!surface.pinnedAgent && messages.length === 0 && !selectedAgentName;
+    // Agent cards are a one-shot fetch, so once loaded with agents present and the pinned
+    // one absent, it won't appear — no timer needed. (agents.length > 0 avoids a first-paint flash.)
+    const pinnedAgentMissing = isAwaitingPinnedAgent && !agentsLoading && agents.length > 0;
 
     // Embedded hero heading. Resolve the pinned agent by its wire name only — the same
     // identifier ?agent= and message routing (agent_name) use — so the greeting label
     // can never disagree with the agent that receives messages.
     const welcomeAgent = useMemo(() => agents.find(a => a.name === selectedAgentName), [agents, selectedAgentName]);
     const heroMessage = configWelcomeMessage || (welcomeAgent ? `Hi, I'm ${welcomeAgent.displayName || welcomeAgent.name}. How can I help you?` : `Hi, I'm ${selectedAgentName}. How can I help you?`);
-    const [pinnedAgentTimedOut, setPinnedAgentTimedOut] = useState(false);
-    useEffect(() => {
-        if (!isAwaitingPinnedAgent) {
-            setPinnedAgentTimedOut(false);
-            return;
-        }
-        const timer = setTimeout(() => setPinnedAgentTimedOut(true), PINNED_AGENT_TIMEOUT_MS);
-        return () => clearTimeout(timer);
-    }, [isAwaitingPinnedAgent]);
 
     // Share notification data: each entry represents a share action (user added at a specific time)
     const [shareNotifications, setShareNotifications] = useState<
@@ -675,7 +667,7 @@ export function ChatPage() {
                                     ) : isAwaitingPinnedAgent ? (
                                         // Embedded: named agent not resolved yet. Show connecting, then a terminal
                                         // "unavailable" error if it never registers.
-                                        pinnedAgentTimedOut ? (
+                                        pinnedAgentMissing ? (
                                             <EmptyState variant="error" title="Agent unavailable" subtitle="This agent does not exist or is currently unavailable." />
                                         ) : (
                                             renderEmbeddedEmptyState(<EmptyState variant="loading" title="Agent connecting..." />)

--- a/client/webui/frontend/src/lib/components/pages/ChatPage.tsx
+++ b/client/webui/frontend/src/lib/components/pages/ChatPage.tsx
@@ -6,13 +6,14 @@ import { PanelLeftIcon, Loader2, GitFork } from "lucide-react";
 import type { ImperativePanelHandle } from "react-resizable-panels";
 
 import { Header } from "@/lib/components/header";
-import { useChatContext, useIsAutoTitleGenerationEnabled, useIsNewNavigationEnabled, useTaskContext, useTitleAnimation, useIsChatSharingEnabled, useTurnDividerAnimation } from "@/lib/hooks";
+import { useChatContext, useChatSurface, useConfigContext, useIsAutoTitleGenerationEnabled, useIsNewNavigationEnabled, useTaskContext, useTitleAnimation, useIsChatSharingEnabled, useTurnDividerAnimation } from "@/lib/hooks";
 import { SLIDE_OUT_DURATION_MS, FADE_OUT_DURATION_MS } from "@/lib/hooks/useTurnDividerAnimation";
 import { useProjectContext } from "@/lib/providers";
 import type { CollaborativeUser } from "@/lib/types/collaboration";
-import { ChatInputArea, ChatMessage, ChatSessionDialog, ChatSessionDeleteDialog, ChatSidePanel, LoadingMessageRow, ProjectBadge, SessionSidePanel, UserPresenceAvatars, ShareNotificationMessage } from "@/lib/components/chat";
+import { ChatInputArea, ChatMessage, ChatSessionDialog, ChatSessionDeleteDialog, ChatSidePanel, EmbeddedChatWelcome, LoadingMessageRow, ProjectBadge, SessionSidePanel, UserPresenceAvatars, ShareNotificationMessage } from "@/lib/components/chat";
 import { Button, ChatMessageList, CHAT_STYLES, ResizablePanelGroup, ResizablePanel, ResizableHandle, Spinner, Tooltip, TooltipContent, TooltipTrigger } from "@/lib/components/ui";
 import { PageLayout } from "@/lib/components/layout";
+import { EmptyState } from "@/lib/components/common/EmptyState";
 import type { ChatMessageListRef } from "@/lib/components/ui/chat/chat-message-list";
 import { useShareLink, useShareUsers } from "@/lib/api/share";
 import { api } from "@/lib/api";
@@ -24,6 +25,10 @@ import { ShareDialog } from "@/lib/components/share/ShareDialog";
 const COLLAPSED_STYLE = { height: 0, overflow: "hidden" } as const;
 const NO_OVERFLOW_ANCHOR_STYLE = { overflowAnchor: "none" } as const;
 const OVERFLOW_ANCHOR_AUTO_STYLE = { overflowAnchor: "auto" } as const;
+// How long the embedded surface waits for its pinned ?agent= to register before
+// showing a terminal "unavailable" message instead of spinning forever.
+const PINNED_AGENT_TIMEOUT_MS = 15000;
+const HERO_MAX_WIDTH_STYLE = { maxWidth: "900px" } as const;
 // Constants for sidepanel behavior
 const COLLAPSED_SIZE = 4; // icon-only mode size
 const PANEL_SIZES_CLOSED = {
@@ -52,11 +57,14 @@ export function ChatPage() {
     const location = useLocation();
     const navigate = useNavigate();
     const { value: inlineActivityTimelineEnabled } = useBooleanFlagDetails("inline_activity_timeline", false);
+    const surface = useChatSurface();
+    const { configWelcomeMessage } = useConfigContext();
     const {
         agents,
         agentsRefetch,
         sessionId,
         sessionName,
+        selectedAgentName,
         messages,
         isSidePanelCollapsed,
         setIsSidePanelCollapsed,
@@ -85,6 +93,33 @@ export function ChatPage() {
     const [isSidePanelTransitioning, setIsSidePanelTransitioning] = useState(false);
     const [isForkingChat, setIsForkingChat] = useState(false);
     const [isShareDialogOpen, setIsShareDialogOpen] = useState(false);
+
+    const isEmbedded = surface.variant === "embedded";
+
+    // Embedded surface requires an explicit ?agent=. With none, it's a misconfiguration —
+    // show a terminal error rather than guessing an agent (the selector is hidden).
+    const noAgentSpecified = isEmbedded && !surface.pinnedAgent && messages.length === 0;
+
+    // A named pinned agent hasn't resolved yet (selectedAgentName still ""). Show a
+    // connecting state, falling back to a terminal "unavailable" error after a timeout
+    // so a bad ?agent= (typo, down, or unauthorized) doesn't spin forever.
+    const isAwaitingPinnedAgent = isEmbedded && !!surface.pinnedAgent && messages.length === 0 && !selectedAgentName;
+
+    // Embedded hero heading. Resolve the pinned agent by its wire name only — the same
+    // identifier ?agent= and message routing (agent_name) use — so the greeting label
+    // can never disagree with the agent that receives messages.
+    const welcomeAgent = useMemo(() => agents.find(a => a.name === selectedAgentName), [agents, selectedAgentName]);
+    const heroMessage = configWelcomeMessage || (welcomeAgent ? `Hi, I'm ${welcomeAgent.displayName || welcomeAgent.name}. How can I help you?` : `Hi, I'm ${selectedAgentName}. How can I help you?`);
+    const [pinnedAgentTimedOut, setPinnedAgentTimedOut] = useState(false);
+    useEffect(() => {
+        if (!isAwaitingPinnedAgent) {
+            setPinnedAgentTimedOut(false);
+            return;
+        }
+        const timer = setTimeout(() => setPinnedAgentTimedOut(true), PINNED_AGENT_TIMEOUT_MS);
+        return () => clearTimeout(timer);
+    }, [isAwaitingPinnedAgent]);
+
     // Share notification data: each entry represents a share action (user added at a specific time)
     const [shareNotifications, setShareNotifications] = useState<
         Array<
@@ -451,6 +486,8 @@ export function ChatPage() {
     );
 
     const handleViewProgressClick = useMemo(() => {
+        // The embedded surface hides the Activity panel, so don't surface a button that opens it.
+        if (!surface.showActivityPanel) return undefined;
         if (inlineActivityTimelineEnabled) return undefined;
         if (!currentTaskId) return undefined;
 
@@ -458,7 +495,7 @@ export function ChatPage() {
             setTaskIdInSidePanel(currentTaskId);
             openSidePanelTab("activity");
         };
-    }, [currentTaskId, setTaskIdInSidePanel, openSidePanelTab, inlineActivityTimelineEnabled]);
+    }, [surface.showActivityPanel, currentTaskId, setTaskIdInSidePanel, openSidePanelTab, inlineActivityTimelineEnabled]);
 
     const lastMessageIndexByTaskId = useMemo(() => {
         const map = new Map<string, number>();
@@ -509,6 +546,19 @@ export function ChatPage() {
             window.removeEventListener("focus", handleWindowFocus);
         };
     }, [isTaskMonitorConnected, isTaskMonitorConnecting, taskMonitorSseError, connectTaskMonitorStream]);
+
+    // Embedded surface empty states (connecting / unavailable / hero) share a centered
+    // layout with the chat input below — factored out so the two branches don't duplicate it.
+    const renderEmbeddedEmptyState = (hero: React.ReactNode) => (
+        <div className="flex min-h-0 flex-1 flex-col items-center justify-center px-4 pb-32">
+            <div className="flex flex-col items-center gap-6" style={HERO_MAX_WIDTH_STYLE}>
+                {hero}
+                <div className="mt-4 w-full" style={CHAT_STYLES}>
+                    <ChatInputArea agents={agents} scrollToBottom={chatMessageListRef.current?.scrollToBottom} />
+                </div>
+            </div>
+        </div>
+    );
 
     return (
         <PageLayout className="relative">
@@ -585,6 +635,24 @@ export function ChatPage() {
                                                 <p className="mt-4 text-sm text-(--secondary-text-wMain)">Loading session...</p>
                                             </Spinner>
                                         </div>
+                                    ) : noAgentSpecified ? (
+                                        // Embedded with no ?agent= — a misconfiguration. Fail loud rather than guess.
+                                        <EmptyState variant="error" title="No agent specified" subtitle="This chat needs an “agent” to be specified in its address." />
+                                    ) : isAwaitingPinnedAgent ? (
+                                        // Embedded: named agent not resolved yet. Show connecting, then a terminal
+                                        // "unavailable" error if it never registers.
+                                        pinnedAgentTimedOut ? (
+                                            <EmptyState variant="error" title="Agent unavailable" subtitle="This agent does not exist or is currently unavailable." />
+                                        ) : (
+                                            renderEmbeddedEmptyState(
+                                                <Spinner size="medium" variant="primary">
+                                                    <p className="mt-4 text-sm text-(--secondary-text-wMain)">Connecting…</p>
+                                                </Spinner>
+                                            )
+                                        )
+                                    ) : isEmbedded && messages.length === 0 ? (
+                                        // Embedded hero welcome — centered empty state for the pinned agent.
+                                        renderEmbeddedEmptyState(<EmbeddedChatWelcome message={heroMessage} />)
                                     ) : (
                                         <>
                                             <ChatMessageList className="text-base" ref={chatMessageListRef}>

--- a/client/webui/frontend/src/lib/components/pages/ChatPage.tsx
+++ b/client/webui/frontend/src/lib/components/pages/ChatPage.tsx
@@ -10,7 +10,20 @@ import { useChatContext, useChatSurface, useConfigContext, useIsAutoTitleGenerat
 import { SLIDE_OUT_DURATION_MS, FADE_OUT_DURATION_MS } from "@/lib/hooks/useTurnDividerAnimation";
 import { useProjectContext } from "@/lib/providers";
 import type { CollaborativeUser } from "@/lib/types/collaboration";
-import { ChatInputArea, ChatMessage, ChatSessionDialog, ChatSessionDeleteDialog, ChatSidePanel, EmbeddedChatWelcome, LoadingMessageRow, ProjectBadge, SessionSidePanel, UserPresenceAvatars, ShareNotificationMessage } from "@/lib/components/chat";
+import {
+    ChatInputArea,
+    ChatMessage,
+    ChatSessionDialog,
+    ChatSessionDeleteDialog,
+    ChatSidePanel,
+    EmbeddedChatWelcome,
+    LoadingMessageRow,
+    ProjectBadge,
+    RecentChatsSidePanel,
+    SessionSidePanel,
+    UserPresenceAvatars,
+    ShareNotificationMessage,
+} from "@/lib/components/chat";
 import { Button, ChatMessageList, CHAT_STYLES, ResizablePanelGroup, ResizablePanel, ResizableHandle, Spinner, Tooltip, TooltipContent, TooltipTrigger } from "@/lib/components/ui";
 import { PageLayout } from "@/lib/components/layout";
 import { EmptyState } from "@/lib/components/common/EmptyState";
@@ -344,6 +357,12 @@ export function ChatPage() {
         setIsSessionSidePanelCollapsed(!isSessionSidePanelCollapsed);
     }, [isSessionSidePanelCollapsed]);
 
+    // Embedded surface only: a left drawer of the pinned agent's recent chats, toggled
+    // from the header (left of New Chat). Starts closed; opening pushes content right.
+    const [isRecentChatsOpen, setIsRecentChatsOpen] = useState(false);
+    const handleRecentChatsToggle = useCallback(() => setIsRecentChatsOpen(open => !open), []);
+    const recentChatsDrawerOpen = surface.showRecentChatsPanel && isRecentChatsOpen;
+
     const breadcrumbs = undefined;
 
     // Determine the page title with pulse/fade effect
@@ -562,7 +581,7 @@ export function ChatPage() {
 
     return (
         <PageLayout className="relative">
-            {!useNewNav && (
+            {!useNewNav && !surface.showRecentChatsPanel && (
                 <div
                     inert={isSessionSidePanelCollapsed}
                     className={`absolute top-0 left-0 z-20 h-screen transition-[transform,visibility] duration-300 ${isSessionSidePanelCollapsed ? "invisible -translate-x-full delay-300" : "visible translate-x-0"}`}
@@ -570,7 +589,12 @@ export function ChatPage() {
                     <SessionSidePanel onToggle={handleSessionSidePanelToggle} />
                 </div>
             )}
-            <div className={`transition-all duration-300 ${!useNewNav && !isSessionSidePanelCollapsed ? "ml-100" : "ml-0"}`}>
+            {surface.showRecentChatsPanel && (
+                <div inert={!isRecentChatsOpen} className={`absolute top-0 left-0 z-20 h-screen transition-[transform,visibility] duration-300 ${isRecentChatsOpen ? "visible translate-x-0" : "invisible -translate-x-full delay-300"}`}>
+                    <RecentChatsSidePanel />
+                </div>
+            )}
+            <div className={`transition-all duration-300 ${(!useNewNav && !isSessionSidePanelCollapsed) || recentChatsDrawerOpen ? "ml-100" : "ml-0"}`}>
                 <Header
                     title={
                         <div className="flex items-center gap-3">
@@ -587,7 +611,17 @@ export function ChatPage() {
                     }
                     breadcrumbs={breadcrumbs}
                     leadingAction={
-                        useNewNav ? (
+                        surface.showRecentChatsPanel ? (
+                            // Embedded: a Recent Chats toggle to the LEFT of New Chat.
+                            <div className="flex items-center gap-2">
+                                <Button data-testid="showRecentChats" variant="ghost" onClick={handleRecentChatsToggle} className="h-10 w-10 p-0" tooltip="Toggle Chat Sessions">
+                                    <PanelLeftIcon className="size-5" />
+                                </Button>
+                                <div className="h-6 border-r"></div>
+
+                                <ChatSessionDialog />
+                            </div>
+                        ) : useNewNav ? (
                             <ChatSessionDialog />
                         ) : isSessionSidePanelCollapsed ? (
                             <div className="flex items-center gap-2">
@@ -624,7 +658,7 @@ export function ChatPage() {
                 />
             </div>
             <div className="flex min-h-0 flex-1">
-                <div className={`min-h-0 flex-1 overflow-x-auto transition-all duration-300 ${!useNewNav && !isSessionSidePanelCollapsed ? "ml-100" : "ml-0"}`}>
+                <div className={`min-h-0 flex-1 overflow-x-auto transition-all duration-300 ${(!useNewNav && !isSessionSidePanelCollapsed) || recentChatsDrawerOpen ? "ml-100" : "ml-0"}`}>
                     <ResizablePanelGroup direction="horizontal" autoSaveId="chat-side-panel" className="h-full">
                         <ResizablePanel defaultSize={chatPanelSizes.default} minSize={chatPanelSizes.min} maxSize={chatPanelSizes.max} id="chat-panel">
                             <div className="flex h-full w-full flex-col">
@@ -644,11 +678,7 @@ export function ChatPage() {
                                         pinnedAgentTimedOut ? (
                                             <EmptyState variant="error" title="Agent unavailable" subtitle="This agent does not exist or is currently unavailable." />
                                         ) : (
-                                            renderEmbeddedEmptyState(
-                                                <Spinner size="medium" variant="primary">
-                                                    <p className="mt-4 text-sm text-(--secondary-text-wMain)">Connecting…</p>
-                                                </Spinner>
-                                            )
+                                            renderEmbeddedEmptyState(<EmptyState variant="loading" title="Agent connecting..." />)
                                         )
                                     ) : isEmbedded && messages.length === 0 ? (
                                         // Embedded hero welcome — centered empty state for the pinned agent.

--- a/client/webui/frontend/src/lib/components/pages/RecentChatsPage.tsx
+++ b/client/webui/frontend/src/lib/components/pages/RecentChatsPage.tsx
@@ -1,15 +1,15 @@
 import React, { useEffect, useState, useRef, useMemo, useCallback } from "react";
 import { useInView } from "react-intersection-observer";
 import { useNavigate, Navigate, useSearchParams } from "react-router-dom";
-import { Loader2, Check, X, Plus, MessageCircle, CalendarDays, Share2 } from "lucide-react";
+import { Loader2, Check, X, Plus, MessageCircle, CalendarDays, Share2, PanelLeftIcon } from "lucide-react";
 import { useQueryClient } from "@tanstack/react-query";
 
 import { useInfiniteSessions, useMarkSessionViewed, useRenameSessionWithAI, sessionKeys } from "@/lib/api/sessions";
 import { useSharedWithMe } from "@/lib/api/share";
-import { useChatContext, useConfigContext, useIsAutoTitleGenerationEnabled, useIsNewNavigationEnabled, useTitleGeneration, useTitleAnimation, useIsChatSharingEnabled } from "@/lib/hooks";
+import { useChatContext, useChatRoute, useChatSurface, useConfigContext, useIsAutoTitleGenerationEnabled, useIsNewNavigationEnabled, useTitleGeneration, useTitleAnimation, useIsChatSharingEnabled } from "@/lib/hooks";
 import type { Session } from "@/lib/types";
 import { cn, formatRelativeTime, formatTimestamp, hasUnseenUpdates } from "@/lib/utils";
-import { ProjectBadge, SessionSearch, SessionActionMenu, ChatSessionDeleteDialog, sessionCardStyles, sessionTitleStyles } from "@/lib/components/chat";
+import { ProjectBadge, SessionSearch, SessionActionMenu, ChatSessionDeleteDialog, RecentChatsSidePanel, sessionCardStyles, sessionTitleStyles } from "@/lib/components/chat";
 import { ShareDialog } from "@/lib/components/share/ShareDialog";
 import { Header } from "@/lib/components/header";
 import { EmptyState } from "@/lib/components/common/EmptyState";
@@ -98,6 +98,13 @@ export const RecentChatsPage: React.FC = () => {
     const { generateTitle } = useTitleGeneration();
     const chatSharingEnabled = useIsChatSharingEnabled();
     const newNavigationEnabled = useIsNewNavigationEnabled();
+    // Embedded "View All": agent-scoped, trimmed chrome, and navigations stay on /embed/chat.
+    const surface = useChatSurface();
+    const isEmbedded = surface.variant === "embedded";
+    const chatRoute = useChatRoute();
+    // Same toggle-able Recent Chats drawer as the embedded chat page, for consistent chrome.
+    const [isRecentChatsOpen, setIsRecentChatsOpen] = useState(false);
+    const recentChatsDrawerOpen = isEmbedded && isRecentChatsOpen;
     const inputRef = useRef<HTMLInputElement>(null);
     const [isShareDialogOpen, setIsShareDialogOpen] = useState(false);
     const [sessionToShare, setSessionToShare] = useState<Session | null>(null);
@@ -141,7 +148,7 @@ export const RecentChatsPage: React.FC = () => {
 
     // Sessions fetched only for chat/scheduler tabs; shared tab uses its own query.
     const sessionSource = activeTab === "shared" ? "chat" : activeTab;
-    const { data, fetchNextPage, hasNextPage, isFetchingNextPage } = useInfiniteSessions(PAGE_SIZE, sessionSource, { enabled: activeTab !== "shared" });
+    const { data, fetchNextPage, hasNextPage, isFetchingNextPage } = useInfiniteSessions(PAGE_SIZE, sessionSource, { enabled: activeTab !== "shared", agentId: isEmbedded ? (surface.pinnedAgent ?? undefined) : undefined });
     const { data: sharedChats = [], isLoading: isLoadingShared } = useSharedWithMe({ enabled: activeTab === "shared" });
     const sessions = useMemo(() => data?.pages.flatMap(page => page.data) ?? [], [data]);
 
@@ -183,7 +190,7 @@ export const RecentChatsPage: React.FC = () => {
     const handleSessionClick = async (session: Session) => {
         if (editingSessionId !== session.id) {
             await handleSwitchSession(session.id);
-            navigate("/chat");
+            navigate(chatRoute);
             // Mark after switch so SSE replay / save_task bumps to updated_time
             // settle first — otherwise last_viewed_at races behind updated_time.
             markViewedMutation.mutate(session.id);
@@ -280,7 +287,7 @@ export const RecentChatsPage: React.FC = () => {
 
     const handleSessionSelect = async (sessionId: string) => {
         await handleSwitchSession(sessionId);
-        navigate("/chat");
+        navigate(chatRoute);
     };
 
     // Get unique project names from sessions, sorted alphabetically
@@ -323,30 +330,45 @@ export const RecentChatsPage: React.FC = () => {
         return sessionWithProject?.projectId || null;
     }, [selectedProject, sessions]);
 
-    // Feature flag gate: redirect to /chat if new_navigation is not enabled
-    if (!newNavigationEnabled) {
+    // Feature flag gate: redirect to /chat if new_navigation is not enabled.
+    // The embedded "View All" surface is reachable regardless of the flag.
+    if (!newNavigationEnabled && !isEmbedded) {
         return <Navigate to="/chat" replace />;
     }
 
     return (
-        <PageLayout>
-            <Header
-                title="Recent Chats"
-                buttons={[
-                    <Button
-                        key="new-chat"
-                        onClick={() => {
-                            navigate("/chat");
-                            handleNewSession();
-                        }}
-                    >
-                        <Plus size={16} className="mr-1" />
-                        New Chat
-                    </Button>,
-                ]}
-            />
+        <PageLayout className={isEmbedded ? "relative" : undefined}>
+            {isEmbedded && (
+                <div inert={!isRecentChatsOpen} className={cn("absolute top-0 left-0 z-20 h-screen transition-[transform,visibility] duration-300", isRecentChatsOpen ? "visible translate-x-0" : "invisible -translate-x-full delay-300")}>
+                    <RecentChatsSidePanel />
+                </div>
+            )}
+            <div className={isEmbedded ? cn("transition-all duration-300", recentChatsDrawerOpen ? "ml-100" : "ml-0") : "contents"}>
+                <Header
+                    title="Recent Chats"
+                    leadingAction={
+                        isEmbedded ? (
+                            <Button data-testid="showRecentChats" variant="ghost" onClick={() => setIsRecentChatsOpen(open => !open)} className="h-10 w-10 p-0" tooltip="Recent Chats">
+                                <PanelLeftIcon className="size-5" />
+                            </Button>
+                        ) : undefined
+                    }
+                    buttons={[
+                        <Button
+                            key="new-chat"
+                            onClick={() => {
+                                navigate(chatRoute);
+                                handleNewSession();
+                            }}
+                        >
+                            <Plus size={16} className="mr-1" />
+                            New Chat
+                        </Button>,
+                    ]}
+                />
+            </div>
 
-            <div className="flex flex-1 flex-col overflow-y-auto px-8 py-6">
+            <div className={cn("flex flex-1 flex-col overflow-y-auto px-8 py-6", recentChatsDrawerOpen && "ml-100 transition-all duration-300")}>
                 {/* Constrain list-item width and center the column to match the
                     pattern used by the Go repo's RecentChatsPage. Outer keeps
                     the scroll container full-width; inner is max-w-4xl. */}
@@ -354,7 +376,7 @@ export const RecentChatsPage: React.FC = () => {
                     {/* Tabs and Search/Filter Bar */}
                     <div className="flex flex-col gap-4">
                         {/* Tabs: Chats / Scheduled Tasks / Shared with Me */}
-                        {(configFeatureEnablement?.scheduler || chatSharingEnabled) && (
+                        {!isEmbedded && (configFeatureEnablement?.scheduler || chatSharingEnabled) && (
                             <div className="flex justify-center">
                                 <Tabs value={activeTab} onValueChange={handleTabChange}>
                                     <TabsList className="bg-transparent p-0">
@@ -383,10 +405,10 @@ export const RecentChatsPage: React.FC = () => {
                         {activeTab !== "shared" && sessions.length > 0 && (
                             <div className="flex items-center gap-4">
                                 <div className="flex-1">
-                                    <SessionSearch onSessionSelect={handleSessionSelect} projectId={selectedProjectId} />
+                                    <SessionSearch onSessionSelect={handleSessionSelect} projectId={selectedProjectId} agentId={isEmbedded ? surface.pinnedAgent : undefined} />
                                 </div>
 
-                                {persistenceEnabled && activeTab === "chat" && projectNames.length > 0 && (
+                                {!isEmbedded && persistenceEnabled && activeTab === "chat" && projectNames.length > 0 && (
                                     <div className="flex items-center gap-2">
                                         <label className="text-sm font-medium">Project:</label>
                                         <Select value={selectedProject} onValueChange={setSelectedProject}>
@@ -568,7 +590,7 @@ export const RecentChatsPage: React.FC = () => {
                                               text: "New Chat",
                                               variant: "default" as const,
                                               onClick: () => {
-                                                  navigate("/chat");
+                                                  navigate(chatRoute);
                                                   handleNewSession();
                                               },
                                           },

--- a/client/webui/frontend/src/lib/components/ui/chat/chatStyles.ts
+++ b/client/webui/frontend/src/lib/components/ui/chat/chatStyles.ts
@@ -1,7 +1,7 @@
 export const CHAT_STYLES = {
     padding: "0 16px",
     maxWidth: "1280px",
-    minWidth: "400px",
+    minWidth: "600px",
     margin: "0 auto",
     width: "100%",
 };

--- a/client/webui/frontend/src/lib/contexts/ChatSurfaceContext.ts
+++ b/client/webui/frontend/src/lib/contexts/ChatSurfaceContext.ts
@@ -1,0 +1,73 @@
+import { createContext } from "react";
+
+/**
+ * A session-menu action key. The set a surface allows is rendered in a fixed
+ * canonical order by SessionActionMenu — adding an action to the menu means
+ * adding it to the relevant surface's `sessionActions`, not editing a branch.
+ */
+export type SessionAction = "goToProject" | "rename" | "renameWithAI" | "move" | "share" | "delete";
+
+/**
+ * A navigation-sidebar section.
+ * - `newChat` — the New Chat button (new nav only)
+ * - `appNav` — the app-level nav items (Chat/Projects/Artifacts/Agents/…); the legacy
+ *   icon rail is entirely app-nav, so it renders only when this section is allowed
+ * - `recentChats` — the Recent Chats list (new nav only)
+ */
+export type NavSection = "newChat" | "appNav" | "recentChats";
+
+/**
+ * The single source of truth for which chrome the chat UI exposes.
+ *
+ * Components read *intent* (e.g. `showActivityPanel`) rather than the activation
+ * mechanism, so suppression decisions live here in one struct instead of being
+ * threaded as scattered `if (embedded)` checks. The activation mechanism (today the
+ * `/embed/chat` route) can change without touching consumers.
+ *
+ * Derived once at load from the hash route (`/#/embed/chat?agent=Foo`), never
+ * persisted, and deliberately NOT part of server config — so an admin on the same
+ * origin can't inherit a sticky embedded surface.
+ */
+export interface ChatSurface {
+    /** "full" = the standard web UI; "embedded" = chat-only, single-agent. */
+    variant: "full" | "embedded";
+    /**
+     * Which navigation sections the sidebar exposes. The new nav renders each allowed
+     * section (header always kept); the legacy icon rail is pure app-nav, so it renders
+     * only when `appNav` is allowed and nothing otherwise. `[]` means no sidebar at all.
+     * Embedded uses `["recentChats"]` — chat navigation only, no New Chat or app nav.
+     */
+    navigation: ReadonlyArray<NavSection>;
+    /** Render the agent selector dropdown in the chat input. */
+    showAgentSelector: boolean;
+    /** Render the Activity tab/icon and the per-message "View activity" button. */
+    showActivityPanel: boolean;
+    /** Allow the "/" prompt-library popover. */
+    allowPrompts: boolean;
+    /** Allow the "@" mention popover (collaboration, not agent routing). */
+    allowMentions: boolean;
+    /**
+     * Wire name of the agent this surface is pinned to, captured once at load.
+     * Stable across in-app navigation that strips the hash query. null in "full".
+     */
+    pinnedAgent: string | null;
+    /** Seed the left-aligned welcome bubble. false in "embedded" — the centered hero owns the empty state. */
+    seedWelcomeBubble: boolean;
+    /** Which session-action-menu items this surface exposes. */
+    sessionActions: ReadonlyArray<SessionAction>;
+}
+
+/** The standard, unconstrained web UI. Also the context default: absence of a provider means full capabilities. */
+export const FULL_CHAT_SURFACE: ChatSurface = {
+    variant: "full",
+    navigation: ["newChat", "appNav", "recentChats"],
+    showAgentSelector: true,
+    showActivityPanel: true,
+    allowPrompts: true,
+    allowMentions: true,
+    pinnedAgent: null,
+    seedWelcomeBubble: true,
+    sessionActions: ["goToProject", "rename", "renameWithAI", "move", "share", "delete"],
+};
+
+export const ChatSurfaceContext = createContext<ChatSurface>(FULL_CHAT_SURFACE);

--- a/client/webui/frontend/src/lib/contexts/ChatSurfaceContext.ts
+++ b/client/webui/frontend/src/lib/contexts/ChatSurfaceContext.ts
@@ -8,21 +8,12 @@ import { createContext } from "react";
 export type SessionAction = "goToProject" | "rename" | "renameWithAI" | "move" | "share" | "delete";
 
 /**
- * A navigation-sidebar section.
- * - `newChat` — the New Chat button (new nav only)
- * - `appNav` — the app-level nav items (Chat/Projects/Artifacts/Agents/…); the legacy
- *   icon rail is entirely app-nav, so it renders only when this section is allowed
- * - `recentChats` — the Recent Chats list (new nav only)
- */
-export type NavSection = "newChat" | "appNav" | "recentChats";
-
-/**
  * The single source of truth for which chrome the chat UI exposes.
  *
  * Components read *intent* (e.g. `showActivityPanel`) rather than the activation
  * mechanism, so suppression decisions live here in one struct instead of being
  * threaded as scattered `if (embedded)` checks. The activation mechanism (today the
- * `/embed/chat` route) can change without touching consumers.
+ * `/embed/*` routes) can change without touching consumers.
  *
  * Derived once at load from the hash route (`/#/embed/chat?agent=Foo`), never
  * persisted, and deliberately NOT part of server config — so an admin on the same
@@ -31,13 +22,13 @@ export type NavSection = "newChat" | "appNav" | "recentChats";
 export interface ChatSurface {
     /** "full" = the standard web UI; "embedded" = chat-only, single-agent. */
     variant: "full" | "embedded";
+    /** Render the navigation sidebar (both the legacy and new-navigation variants). */
+    showNav: boolean;
     /**
-     * Which navigation sections the sidebar exposes. The new nav renders each allowed
-     * section (header always kept); the legacy icon rail is pure app-nav, so it renders
-     * only when `appNav` is allowed and nothing otherwise. `[]` means no sidebar at all.
-     * Embedded uses `["recentChats"]` — chat navigation only, no New Chat or app nav.
+     * Show the embedded Recent Chats affordance: a header toggle (left of New Chat) that
+     * opens a left drawer of the pinned agent's recent chats. Embedded only.
      */
-    navigation: ReadonlyArray<NavSection>;
+    showRecentChatsPanel: boolean;
     /** Render the agent selector dropdown in the chat input. */
     showAgentSelector: boolean;
     /** Render the Activity tab/icon and the per-message "View activity" button. */
@@ -60,7 +51,8 @@ export interface ChatSurface {
 /** The standard, unconstrained web UI. Also the context default: absence of a provider means full capabilities. */
 export const FULL_CHAT_SURFACE: ChatSurface = {
     variant: "full",
-    navigation: ["newChat", "appNav", "recentChats"],
+    showNav: true,
+    showRecentChatsPanel: false,
     showAgentSelector: true,
     showActivityPanel: true,
     allowPrompts: true,

--- a/client/webui/frontend/src/lib/contexts/index.ts
+++ b/client/webui/frontend/src/lib/contexts/index.ts
@@ -1,5 +1,6 @@
 export * from "./AuthContext";
 export * from "./ChatContext";
+export * from "./ChatSurfaceContext";
 export * from "./ConfigContext";
 export * from "./CsrfContext";
 export * from "./SSEContext";

--- a/client/webui/frontend/src/lib/hooks/index.ts
+++ b/client/webui/frontend/src/lib/hooks/index.ts
@@ -40,6 +40,7 @@ export * from "./useIsProjectSharingEnabled";
 export * from "./useIsProjectIndexingEnabled";
 export * from "./useIsMentionsEnabled";
 export * from "./useIsNewNavigationEnabled";
+export * from "./useChatSurface";
 export * from "./useSSEContext";
 export * from "./useIndexingSSE";
 export * from "./useNavigationItems";

--- a/client/webui/frontend/src/lib/hooks/index.ts
+++ b/client/webui/frontend/src/lib/hooks/index.ts
@@ -41,6 +41,7 @@ export * from "./useIsProjectIndexingEnabled";
 export * from "./useIsMentionsEnabled";
 export * from "./useIsNewNavigationEnabled";
 export * from "./useChatSurface";
+export * from "./useChatRoute";
 export * from "./useSSEContext";
 export * from "./useIndexingSSE";
 export * from "./useNavigationItems";

--- a/client/webui/frontend/src/lib/hooks/useChatRoute.ts
+++ b/client/webui/frontend/src/lib/hooks/useChatRoute.ts
@@ -1,0 +1,12 @@
+import { useChatSurface } from "./useChatSurface";
+
+/**
+ * The route to navigate to when opening a chat. In the embedded surface this stays on
+ * `/embed/chat?agent=<pinned>` so the URL keeps the embedded route + pinned agent (survives
+ * a refresh and back/forward); in the full UI it's the normal `/chat`.
+ */
+export function useChatRoute(): string {
+    const surface = useChatSurface();
+    if (surface.variant !== "embedded") return "/chat";
+    return surface.pinnedAgent ? `/embed/chat?agent=${encodeURIComponent(surface.pinnedAgent)}` : "/embed/chat";
+}

--- a/client/webui/frontend/src/lib/hooks/useChatSurface.ts
+++ b/client/webui/frontend/src/lib/hooks/useChatSurface.ts
@@ -1,0 +1,12 @@
+import { useContext } from "react";
+
+import { ChatSurfaceContext, type ChatSurface } from "@/lib/contexts";
+
+/**
+ * The chat surface capabilities. Defaults to the full web UI when no
+ * ChatSurfaceProvider is present (the context default), so consumers never need
+ * a provider to behave as the standard UI.
+ */
+export function useChatSurface(): ChatSurface {
+    return useContext(ChatSurfaceContext);
+}

--- a/client/webui/frontend/src/lib/providers/AuthProvider.tsx
+++ b/client/webui/frontend/src/lib/providers/AuthProvider.tsx
@@ -4,6 +4,7 @@ import { useQueryClient } from "@tanstack/react-query";
 import { api, scheduleProactiveRefresh, cancelProactiveRefresh } from "@/lib/api";
 import { AuthContext } from "@/lib/contexts/AuthContext";
 import { useConfigContext, useCsrfContext } from "@/lib/hooks";
+import { stashPostLoginRedirect } from "@/lib/utils/url";
 import { EmptyState } from "../components";
 
 interface AuthProviderProps {
@@ -81,6 +82,7 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
     }, [configUseAuthorization, configAuthLoginUrl, fetchCsrfToken]);
 
     const login = () => {
+        stashPostLoginRedirect();
         window.location.href = configAuthLoginUrl;
     };
 

--- a/client/webui/frontend/src/lib/providers/ChatProvider.tsx
+++ b/client/webui/frontend/src/lib/providers/ChatProvider.tsx
@@ -5,12 +5,12 @@ import { useBooleanFlagDetails } from "@openfeature/react-sdk";
 import { api } from "@/lib/api";
 import type { AttachedArtifactRef } from "@/lib/types";
 import { ChatContext, type ChatContextValue, type PendingPromptData } from "@/lib/contexts";
-import { useConfigContext, useArtifacts, useAgentCards, useTaskContext, useErrorDialog, useBackgroundTaskMonitor, useArtifactPreview, useArtifactOperations, useCollaborativeSession } from "@/lib/hooks";
+import { useConfigContext, useChatSurface, useArtifacts, useAgentCards, useTaskContext, useErrorDialog, useBackgroundTaskMonitor, useArtifactPreview, useArtifactOperations, useCollaborativeSession } from "@/lib/hooks";
 import { useAutoGenerateTitle } from "@/lib/hooks/useAutoGenerateTitle";
 import { useProjectContext, registerProjectDeletedCallback } from "@/lib/providers";
 import { processChatEvent, serializeChatMessage, deserializeChatMessages } from "@/lib/providers/chat";
 import type { ChatEffect } from "@/lib/providers/chat";
-import { getErrorMessage, fileToBase64, migrateTask, CURRENT_SCHEMA_VERSION, getApiBearerToken, internalToDisplayText, extractRagDataFromTasks, uuid } from "@/lib/utils";
+import { getErrorMessage, fileToBase64, migrateTask, CURRENT_SCHEMA_VERSION, getApiBearerToken, internalToDisplayText, extractRagDataFromTasks, uuid, selectInitialAgent } from "@/lib/utils";
 import { ConfirmationDialog } from "@/lib/components/common/ConfirmationDialog";
 
 import type {
@@ -26,7 +26,6 @@ import type {
     Task,
     TextPart,
     ArtifactPart,
-    AgentCardInfo,
     Project,
     StoredTaskData,
     RAGSearchResult,
@@ -42,6 +41,7 @@ interface ChatProviderProps {
 export const ChatProvider: React.FC<ChatProviderProps> = ({ children }) => {
     // ============ Hooks ============
     const { configWelcomeMessage, persistenceEnabled, configCollectFeedback, backgroundTasksEnabled, backgroundTasksDefaultTimeoutMs, configUseAuthorization } = useConfigContext();
+    const surface = useChatSurface();
     const { value: inlineActivityTimelineEnabled } = useBooleanFlagDetails("inline_activity_timeline", false);
     const { value: showThinkingContentEnabled } = useBooleanFlagDetails("show_thinking_content", false);
     const { activeProject, setActiveProject, projects } = useProjectContext();
@@ -369,9 +369,14 @@ export const ChatProvider: React.FC<ChatProviderProps> = ({ children }) => {
                 setRagData(allRagData);
             }
 
-            // Set the agent name if found
+            // Set the agent name if found. In the embedded surface, prefer the pinned
+            // agent (captured once at load, stable across navigation that strips the
+            // hash query) over the loaded session's stored agent, so a cross-agent
+            // session can't silently re-route the next message — the selector is hidden,
+            // so a user couldn't detect it.
             if (agentName) {
-                setSelectedAgentName(agentName);
+                const pinnedAgent = surface.variant === "embedded" ? surface.pinnedAgent : null;
+                setSelectedAgentName(pinnedAgent ?? agentName);
             }
 
             // Set taskIdInSidePanel to the most recent task for workflow visualization
@@ -547,7 +552,7 @@ export const ChatProvider: React.FC<ChatProviderProps> = ({ children }) => {
             // Collaborative session detection happens in switchSession via useCollaborativeSession hook.
             // Sender info in messages is kept for UI display purposes only.
         },
-        [backgroundTasksEnabled, setRagData, setMessages, saveTaskToBackend]
+        [backgroundTasksEnabled, setRagData, setMessages, saveTaskToBackend, surface.variant, surface.pinnedAgent]
     );
 
     // Background task monitoring
@@ -1783,45 +1788,31 @@ export const ChatProvider: React.FC<ChatProviderProps> = ({ children }) => {
     useEffect(() => {
         // Don't show welcome message if we're loading a session
         if (!selectedAgentName && agents.length > 0 && messages.length === 0 && !isLoadingSession) {
-            // Priority order for agent selection:
-            // 1. URL parameter agent (?agent=AgentName)
-            // 2. Project's default agent (if in project context)
-            // 3. OrchestratorAgent (fallback)
-            // 4. First available agent
-            let selectedAgent = agents[0];
+            // Embedded surface pins to the captured ?agent= (stable across navigation);
+            // full UI keeps reading ?agent= from the (pre-hash) query string as before.
+            const urlAgentName = surface.variant === "embedded" ? surface.pinnedAgent : new URLSearchParams(window.location.search).get("agent");
+            const { agent: selectedAgent, shouldSeedWelcome } = selectInitialAgent({
+                agents,
+                urlAgentName,
+                embedded: surface.variant === "embedded",
+                projectDefaultAgentId: activeProject?.defaultAgentId,
+            });
 
-            // Check URL parameter first
-            const urlParams = new URLSearchParams(window.location.search);
-            const urlAgentName = urlParams.get("agent");
-            let urlAgent: AgentCardInfo | undefined;
-
-            if (urlAgentName) {
-                urlAgent = agents.find(agent => agent.name === urlAgentName);
-                if (urlAgent) {
-                    selectedAgent = urlAgent;
-                    console.log(`Using URL parameter agent: ${selectedAgent.name}`);
-                } else {
-                    console.warn(`URL parameter agent "${urlAgentName}" not found in available agents, falling back to priority order`);
-                }
-            }
-
-            // If no URL agent found, follow existing priority order
-            if (!urlAgent) {
-                if (activeProject?.defaultAgentId) {
-                    const projectDefaultAgent = agents.find(agent => agent.name === activeProject.defaultAgentId);
-                    if (projectDefaultAgent) {
-                        selectedAgent = projectDefaultAgent;
-                        console.log(`Using project default agent: ${selectedAgent.name}`);
-                    } else {
-                        console.warn(`Project default agent "${activeProject.defaultAgentId}" not found, falling back to OrchestratorAgent`);
-                        selectedAgent = agents.find(agent => agent.name === "OrchestratorAgent") ?? agents[0];
-                    }
-                } else {
-                    selectedAgent = agents.find(agent => agent.name === "OrchestratorAgent") ?? agents[0];
-                }
+            // Embedded pinned agent not yet discovered: bail and leave selectedAgentName=""
+            // so the input shows a connecting state. The effect re-fires as agents register
+            // (dep array) and resolves the instant the pinned agent appears.
+            if (!selectedAgent) {
+                return;
             }
 
             setSelectedAgentName(selectedAgent.name);
+
+            // Embedded surface: skip the seeded welcome bubble so messages.length === 0
+            // holds and the centered hero owns the empty state. Full UI keeps its
+            // left-aligned seeded bubble.
+            if (!shouldSeedWelcome) {
+                return;
+            }
 
             const displayedText = configWelcomeMessage || `Hi! I'm the ${selectedAgent?.displayName}. How can I help?`;
             setMessages([
@@ -1837,7 +1828,7 @@ export const ChatProvider: React.FC<ChatProviderProps> = ({ children }) => {
                 },
             ]);
         }
-    }, [agents, configWelcomeMessage, messages.length, selectedAgentName, sessionId, isLoadingSession, activeProject, setMessages]);
+    }, [agents, configWelcomeMessage, messages.length, selectedAgentName, sessionId, isLoadingSession, activeProject, setMessages, surface.variant, surface.pinnedAgent]);
 
     // Store the latest handlers in refs so they can be accessed without triggering effect re-runs
     // Note: handleSseMessageRef is declared earlier (line ~103) for use in loadSessionTasks

--- a/client/webui/frontend/src/lib/providers/ChatProvider.tsx
+++ b/client/webui/frontend/src/lib/providers/ChatProvider.tsx
@@ -10,7 +10,7 @@ import { useAutoGenerateTitle } from "@/lib/hooks/useAutoGenerateTitle";
 import { useProjectContext, registerProjectDeletedCallback } from "@/lib/providers";
 import { processChatEvent, serializeChatMessage, deserializeChatMessages } from "@/lib/providers/chat";
 import type { ChatEffect } from "@/lib/providers/chat";
-import { getErrorMessage, fileToBase64, migrateTask, CURRENT_SCHEMA_VERSION, getApiBearerToken, internalToDisplayText, extractRagDataFromTasks, uuid, selectInitialAgent } from "@/lib/utils";
+import { getErrorMessage, fileToBase64, migrateTask, CURRENT_SCHEMA_VERSION, getApiBearerToken, internalToDisplayText, extractRagDataFromTasks, uuid, selectInitialAgent, resolveSessionLoadAgent } from "@/lib/utils";
 import { ConfirmationDialog } from "@/lib/components/common/ConfirmationDialog";
 
 import type {
@@ -375,8 +375,7 @@ export const ChatProvider: React.FC<ChatProviderProps> = ({ children }) => {
             // session can't silently re-route the next message — the selector is hidden,
             // so a user couldn't detect it.
             if (agentName) {
-                const pinnedAgent = surface.variant === "embedded" ? surface.pinnedAgent : null;
-                setSelectedAgentName(pinnedAgent ?? agentName);
+                setSelectedAgentName(resolveSessionLoadAgent({ embedded: surface.variant === "embedded", pinnedAgent: surface.pinnedAgent, storedAgent: agentName }));
             }
 
             // Set taskIdInSidePanel to the most recent task for workflow visualization

--- a/client/webui/frontend/src/lib/providers/ChatSurfaceProvider.tsx
+++ b/client/webui/frontend/src/lib/providers/ChatSurfaceProvider.tsx
@@ -5,16 +5,17 @@ import { getHashPath, getHashQueryParams } from "@/lib/utils/url";
 
 const EMBEDDED_SESSION_ACTIONS: ReadonlyArray<SessionAction> = ["rename", "renameWithAI", "delete"];
 
-/** The hash-route path that renders the embedded, single-agent surface. */
-export const EMBEDDED_ROUTE_PATH = "/embed/chat";
+/** Hash-route prefix for embedded surfaces (`/embed/chat`, `/embed/recent-chats`, …). */
+export const EMBEDDED_ROUTE_PREFIX = "/embed/";
 
 /**
  * Compute the chat surface once at load from the hash-route path. Read-once (no
  * full-UI flash, no later recompute), so the pinned agent is stable even if
- * in-app navigation later strips the hash query.
+ * in-app navigation later strips the hash query. Any `/embed/*` route is embedded,
+ * so View All (`/embed/recent-chats`) stays embedded on direct load / refresh.
  */
 function computeChatSurface(): ChatSurface {
-    const embedded = getHashPath() === EMBEDDED_ROUTE_PATH;
+    const embedded = getHashPath().startsWith(EMBEDDED_ROUTE_PREFIX);
 
     if (!embedded) {
         return FULL_CHAT_SURFACE;
@@ -22,7 +23,8 @@ function computeChatSurface(): ChatSurface {
 
     return {
         variant: "embedded",
-        navigation: ["recentChats"],
+        showNav: false,
+        showRecentChatsPanel: true,
         showAgentSelector: false,
         showActivityPanel: false,
         allowPrompts: false,

--- a/client/webui/frontend/src/lib/providers/ChatSurfaceProvider.tsx
+++ b/client/webui/frontend/src/lib/providers/ChatSurfaceProvider.tsx
@@ -1,0 +1,46 @@
+import React, { useState, type ReactNode } from "react";
+
+import { ChatSurfaceContext, FULL_CHAT_SURFACE, type ChatSurface, type SessionAction } from "@/lib/contexts/ChatSurfaceContext";
+import { getHashPath, getHashQueryParams } from "@/lib/utils/url";
+
+const EMBEDDED_SESSION_ACTIONS: ReadonlyArray<SessionAction> = ["rename", "renameWithAI", "delete"];
+
+/** The hash-route path that renders the embedded, single-agent surface. */
+export const EMBEDDED_ROUTE_PATH = "/embed/chat";
+
+/**
+ * Compute the chat surface once at load from the hash-route path. Read-once (no
+ * full-UI flash, no later recompute), so the pinned agent is stable even if
+ * in-app navigation later strips the hash query.
+ */
+function computeChatSurface(): ChatSurface {
+    const embedded = getHashPath() === EMBEDDED_ROUTE_PATH;
+
+    if (!embedded) {
+        return FULL_CHAT_SURFACE;
+    }
+
+    return {
+        variant: "embedded",
+        navigation: ["recentChats"],
+        showAgentSelector: false,
+        showActivityPanel: false,
+        allowPrompts: false,
+        // Mentions are collaboration, not agent routing, so they stay on: the
+        // embedded surface is a UI-only default entry point, not an isolation boundary.
+        allowMentions: true,
+        pinnedAgent: getHashQueryParams().get("agent"),
+        seedWelcomeBubble: false,
+        sessionActions: EMBEDDED_SESSION_ACTIONS,
+    };
+}
+
+interface ChatSurfaceProviderProps {
+    children: ReactNode;
+}
+
+export const ChatSurfaceProvider: React.FC<ChatSurfaceProviderProps> = ({ children }) => {
+    // useState initializer runs exactly once — the surface is fixed for the session.
+    const [surface] = useState<ChatSurface>(computeChatSurface);
+    return <ChatSurfaceContext.Provider value={surface}>{children}</ChatSurfaceContext.Provider>;
+};

--- a/client/webui/frontend/src/lib/providers/index.ts
+++ b/client/webui/frontend/src/lib/providers/index.ts
@@ -1,4 +1,5 @@
 export * from "./AudioSettingsProvider";
+export * from "./ChatSurfaceProvider";
 export * from "./ConfigProvider";
 export * from "./FeatureFlagProvider";
 export * from "./TaskProvider";

--- a/client/webui/frontend/src/lib/types/fe.ts
+++ b/client/webui/frontend/src/lib/types/fe.ts
@@ -352,6 +352,8 @@ export interface Session {
     createdTime: string;
     updatedTime: string;
     name: string | null;
+    /** Wire name of the agent this session belongs to (server `agentId`). Used to scope the embedded recent-chats list. */
+    agentId?: string | null;
     projectId?: string | null;
     projectName?: string | null;
     source?: string | null; // "chat" or "scheduler"

--- a/client/webui/frontend/src/lib/utils/agentUtils.ts
+++ b/client/webui/frontend/src/lib/utils/agentUtils.ts
@@ -35,6 +35,46 @@ export interface WorkflowNodeConfig {
     delay?: string;
 }
 
+export interface InitialAgentSelection {
+    /** The agent to select, or null to bail (embedded pinned agent not yet available). */
+    agent: AgentCardInfo | null;
+    /** Whether the caller should seed the welcome bubble. Always false on the embedded surface. */
+    shouldSeedWelcome: boolean;
+}
+
+/**
+ * Decide which agent to pin when a chat opens with no agent yet selected.
+ *
+ * Embedded surface: requires an explicit, resolvable ?agent=. It pins to that
+ * agent or bails (agent === null) — when none is named, or the named one hasn't
+ * registered yet. It never falls back to a default, which would be
+ * nondeterministic across deployments and invisible (the selector is hidden).
+ * The welcome bubble is never seeded.
+ *
+ * Full UI priority: URL ?agent=, then project default, then OrchestratorAgent,
+ * then first available.
+ *
+ * Callers must guarantee `agents` is non-empty.
+ */
+export function selectInitialAgent({ agents, urlAgentName, embedded, projectDefaultAgentId }: { agents: AgentCardInfo[]; urlAgentName: string | null; embedded: boolean; projectDefaultAgentId?: string | null }): InitialAgentSelection {
+    const urlAgent = urlAgentName ? agents.find(agent => agent.name === urlAgentName) : undefined;
+
+    if (embedded) {
+        return { agent: urlAgent ?? null, shouldSeedWelcome: false };
+    }
+
+    let selectedAgent = urlAgent ?? agents[0];
+    if (!urlAgent) {
+        if (projectDefaultAgentId) {
+            selectedAgent = agents.find(agent => agent.name === projectDefaultAgentId) ?? agents.find(agent => agent.name === "OrchestratorAgent") ?? agents[0];
+        } else {
+            selectedAgent = agents.find(agent => agent.name === "OrchestratorAgent") ?? agents[0];
+        }
+    }
+
+    return { agent: selectedAgent, shouldSeedWelcome: true };
+}
+
 /**
  * Extract agent type from agent card extensions
  */

--- a/client/webui/frontend/src/lib/utils/agentUtils.ts
+++ b/client/webui/frontend/src/lib/utils/agentUtils.ts
@@ -43,6 +43,17 @@ export interface InitialAgentSelection {
 }
 
 /**
+ * On session load, decide which agent the chat is pinned to. In the embedded surface the
+ * pinned `?agent=` wins over the loaded session's stored agent, so opening a cross-agent
+ * session can't silently re-route the next message (the selector is hidden, so the user
+ * couldn't detect it). Falls back to the session's stored agent in the full UI, or when no
+ * agent is pinned.
+ */
+export function resolveSessionLoadAgent({ embedded, pinnedAgent, storedAgent }: { embedded: boolean; pinnedAgent: string | null; storedAgent: string }): string {
+    return (embedded ? pinnedAgent : null) ?? storedAgent;
+}
+
+/**
  * Decide which agent to pin when a chat opens with no agent yet selected.
  *
  * Embedded surface: requires an explicit, resolvable ?agent=. It pins to that

--- a/client/webui/frontend/src/lib/utils/url.test.ts
+++ b/client/webui/frontend/src/lib/utils/url.test.ts
@@ -1,0 +1,92 @@
+import { describe, it, expect, afterEach } from "vitest";
+import { getHashQueryParams, getHashPath, stashPostLoginRedirect, consumePostLoginRedirect } from "./url";
+
+const POST_LOGIN_REDIRECT_KEY = "sam_post_login_redirect";
+
+describe("getHashQueryParams", () => {
+    afterEach(() => {
+        // Reset both search and hash so cases don't bleed into each other.
+        window.history.replaceState({}, "", "/");
+    });
+
+    it("parses the query segment that follows the hash route", () => {
+        window.history.replaceState({}, "", "/#/embed/chat?agent=Foo");
+        const params = getHashQueryParams();
+        expect(params.get("agent")).toBe("Foo");
+    });
+
+    it("returns no params when the hash route carries no query", () => {
+        window.history.replaceState({}, "", "/#/embed/chat");
+        const params = getHashQueryParams();
+        expect(params.get("agent")).toBeNull();
+    });
+
+    it("ignores a real query string before the hash (reads hash, not search)", () => {
+        // Params in window.location.search (the rejected before-# form) must not be read —
+        // the embedded surface's ?agent= travels with the hash route.
+        window.history.replaceState({}, "", "/?agent=Foo#/embed/chat");
+        expect(window.location.search).toBe("?agent=Foo"); // precondition
+        expect(getHashQueryParams().get("agent")).toBeNull();
+    });
+});
+
+describe("getHashPath", () => {
+    afterEach(() => {
+        window.history.replaceState({}, "", "/");
+    });
+
+    it("returns the route path without the leading # or query segment", () => {
+        window.history.replaceState({}, "", "/#/embed/chat?agent=Foo");
+        expect(getHashPath()).toBe("/embed/chat");
+    });
+
+    it("returns the path when there is no query", () => {
+        window.history.replaceState({}, "", "/#/chat");
+        expect(getHashPath()).toBe("/chat");
+    });
+
+    it("returns empty string when there is no hash", () => {
+        window.history.replaceState({}, "", "/");
+        expect(getHashPath()).toBe("");
+    });
+});
+
+describe("post-login redirect stash/restore", () => {
+    afterEach(() => {
+        localStorage.removeItem(POST_LOGIN_REDIRECT_KEY);
+        window.history.replaceState({}, "", "/");
+    });
+
+    it("stashes the current URL and restores it once", () => {
+        window.history.replaceState({}, "", "/#/embed/chat?agent=Foo");
+        stashPostLoginRedirect();
+        expect(localStorage.getItem(POST_LOGIN_REDIRECT_KEY)).toContain("/embed/chat");
+
+        const restored = consumePostLoginRedirect();
+        expect(restored).toContain("/#/embed/chat?agent=Foo");
+    });
+
+    it("is one-shot — the key is cleared after the first read", () => {
+        window.history.replaceState({}, "", "/#/embed/chat?agent=Foo");
+        stashPostLoginRedirect();
+
+        consumePostLoginRedirect();
+        expect(localStorage.getItem(POST_LOGIN_REDIRECT_KEY)).toBeNull();
+        // A second consume has nothing to restore and falls back to "/".
+        expect(consumePostLoginRedirect()).toBe("/");
+    });
+
+    it("falls back to / when nothing was stashed", () => {
+        expect(consumePostLoginRedirect()).toBe("/");
+    });
+
+    it("rejects a cross-origin stashed value (open-redirect guard)", () => {
+        localStorage.setItem(POST_LOGIN_REDIRECT_KEY, "https://evil.example.com/#/embed/chat?agent=Foo");
+        expect(consumePostLoginRedirect()).toBe("/");
+    });
+
+    it("rejects an unparseable stashed value", () => {
+        localStorage.setItem(POST_LOGIN_REDIRECT_KEY, "not-a-url");
+        expect(consumePostLoginRedirect()).toBe("/");
+    });
+});

--- a/client/webui/frontend/src/lib/utils/url.ts
+++ b/client/webui/frontend/src/lib/utils/url.ts
@@ -31,3 +31,63 @@ export function getCleanDomain(url: string): string {
 export function getFaviconUrl(domain: string, size: number = 32): string {
     return `https://www.google.com/s2/favicons?domain=${domain}&sz=${size}`;
 }
+
+/**
+ * Embedded chat params live in the query segment of the hash route, after the
+ * route path: `/#/embed/chat?agent=Foo`. We read them from window.location.hash
+ * (not window.location.search) so the params travel with the hash route.
+ * Synchronous + read-once-at-load, so no full-UI flash.
+ */
+export function getHashQueryParams(): URLSearchParams {
+    const hash = window.location.hash;
+    const queryIndex = hash.indexOf("?");
+    return new URLSearchParams(queryIndex >= 0 ? hash.slice(queryIndex + 1) : "");
+}
+
+/**
+ * The route path inside the hash, without the leading "#" or any query segment.
+ * `/#/embed/chat?agent=Foo` → `/embed/chat`. Used to detect the embedded surface
+ * route synchronously at load (read-once, no flash).
+ */
+export function getHashPath(): string {
+    const hash = window.location.hash.replace(/^#/, "");
+    return hash.split("?")[0];
+}
+
+const POST_LOGIN_REDIRECT_KEY = "sam_post_login_redirect";
+
+/**
+ * Remember the current URL before leaving the SPA for the IdP, so the embedded
+ * chat params (which the login round-trip would otherwise drop) can be restored
+ * after the callback. Written at every exit-to-login site.
+ */
+export function stashPostLoginRedirect(): void {
+    try {
+        localStorage.setItem(POST_LOGIN_REDIRECT_KEY, window.location.href);
+    } catch {
+        // localStorage unavailable (private mode / disabled) — restore falls back to "/".
+    }
+}
+
+/**
+ * Read and clear the stashed post-login URL. One-shot (deleted on read) and
+ * same-origin checked so a poisoned key cannot drive an open redirect. Falls back
+ * to "/" when absent, unparseable, or cross-origin.
+ */
+export function consumePostLoginRedirect(): string {
+    let stashed: string | null = null;
+    try {
+        stashed = localStorage.getItem(POST_LOGIN_REDIRECT_KEY);
+        localStorage.removeItem(POST_LOGIN_REDIRECT_KEY);
+    } catch {
+        return "/";
+    }
+    if (!stashed) return "/";
+    try {
+        const url = new URL(stashed);
+        if (url.origin === window.location.origin) return url.href;
+    } catch {
+        // Not an absolute same-origin URL — ignore.
+    }
+    return "/";
+}

--- a/client/webui/frontend/src/router.tsx
+++ b/client/webui/frontend/src/router.tsx
@@ -27,9 +27,15 @@ export const createRouter = () => {
                 },
                 {
                     // Embedded, chat-only single-agent surface (?agent=Foo). Reuses ChatPage;
-                    // ChatSurfaceProvider keys the embedded layout off this route path.
+                    // ChatSurfaceProvider keys the embedded layout off the /embed/* route path.
                     path: "embed/chat",
                     element: <ChatPage />,
+                },
+                {
+                    // Embedded "View All" — agent-scoped recent chats. Reuses RecentChatsPage,
+                    // which trims its chrome and scopes to ?agent= when the surface is embedded.
+                    path: "embed/recent-chats",
+                    element: <RecentChatsPage />,
                 },
                 {
                     path: "recent-chats",

--- a/client/webui/frontend/src/router.tsx
+++ b/client/webui/frontend/src/router.tsx
@@ -26,6 +26,12 @@ export const createRouter = () => {
                     element: <ChatPage />,
                 },
                 {
+                    // Embedded, chat-only single-agent surface (?agent=Foo). Reuses ChatPage;
+                    // ChatSurfaceProvider keys the embedded layout off this route path.
+                    path: "embed/chat",
+                    element: <ChatPage />,
+                },
+                {
                     path: "recent-chats",
                     element: <RecentChatsPage />,
                 },

--- a/client/webui/frontend/src/stories/api/sessionHooks.test.tsx
+++ b/client/webui/frontend/src/stories/api/sessionHooks.test.tsx
@@ -87,8 +87,8 @@ describe("useRecentSessions / useInfiniteSessions — auth user switch", () => {
 
         // Alice's cached entry must still be reachable under her own key —
         // proving the new fetch went to a *different* cache slot.
-        const aliceCached = queryClient.getQueryData(["sessions", "list", "recent", "alice", 10]) as Session[] | undefined;
-        const bobCached = queryClient.getQueryData(["sessions", "list", "recent", "bob", 10]) as Session[] | undefined;
+        const aliceCached = queryClient.getQueryData(["sessions", "list", "recent", "alice", 10, null]) as Session[] | undefined;
+        const bobCached = queryClient.getQueryData(["sessions", "list", "recent", "bob", 10, null]) as Session[] | undefined;
         expect(aliceCached?.[0]?.id).toBe("alice-sess");
         expect(bobCached?.[0]?.id).toBe("bob-sess");
     });

--- a/client/webui/frontend/src/stories/api/sessionKeys.test.ts
+++ b/client/webui/frontend/src/stories/api/sessionKeys.test.ts
@@ -10,13 +10,15 @@ describe("sessionKeys", () => {
         expect(sessionKeys.lists()).toEqual(["sessions", "list"]);
     });
 
-    test("recent(userId, max) is scoped by userId", () => {
-        expect(sessionKeys.recent("alice", 10)).toEqual(["sessions", "list", "recent", "alice", 10]);
+    test("recent(userId, max, agentId?) is scoped by userId (and agent)", () => {
+        expect(sessionKeys.recent("alice", 10)).toEqual(["sessions", "list", "recent", "alice", 10, null]);
+        expect(sessionKeys.recent("alice", 10, "AgentX")).toEqual(["sessions", "list", "recent", "alice", 10, "AgentX"]);
     });
 
-    test("infinite(userId, pageSize, source?) is scoped by userId", () => {
-        expect(sessionKeys.infinite("alice", 20)).toEqual(["sessions", "list", "infinite", "alice", 20, undefined]);
-        expect(sessionKeys.infinite("alice", 20, "scheduler")).toEqual(["sessions", "list", "infinite", "alice", 20, "scheduler"]);
+    test("infinite(userId, pageSize, source?, agentId?) is scoped by userId (and agent)", () => {
+        expect(sessionKeys.infinite("alice", 20)).toEqual(["sessions", "list", "infinite", "alice", 20, undefined, null]);
+        expect(sessionKeys.infinite("alice", 20, "scheduler")).toEqual(["sessions", "list", "infinite", "alice", 20, "scheduler", null]);
+        expect(sessionKeys.infinite("alice", 20, "chat", "AgentX")).toEqual(["sessions", "list", "infinite", "alice", 20, "chat", "AgentX"]);
     });
 
     test("different userId values produce non-equal recent keys", () => {

--- a/client/webui/frontend/src/stories/chat/AttachArtifactDialog.test.tsx
+++ b/client/webui/frontend/src/stories/chat/AttachArtifactDialog.test.tsx
@@ -21,6 +21,7 @@ import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { AttachArtifactDialog } from "@/lib/components/chat/file/AttachArtifactDialog";
 import type { ArtifactWithSession } from "@/lib/api/artifacts";
 import { artifactKeys } from "@/lib/api/artifacts/keys";
+import * as artifactService from "@/lib/api/artifacts/service";
 
 expect.extend(matchers);
 
@@ -92,8 +93,20 @@ function renderDialog(artifacts: ArtifactWithSession[], options: { hasMore?: boo
     // fetchNextPage via QueryClient's fetchNextPage event pipeline: the
     // IntersectionObserver callback calls `loadMore` which ultimately
     // triggers fetchNextPage — we intercept that on the QueryClient itself.
+    const rawArtifacts = artifacts.map(toRawArtifact);
+
+    // `useAllArtifacts` uses `refetchOnMount: "always"`, so it always refetches on mount
+    // through `getAllArtifacts`. Without a mock that refetch hits the (unmocked) network and,
+    // depending on the jsdom/fetch environment, resolves with empty data that clobbers the
+    // seeded cache. Stub the service to return the same artifacts so the refetch is deterministic.
+    vi.spyOn(artifactService, "getAllArtifacts").mockResolvedValue({
+        artifacts: rawArtifacts,
+        nextPage: options.hasMore ? 2 : null,
+        totalCount: artifacts.length,
+    } as Awaited<ReturnType<typeof artifactService.getAllArtifacts>>);
+
     qc.setQueryData([...artifactKeys.lists(), { search: undefined }], {
-        pages: [{ artifacts: artifacts.map(toRawArtifact), nextPage: options.hasMore ? 2 : null, totalCount: artifacts.length }],
+        pages: [{ artifacts: rawArtifacts, nextPage: options.hasMore ? 2 : null, totalCount: artifacts.length }],
         pageParams: [1],
     });
 
@@ -121,6 +134,7 @@ describe("AttachArtifactDialog", () => {
 
     afterEach(() => {
         vi.unstubAllGlobals();
+        vi.restoreAllMocks();
         qc?.clear();
     });
 

--- a/client/webui/frontend/src/stories/chat/ChatInputArea.submitRestore.test.tsx
+++ b/client/webui/frontend/src/stories/chat/ChatInputArea.submitRestore.test.tsx
@@ -13,6 +13,7 @@ import { OpenFeatureTestProvider } from "@openfeature/react-sdk";
 import { ChatInputArea } from "@/lib/components/chat/ChatInputArea";
 import type { ArtifactWithSession } from "@/lib/api/artifacts";
 import { artifactKeys } from "@/lib/api/artifacts/keys";
+import * as artifactService from "@/lib/api/artifacts/service";
 import { queryClient } from "@/lib/providers/QueryClient";
 import { StoryProvider } from "../mocks/StoryProvider";
 
@@ -72,10 +73,20 @@ function seedArtifacts(artifacts: ArtifactWithSession[]) {
         pages: [{ artifacts: raw, nextPage: null, totalCount: raw.length }],
         pageParams: [1],
     });
+
+    // `useAllArtifacts` force-refetches on mount (refetchOnMount: "always"); without a mock that
+    // refetch hits the unmocked network and can clobber the seeded cache with empty data. Stub the
+    // service to return the same artifacts so the refetch is deterministic across environments.
+    vi.spyOn(artifactService, "getAllArtifacts").mockResolvedValue({
+        artifacts: raw,
+        nextPage: null,
+        totalCount: raw.length,
+    } as Awaited<ReturnType<typeof artifactService.getAllArtifacts>>);
 }
 
 afterEach(() => {
     queryClient.clear();
+    vi.restoreAllMocks();
 });
 
 // ---------------------------------------------------------------------------

--- a/client/webui/frontend/src/stories/chat/ChatPage.test.tsx
+++ b/client/webui/frontend/src/stories/chat/ChatPage.test.tsx
@@ -21,6 +21,31 @@ const mockUseLocation = vi.fn();
 const mockUseNavigate = vi.fn();
 const mockUseShareLink = vi.fn();
 const mockUseShareUsers = vi.fn();
+const mockUseChatSurface = vi.fn();
+
+const FULL_SURFACE = {
+    variant: "full",
+    navigation: ["newChat", "appNav", "recentChats"],
+    showAgentSelector: true,
+    showActivityPanel: true,
+    allowPrompts: true,
+    allowMentions: true,
+    pinnedAgent: null,
+    seedWelcomeBubble: true,
+    sessionActions: ["goToProject", "rename", "renameWithAI", "move", "share", "delete"],
+};
+
+const EMBEDDED_SURFACE = {
+    variant: "embedded",
+    navigation: ["recentChats"],
+    showAgentSelector: false,
+    showActivityPanel: false,
+    allowPrompts: false,
+    allowMentions: true,
+    pinnedAgent: "WeatherAgent",
+    seedWelcomeBubble: false,
+    sessionActions: ["rename", "renameWithAI", "delete"],
+};
 
 function makeDefaultChatContext(overrides: Record<string, unknown> = {}) {
     return {
@@ -74,6 +99,7 @@ describe("ChatPage", () => {
         mockUseNavigate.mockReset();
         mockUseShareLink.mockReset();
         mockUseShareUsers.mockReset();
+        mockUseChatSurface.mockReset();
 
         // Default return values
         mockUseChatContext.mockReturnValue(makeDefaultChatContext());
@@ -87,6 +113,7 @@ describe("ChatPage", () => {
         mockUseNavigate.mockReturnValue(vi.fn());
         mockUseShareLink.mockReturnValue({ data: null });
         mockUseShareUsers.mockReturnValue({ data: { users: [] } });
+        mockUseChatSurface.mockReturnValue(FULL_SURFACE);
 
         vi.doMock("@/lib/hooks", async () => {
             const actual = await vi.importActual<typeof import("@/lib/hooks")>("@/lib/hooks");
@@ -98,6 +125,7 @@ describe("ChatPage", () => {
                 useConfigContext: mockUseConfigContext,
                 useIsChatSharingEnabled: mockUseIsChatSharingEnabled,
                 useIsAutoTitleGenerationEnabled: mockUseIsAutoTitleGenerationEnabled,
+                useChatSurface: mockUseChatSurface,
             };
         });
 
@@ -160,6 +188,7 @@ describe("ChatPage", () => {
             ChatSessionDeleteDialog: () => React.createElement("div", { "data-testid": "chat-session-delete-dialog" }),
             ChatSidePanel: () => React.createElement("div", { "data-testid": "chat-side-panel" }),
             ChatInputArea: () => React.createElement("div", { "data-testid": "chat-input-area" }),
+            EmbeddedChatWelcome: ({ message }: { message?: string }) => React.createElement("div", { "data-testid": "embedded-chat-welcome" }, message),
             LoadingMessageRow: () => React.createElement("div", { "data-testid": "loading-message-row" }),
             ProjectBadge: ({ text }: { text: string }) => React.createElement("span", { "data-testid": "project-badge" }, text),
             SessionSidePanel: ({ onToggle }: { onToggle: () => void }) => React.createElement("div", { "data-testid": "session-side-panel", onClick: onToggle }),
@@ -260,5 +289,45 @@ describe("ChatPage", () => {
         expect(screen.getByRole("button", { name: /Continue in New Chat/i })).toBeInTheDocument();
         // Share button should NOT be present for collaborative sessions
         expect(screen.queryByTestId("share-button")).not.toBeInTheDocument();
+    });
+
+    describe("embedded surface", () => {
+        test("shows a 'No agent specified' error when the embedded URL has no ?agent=", () => {
+            mockUseChatSurface.mockReturnValue({ ...EMBEDDED_SURFACE, pinnedAgent: null });
+            mockUseChatContext.mockReturnValue(makeDefaultChatContext({ selectedAgentName: "", messages: [] }));
+
+            renderPage();
+            expect(screen.getByText("No agent specified")).toBeInTheDocument();
+            // Misconfiguration is terminal — no connecting spinner, no input.
+            expect(screen.queryByText("Connecting…")).not.toBeInTheDocument();
+            expect(screen.queryByTestId("chat-input-area")).not.toBeInTheDocument();
+        });
+
+        test("shows the Connecting state while the pinned agent has not resolved", () => {
+            mockUseChatSurface.mockReturnValue(EMBEDDED_SURFACE);
+            mockUseChatContext.mockReturnValue(makeDefaultChatContext({ selectedAgentName: "", messages: [] }));
+
+            renderPage();
+            expect(screen.getByText("Connecting…")).toBeInTheDocument();
+            // No seeded welcome bubble and no Activity surfacing in embedded mode.
+            expect(screen.queryByTestId("embedded-chat-welcome")).not.toBeInTheDocument();
+        });
+
+        test("shows the centered hero greeting once the pinned agent resolves", () => {
+            mockUseChatSurface.mockReturnValue(EMBEDDED_SURFACE);
+            mockUseChatContext.mockReturnValue(
+                makeDefaultChatContext({
+                    selectedAgentName: "WeatherAgent",
+                    agents: [{ name: "WeatherAgent", displayName: "Weather" }],
+                    messages: [],
+                })
+            );
+
+            renderPage();
+            const hero = screen.getByTestId("embedded-chat-welcome");
+            expect(hero).toBeInTheDocument();
+            // Greeting is built from the resolved agent's display name.
+            expect(hero).toHaveTextContent("Hi, I'm Weather. How can I help you?");
+        });
     });
 });

--- a/client/webui/frontend/src/stories/chat/ChatPage.test.tsx
+++ b/client/webui/frontend/src/stories/chat/ChatPage.test.tsx
@@ -25,7 +25,8 @@ const mockUseChatSurface = vi.fn();
 
 const FULL_SURFACE = {
     variant: "full",
-    navigation: ["newChat", "appNav", "recentChats"],
+    showNav: true,
+    showRecentChatsPanel: false,
     showAgentSelector: true,
     showActivityPanel: true,
     allowPrompts: true,
@@ -37,7 +38,8 @@ const FULL_SURFACE = {
 
 const EMBEDDED_SURFACE = {
     variant: "embedded",
-    navigation: ["recentChats"],
+    showNav: false,
+    showRecentChatsPanel: true,
     showAgentSelector: false,
     showActivityPanel: false,
     allowPrompts: false,
@@ -192,6 +194,7 @@ describe("ChatPage", () => {
             LoadingMessageRow: () => React.createElement("div", { "data-testid": "loading-message-row" }),
             ProjectBadge: ({ text }: { text: string }) => React.createElement("span", { "data-testid": "project-badge" }, text),
             SessionSidePanel: ({ onToggle }: { onToggle: () => void }) => React.createElement("div", { "data-testid": "session-side-panel", onClick: onToggle }),
+            RecentChatsSidePanel: () => React.createElement("div", { "data-testid": "recent-chats-side-panel" }),
             UserPresenceAvatars: () => React.createElement("div", { "data-testid": "user-presence-avatars" }),
             ShareNotificationMessage: () => React.createElement("div", { "data-testid": "share-notification" }),
         }));
@@ -308,7 +311,7 @@ describe("ChatPage", () => {
             mockUseChatContext.mockReturnValue(makeDefaultChatContext({ selectedAgentName: "", messages: [] }));
 
             renderPage();
-            expect(screen.getByText("Connecting…")).toBeInTheDocument();
+            expect(screen.getByText("Agent connecting...")).toBeInTheDocument();
             // No seeded welcome bubble and no Activity surfacing in embedded mode.
             expect(screen.queryByTestId("embedded-chat-welcome")).not.toBeInTheDocument();
         });
@@ -328,6 +331,22 @@ describe("ChatPage", () => {
             expect(hero).toBeInTheDocument();
             // Greeting is built from the resolved agent's display name.
             expect(hero).toHaveTextContent("Hi, I'm Weather. How can I help you?");
+        });
+
+        test("renders the Recent Chats toggle + drawer in embedded", () => {
+            mockUseChatSurface.mockReturnValue(EMBEDDED_SURFACE);
+            mockUseChatContext.mockReturnValue(makeDefaultChatContext({ selectedAgentName: "WeatherAgent", agents: [{ name: "WeatherAgent", displayName: "Weather" }], messages: [] }));
+
+            renderPage();
+            expect(screen.getByTestId("showRecentChats")).toBeInTheDocument();
+            expect(screen.getByTestId("recent-chats-side-panel")).toBeInTheDocument();
+        });
+
+        test("does not render the Recent Chats toggle/drawer in the full surface", () => {
+            // FULL_SURFACE is the default mock.
+            renderPage();
+            expect(screen.queryByTestId("showRecentChats")).not.toBeInTheDocument();
+            expect(screen.queryByTestId("recent-chats-side-panel")).not.toBeInTheDocument();
         });
     });
 });

--- a/client/webui/frontend/src/stories/chat/SessionActionMenu.test.tsx
+++ b/client/webui/frontend/src/stories/chat/SessionActionMenu.test.tsx
@@ -1,0 +1,68 @@
+/// <reference types="@testing-library/jest-dom" />
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, test, expect, vi } from "vitest";
+import * as matchers from "@testing-library/jest-dom/matchers";
+
+import { SessionActionMenu } from "@/lib/components/chat/SessionActionMenu";
+import { ChatSurfaceContext, FULL_CHAT_SURFACE, type ChatSurface } from "@/lib/contexts";
+import type { Session } from "@/lib/types";
+
+expect.extend(matchers);
+
+const EMBEDDED_SURFACE: ChatSurface = {
+    ...FULL_CHAT_SURFACE,
+    variant: "embedded",
+    sessionActions: ["rename", "renameWithAI", "delete"],
+};
+
+const session = { id: "s1", name: "My session", projectId: "p1" } as unknown as Session;
+
+function renderMenu(surface: ChatSurface) {
+    const handlers = {
+        onRename: vi.fn(),
+        onRenameWithAI: vi.fn(),
+        onMove: vi.fn(),
+        onDelete: vi.fn(),
+        onGoToProject: vi.fn(),
+        onShare: vi.fn(),
+    };
+    render(
+        <ChatSurfaceContext.Provider value={surface}>
+            <SessionActionMenu session={session} {...handlers} />
+        </ChatSurfaceContext.Provider>
+    );
+    return handlers;
+}
+
+async function openMenu() {
+    const user = userEvent.setup();
+    await user.click(screen.getByRole("button"));
+}
+
+describe("SessionActionMenu — surface allowlist", () => {
+    test("full surface shows every action", async () => {
+        renderMenu(FULL_CHAT_SURFACE);
+        await openMenu();
+
+        expect(screen.getByText("Go to Project")).toBeInTheDocument();
+        expect(screen.getByText("Rename")).toBeInTheDocument();
+        expect(screen.getByText("Rename with AI")).toBeInTheDocument();
+        expect(screen.getByText("Move to Project")).toBeInTheDocument();
+        expect(screen.getByText("Share")).toBeInTheDocument();
+        expect(screen.getByText("Delete")).toBeInTheDocument();
+    });
+
+    test("embedded surface shows only Rename / Rename with AI / Delete", async () => {
+        renderMenu(EMBEDDED_SURFACE);
+        await openMenu();
+
+        expect(screen.getByText("Rename")).toBeInTheDocument();
+        expect(screen.getByText("Rename with AI")).toBeInTheDocument();
+        expect(screen.getByText("Delete")).toBeInTheDocument();
+
+        expect(screen.queryByText("Go to Project")).not.toBeInTheDocument();
+        expect(screen.queryByText("Move to Project")).not.toBeInTheDocument();
+        expect(screen.queryByText("Share")).not.toBeInTheDocument();
+    });
+});

--- a/client/webui/frontend/src/stories/layout/AppLayout.test.tsx
+++ b/client/webui/frontend/src/stories/layout/AppLayout.test.tsx
@@ -6,6 +6,7 @@ import React from "react";
 
 import { renderWithProviders } from "@/lib/test-utils";
 import * as modelsApi from "@/lib/api/models";
+import { ChatSurfaceContext, type ChatSurface } from "@/lib/contexts";
 import AppLayout from "@/AppLayout";
 
 expect.extend(matchers);
@@ -87,5 +88,60 @@ describe("AppLayout model warning banner", () => {
             expect(screen.getByText(/Ask your administrator/)).toBeInTheDocument();
             expect(screen.queryByRole("button", { name: /Go to Models/i })).not.toBeInTheDocument();
         });
+    });
+});
+
+const EMBEDDED_SURFACE: ChatSurface = {
+    variant: "embedded",
+    navigation: ["recentChats"],
+    showAgentSelector: false,
+    showActivityPanel: false,
+    allowPrompts: false,
+    allowMentions: true,
+    pinnedAgent: "WeatherAgent",
+    seedWelcomeBubble: false,
+    sessionActions: ["rename", "renameWithAI", "delete"],
+};
+
+describe("AppLayout navigation gating by chat surface", () => {
+    beforeEach(() => {
+        mockModelConfigStatus.mockReturnValue({ data: { configured: true } });
+    });
+
+    test("embedded + new_navigation renders the collapsible sidebar with Recent Chats but no New Chat / app nav (issue #1)", async () => {
+        await renderWithProviders(
+            <ChatSurfaceContext.Provider value={EMBEDDED_SURFACE}>
+                <AppLayout />
+            </ChatSurfaceContext.Provider>,
+            { featureFlags: { new_navigation: true } }
+        );
+        expect(screen.getByTestId("collapsible-navigation-sidebar")).toBeInTheDocument();
+        expect(screen.getByText("Recent Chats")).toBeInTheDocument();
+        // New Chat button and app nav items are suppressed in recent-chats-only mode.
+        expect(screen.queryByText("New Chat")).not.toBeInTheDocument();
+        // The legacy icon rail is never shown alongside the new nav.
+        expect(screen.queryByTestId("navigation-sidebar")).not.toBeInTheDocument();
+    });
+
+    test("embedded + legacy nav renders no sidebar (the icon rail has no Recent Chats)", async () => {
+        await renderWithProviders(
+            <ChatSurfaceContext.Provider value={EMBEDDED_SURFACE}>
+                <AppLayout />
+            </ChatSurfaceContext.Provider>,
+            { featureFlags: { new_navigation: false } }
+        );
+        expect(screen.queryByTestId("navigation-sidebar")).not.toBeInTheDocument();
+        expect(screen.queryByTestId("collapsible-navigation-sidebar")).not.toBeInTheDocument();
+    });
+
+    test("full surface shows the full collapsible nav (incl. New Chat) when new_navigation is enabled", async () => {
+        await renderWithProviders(<AppLayout />, { featureFlags: { new_navigation: true } });
+        expect(screen.getByTestId("collapsible-navigation-sidebar")).toBeInTheDocument();
+        expect(screen.getByText("New Chat")).toBeInTheDocument();
+    });
+
+    test("full surface still shows the legacy nav when new_navigation is disabled", async () => {
+        await renderWithProviders(<AppLayout />, { featureFlags: { new_navigation: false } });
+        expect(screen.getByTestId("navigation-sidebar")).toBeInTheDocument();
     });
 });

--- a/client/webui/frontend/src/stories/layout/AppLayout.test.tsx
+++ b/client/webui/frontend/src/stories/layout/AppLayout.test.tsx
@@ -93,7 +93,8 @@ describe("AppLayout model warning banner", () => {
 
 const EMBEDDED_SURFACE: ChatSurface = {
     variant: "embedded",
-    navigation: ["recentChats"],
+    showNav: false,
+    showRecentChatsPanel: true,
     showAgentSelector: false,
     showActivityPanel: false,
     allowPrompts: false,
@@ -108,22 +109,20 @@ describe("AppLayout navigation gating by chat surface", () => {
         mockModelConfigStatus.mockReturnValue({ data: { configured: true } });
     });
 
-    test("embedded + new_navigation renders the collapsible sidebar with Recent Chats but no New Chat / app nav (issue #1)", async () => {
+    test("embedded surface renders NO nav sidebar even when new_navigation is enabled (issue #1)", async () => {
         await renderWithProviders(
             <ChatSurfaceContext.Provider value={EMBEDDED_SURFACE}>
                 <AppLayout />
             </ChatSurfaceContext.Provider>,
             { featureFlags: { new_navigation: true } }
         );
-        expect(screen.getByTestId("collapsible-navigation-sidebar")).toBeInTheDocument();
-        expect(screen.getByText("Recent Chats")).toBeInTheDocument();
-        // New Chat button and app nav items are suppressed in recent-chats-only mode.
+        // Neither nav variant renders: no collapsible (Recent Chats / New Chat) and no legacy rail.
+        expect(screen.queryByText("Recent Chats")).not.toBeInTheDocument();
         expect(screen.queryByText("New Chat")).not.toBeInTheDocument();
-        // The legacy icon rail is never shown alongside the new nav.
         expect(screen.queryByTestId("navigation-sidebar")).not.toBeInTheDocument();
     });
 
-    test("embedded + legacy nav renders no sidebar (the icon rail has no Recent Chats)", async () => {
+    test("embedded surface renders NO nav sidebar when new_navigation is disabled", async () => {
         await renderWithProviders(
             <ChatSurfaceContext.Provider value={EMBEDDED_SURFACE}>
                 <AppLayout />
@@ -131,13 +130,13 @@ describe("AppLayout navigation gating by chat surface", () => {
             { featureFlags: { new_navigation: false } }
         );
         expect(screen.queryByTestId("navigation-sidebar")).not.toBeInTheDocument();
-        expect(screen.queryByTestId("collapsible-navigation-sidebar")).not.toBeInTheDocument();
+        expect(screen.queryByText("Recent Chats")).not.toBeInTheDocument();
     });
 
     test("full surface shows the full collapsible nav (incl. New Chat) when new_navigation is enabled", async () => {
         await renderWithProviders(<AppLayout />, { featureFlags: { new_navigation: true } });
-        expect(screen.getByTestId("collapsible-navigation-sidebar")).toBeInTheDocument();
         expect(screen.getByText("New Chat")).toBeInTheDocument();
+        expect(screen.getByText("Recent Chats")).toBeInTheDocument();
     });
 
     test("full surface still shows the legacy nav when new_navigation is disabled", async () => {

--- a/client/webui/frontend/src/stories/navigation/EmbeddedRouteGuard.test.tsx
+++ b/client/webui/frontend/src/stories/navigation/EmbeddedRouteGuard.test.tsx
@@ -1,0 +1,59 @@
+/// <reference types="@testing-library/jest-dom" />
+import { render, screen, waitFor } from "@testing-library/react";
+import { describe, test, expect, vi, beforeEach, afterEach } from "vitest";
+import * as matchers from "@testing-library/jest-dom/matchers";
+import { MemoryRouter, useLocation } from "react-router-dom";
+
+import { EmbeddedRouteGuard } from "@/lib/components/navigation/EmbeddedRouteGuard";
+import { ChatSurfaceContext, FULL_CHAT_SURFACE, type ChatSurface } from "@/lib/contexts";
+
+expect.extend(matchers);
+
+const EMBEDDED: ChatSurface = { ...FULL_CHAT_SURFACE, variant: "embedded", showNav: false, showRecentChatsPanel: true, pinnedAgent: "WeatherAgent" };
+const EMBEDDED_NO_AGENT: ChatSurface = { ...EMBEDDED, pinnedAgent: null };
+
+function LocationProbe() {
+    const loc = useLocation();
+    return <div data-testid="loc">{loc.pathname + loc.search}</div>;
+}
+
+function renderAt(initial: string, surface: ChatSurface) {
+    return render(
+        <MemoryRouter initialEntries={[initial]}>
+            <ChatSurfaceContext.Provider value={surface}>
+                <EmbeddedRouteGuard />
+                <LocationProbe />
+            </ChatSurfaceContext.Provider>
+        </MemoryRouter>
+    );
+}
+
+describe("EmbeddedRouteGuard", () => {
+    beforeEach(() => vi.spyOn(console, "warn").mockImplementation(() => {}));
+    afterEach(() => vi.restoreAllMocks());
+
+    test("redirects an off-embed route back to /embed/chat with the pinned agent", async () => {
+        renderAt("/projects", EMBEDDED);
+        await waitFor(() => expect(screen.getByTestId("loc")).toHaveTextContent("/embed/chat?agent=WeatherAgent"));
+    });
+
+    test("re-appends a dropped ?agent= on an embed route", async () => {
+        renderAt("/embed/chat", EMBEDDED);
+        await waitFor(() => expect(screen.getByTestId("loc")).toHaveTextContent("/embed/chat?agent=WeatherAgent"));
+    });
+
+    test("leaves a valid embed route (with agent) untouched", () => {
+        renderAt("/embed/recent-chats?agent=WeatherAgent", EMBEDDED);
+        expect(screen.getByTestId("loc")).toHaveTextContent("/embed/recent-chats?agent=WeatherAgent");
+    });
+
+    test("no-agent embed does not loop on /embed/chat", () => {
+        renderAt("/embed/chat", EMBEDDED_NO_AGENT);
+        expect(screen.getByTestId("loc")).toHaveTextContent("/embed/chat");
+    });
+
+    test("full surface never redirects (no-op off embed)", () => {
+        renderAt("/projects", FULL_CHAT_SURFACE);
+        expect(screen.getByTestId("loc")).toHaveTextContent("/projects");
+    });
+});

--- a/client/webui/frontend/src/stories/providers/ChatSurfaceProvider.test.tsx
+++ b/client/webui/frontend/src/stories/providers/ChatSurfaceProvider.test.tsx
@@ -30,7 +30,7 @@ describe("ChatSurfaceProvider", () => {
         window.history.replaceState({}, "", "/");
     });
 
-    test("defaults to the full surface when no agentMode param is present", () => {
+    test("defaults to the full surface on a non-embed route", () => {
         window.history.replaceState({}, "", "/#/chat");
         render(
             <ChatSurfaceProvider>
@@ -39,7 +39,8 @@ describe("ChatSurfaceProvider", () => {
         );
         const surface = readSurface();
         expect(surface.variant).toBe("full");
-        expect(surface.navigation).toEqual(["newChat", "appNav", "recentChats"]);
+        expect(surface.showNav).toBe(true);
+        expect(surface.showRecentChatsPanel).toBe(false);
         expect(surface.showAgentSelector).toBe(true);
         expect(surface.showActivityPanel).toBe(true);
         expect(surface.pinnedAgent).toBeNull();
@@ -55,13 +56,27 @@ describe("ChatSurfaceProvider", () => {
         );
         const surface = readSurface();
         expect(surface.variant).toBe("embedded");
-        expect(surface.navigation).toEqual(["recentChats"]);
+        expect(surface.showNav).toBe(false);
+        expect(surface.showRecentChatsPanel).toBe(true);
         expect(surface.showAgentSelector).toBe(false);
         expect(surface.showActivityPanel).toBe(false);
         expect(surface.allowPrompts).toBe(false);
         expect(surface.pinnedAgent).toBe("WeatherAgent");
         expect(surface.seedWelcomeBubble).toBe(false);
         expect(surface.sessionActions).toEqual(["rename", "renameWithAI", "delete"]);
+    });
+
+    test("treats the /embed/recent-chats route as embedded too (View All stays embedded)", () => {
+        window.history.replaceState({}, "", "/#/embed/recent-chats?agent=WeatherAgent");
+        render(
+            <ChatSurfaceProvider>
+                <SurfaceProbe />
+            </ChatSurfaceProvider>
+        );
+        const surface = readSurface();
+        expect(surface.variant).toBe("embedded");
+        expect(surface.showNav).toBe(false);
+        expect(surface.pinnedAgent).toBe("WeatherAgent");
     });
 
     test("keeps the pinned agent stable after the hash query is later stripped (issue #3)", () => {

--- a/client/webui/frontend/src/stories/providers/ChatSurfaceProvider.test.tsx
+++ b/client/webui/frontend/src/stories/providers/ChatSurfaceProvider.test.tsx
@@ -1,0 +1,89 @@
+/// <reference types="@testing-library/jest-dom" />
+import { useState } from "react";
+import { render, screen, act } from "@testing-library/react";
+import { describe, test, expect, afterEach } from "vitest";
+
+import { ChatSurfaceProvider } from "@/lib/providers/ChatSurfaceProvider";
+import { useChatSurface } from "@/lib/hooks/useChatSurface";
+
+// Dumps the live surface as JSON plus a button that bumps local state, so a test
+// can force a re-render without remounting the provider.
+function SurfaceProbe() {
+    const [, setTick] = useState(0);
+    const surface = useChatSurface();
+    return (
+        <>
+            <pre data-testid="surface">{JSON.stringify(surface)}</pre>
+            <button data-testid="rerender" onClick={() => setTick(t => t + 1)}>
+                rerender
+            </button>
+        </>
+    );
+}
+
+function readSurface() {
+    return JSON.parse(screen.getByTestId("surface").textContent || "{}");
+}
+
+describe("ChatSurfaceProvider", () => {
+    afterEach(() => {
+        window.history.replaceState({}, "", "/");
+    });
+
+    test("defaults to the full surface when no agentMode param is present", () => {
+        window.history.replaceState({}, "", "/#/chat");
+        render(
+            <ChatSurfaceProvider>
+                <SurfaceProbe />
+            </ChatSurfaceProvider>
+        );
+        const surface = readSurface();
+        expect(surface.variant).toBe("full");
+        expect(surface.navigation).toEqual(["newChat", "appNav", "recentChats"]);
+        expect(surface.showAgentSelector).toBe(true);
+        expect(surface.showActivityPanel).toBe(true);
+        expect(surface.pinnedAgent).toBeNull();
+        expect(surface.seedWelcomeBubble).toBe(true);
+    });
+
+    test("computes an embedded surface from the /embed/chat route and captures the pinned agent", () => {
+        window.history.replaceState({}, "", "/#/embed/chat?agent=WeatherAgent");
+        render(
+            <ChatSurfaceProvider>
+                <SurfaceProbe />
+            </ChatSurfaceProvider>
+        );
+        const surface = readSurface();
+        expect(surface.variant).toBe("embedded");
+        expect(surface.navigation).toEqual(["recentChats"]);
+        expect(surface.showAgentSelector).toBe(false);
+        expect(surface.showActivityPanel).toBe(false);
+        expect(surface.allowPrompts).toBe(false);
+        expect(surface.pinnedAgent).toBe("WeatherAgent");
+        expect(surface.seedWelcomeBubble).toBe(false);
+        expect(surface.sessionActions).toEqual(["rename", "renameWithAI", "delete"]);
+    });
+
+    test("keeps the pinned agent stable after the hash query is later stripped (issue #3)", () => {
+        // Embedded tab pins to WeatherAgent...
+        window.history.replaceState({}, "", "/#/embed/chat?agent=WeatherAgent");
+        render(
+            <ChatSurfaceProvider>
+                <SurfaceProbe />
+            </ChatSurfaceProvider>
+        );
+        expect(readSurface().pinnedAgent).toBe("WeatherAgent");
+
+        // ...then in-app navigation strips the hash query, and the component re-renders.
+        act(() => {
+            window.history.replaceState({}, "", "/#/chat");
+        });
+        act(() => {
+            screen.getByTestId("rerender").click();
+        });
+
+        // The pinned agent must NOT be re-derived to null — it was captured once at load.
+        expect(readSurface().pinnedAgent).toBe("WeatherAgent");
+        expect(readSurface().variant).toBe("embedded");
+    });
+});

--- a/client/webui/frontend/src/stories/utils/agentUtils.test.ts
+++ b/client/webui/frontend/src/stories/utils/agentUtils.test.ts
@@ -1,5 +1,5 @@
 import { describe, test, expect } from "vitest";
-import { selectInitialAgent } from "@/lib/utils/agentUtils";
+import { selectInitialAgent, resolveSessionLoadAgent } from "@/lib/utils/agentUtils";
 import type { AgentCardInfo } from "@/lib/types";
 
 const agent = (name: string): AgentCardInfo => ({ name, displayName: name }) as unknown as AgentCardInfo;
@@ -94,5 +94,29 @@ describe("selectInitialAgent — priority order (full UI)", () => {
         const result = selectInitialAgent({ agents: [alpha, beta], urlAgentName: null, embedded: false });
 
         expect(result.agent).toBe(alpha);
+    });
+});
+
+describe("resolveSessionLoadAgent — embedded agent-pinning isolation", () => {
+    test("embedded: pinned agent wins over the loaded session's stored (cross-)agent", () => {
+        // The load-bearing isolation guarantee: opening a session stored against another
+        // agent must not re-route the next message away from the pinned agent.
+        expect(resolveSessionLoadAgent({ embedded: true, pinnedAgent: "WeatherAgent", storedAgent: "OtherAgent" })).toBe("WeatherAgent");
+    });
+
+    test("embedded: pinned agent used even when it matches the stored agent", () => {
+        expect(resolveSessionLoadAgent({ embedded: true, pinnedAgent: "WeatherAgent", storedAgent: "WeatherAgent" })).toBe("WeatherAgent");
+    });
+
+    test("embedded with no pinned agent falls back to the stored agent", () => {
+        expect(resolveSessionLoadAgent({ embedded: true, pinnedAgent: null, storedAgent: "OtherAgent" })).toBe("OtherAgent");
+    });
+
+    test("full UI uses the loaded session's stored agent (no pinning)", () => {
+        expect(resolveSessionLoadAgent({ embedded: false, pinnedAgent: null, storedAgent: "OtherAgent" })).toBe("OtherAgent");
+    });
+
+    test("full UI ignores any pinnedAgent value", () => {
+        expect(resolveSessionLoadAgent({ embedded: false, pinnedAgent: "WeatherAgent", storedAgent: "OtherAgent" })).toBe("OtherAgent");
     });
 });

--- a/client/webui/frontend/src/stories/utils/agentUtils.test.ts
+++ b/client/webui/frontend/src/stories/utils/agentUtils.test.ts
@@ -1,0 +1,98 @@
+import { describe, test, expect } from "vitest";
+import { selectInitialAgent } from "@/lib/utils/agentUtils";
+import type { AgentCardInfo } from "@/lib/types";
+
+const agent = (name: string): AgentCardInfo => ({ name, displayName: name }) as unknown as AgentCardInfo;
+
+const orchestrator = agent("OrchestratorAgent");
+const alpha = agent("AlphaAgent");
+const beta = agent("BetaAgent");
+
+describe("selectInitialAgent — pinned agent (embedded mode)", () => {
+    test("selects the URL agent and never seeds the welcome bubble", () => {
+        const result = selectInitialAgent({ agents: [orchestrator, alpha], urlAgentName: "AlphaAgent", embedded: true });
+
+        expect(result.agent).toBe(alpha);
+        expect(result.shouldSeedWelcome).toBe(false);
+    });
+
+    test("bails when the pinned agent is not yet available", () => {
+        const result = selectInitialAgent({ agents: [orchestrator], urlAgentName: "AlphaAgent", embedded: true });
+
+        expect(result.agent).toBeNull();
+        expect(result.shouldSeedWelcome).toBe(false);
+    });
+
+    test("bails when no ?agent= is given — embedded never falls back to a default", () => {
+        // Even with an OrchestratorAgent available, a missing ?agent= must not silently
+        // pin to it; the embedded surface requires an explicit agent (caller shows an error).
+        const result = selectInitialAgent({ agents: [alpha, orchestrator], urlAgentName: null, embedded: true });
+
+        expect(result.agent).toBeNull();
+        expect(result.shouldSeedWelcome).toBe(false);
+    });
+
+    test("ignores the project default — embedded only honors an explicit ?agent=", () => {
+        const result = selectInitialAgent({ agents: [alpha, beta], urlAgentName: null, embedded: true, projectDefaultAgentId: "BetaAgent" });
+
+        expect(result.agent).toBeNull();
+        expect(result.shouldSeedWelcome).toBe(false);
+    });
+
+    test("pins by wire name only — a shared displayName cannot misroute", () => {
+        // Two agents collide on displayName but have distinct wire names. ?agent=
+        // must resolve against the unique wire name, never the ambiguous label.
+        const first = { name: "agent-uuid-1", displayName: "Weather Agent" } as unknown as AgentCardInfo;
+        const second = { name: "agent-uuid-2", displayName: "Weather Agent" } as unknown as AgentCardInfo;
+        const result = selectInitialAgent({ agents: [first, second], urlAgentName: "agent-uuid-2", embedded: true });
+
+        expect(result.agent).toBe(second);
+    });
+
+    test("does not resolve a ?agent= that matches only a displayName", () => {
+        const platform = { name: "agent-uuid-1", displayName: "Weather Agent" } as unknown as AgentCardInfo;
+        const result = selectInitialAgent({ agents: [platform], urlAgentName: "Weather Agent", embedded: true });
+
+        expect(result.agent).toBeNull();
+    });
+});
+
+describe("selectInitialAgent — priority order (full UI)", () => {
+    test("URL agent wins and the welcome bubble is seeded", () => {
+        const result = selectInitialAgent({ agents: [orchestrator, alpha], urlAgentName: "AlphaAgent", embedded: false });
+
+        expect(result.agent).toBe(alpha);
+        expect(result.shouldSeedWelcome).toBe(true);
+    });
+
+    test("falls back to priority order when the URL agent is unknown", () => {
+        const result = selectInitialAgent({ agents: [alpha, orchestrator], urlAgentName: "GhostAgent", embedded: false });
+
+        expect(result.agent).toBe(orchestrator);
+        expect(result.shouldSeedWelcome).toBe(true);
+    });
+
+    test("uses the project default agent when present", () => {
+        const result = selectInitialAgent({ agents: [orchestrator, alpha, beta], urlAgentName: null, embedded: false, projectDefaultAgentId: "BetaAgent" });
+
+        expect(result.agent).toBe(beta);
+    });
+
+    test("falls back to OrchestratorAgent when the project default is missing", () => {
+        const result = selectInitialAgent({ agents: [alpha, orchestrator], urlAgentName: null, embedded: false, projectDefaultAgentId: "GhostAgent" });
+
+        expect(result.agent).toBe(orchestrator);
+    });
+
+    test("prefers OrchestratorAgent over the first agent when no project default", () => {
+        const result = selectInitialAgent({ agents: [alpha, orchestrator], urlAgentName: null, embedded: false });
+
+        expect(result.agent).toBe(orchestrator);
+    });
+
+    test("falls back to the first agent when OrchestratorAgent is absent", () => {
+        const result = selectInitialAgent({ agents: [alpha, beta], urlAgentName: null, embedded: false });
+
+        expect(result.agent).toBe(alpha);
+    });
+});

--- a/src/solace_agent_mesh/gateway/http_sse/repository/session_repository.py
+++ b/src/solace_agent_mesh/gateway/http_sse/repository/session_repository.py
@@ -28,9 +28,9 @@ class SessionRepository(PaginatedRepository[SessionModel, Session], ISessionRepo
 
     def find_by_user(
         self, session: DBSession, user_id: UserId, pagination: PaginationParams | None = None,
-        project_id: str | None = None, source: str | None = None,
+        project_id: str | None = None, source: str | None = None, agent_id: str | None = None,
     ) -> list[Session]:
-        """Find all sessions for a specific user with optional project and source filtering."""
+        """Find all sessions for a specific user with optional project, source and agent filtering."""
         query = session.query(SessionModel).filter(
             SessionModel.user_id == user_id,
             SessionModel.deleted_at.is_(None)  # Exclude soft-deleted sessions
@@ -43,6 +43,10 @@ class SessionRepository(PaginatedRepository[SessionModel, Session], ISessionRepo
         # Optional source filtering (e.g., "chat" or "scheduler")
         if source is not None:
             query = query.filter(SessionModel.source == source)
+
+        # Optional agent filtering (e.g., embedded single-agent chat surface)
+        if agent_id is not None:
+            query = query.filter(SessionModel.agent_id == agent_id)
 
         # Eager load project relationship
         query = query.options(joinedload(SessionModel.project))
@@ -57,8 +61,8 @@ class SessionRepository(PaginatedRepository[SessionModel, Session], ISessionRepo
         return [Session.model_validate(model) for model in models]
 
     @MonitorLatency(DBMonitor.query("sessions"))
-    def count_by_user(self, session: DBSession, user_id: UserId, project_id: str | None = None, source: str | None = None) -> int:
-        """Count total sessions for a specific user with optional project and source filtering."""
+    def count_by_user(self, session: DBSession, user_id: UserId, project_id: str | None = None, source: str | None = None, agent_id: str | None = None) -> int:
+        """Count total sessions for a specific user with optional project, source and agent filtering."""
         query = session.query(SessionModel).filter(
             SessionModel.user_id == user_id,
             SessionModel.deleted_at.is_(None)  # Exclude soft-deleted sessions
@@ -71,6 +75,10 @@ class SessionRepository(PaginatedRepository[SessionModel, Session], ISessionRepo
         # Optional source filtering
         if source is not None:
             query = query.filter(SessionModel.source == source)
+
+        # Optional agent filtering (e.g., embedded single-agent chat surface)
+        if agent_id is not None:
+            query = query.filter(SessionModel.agent_id == agent_id)
 
         return query.count()
 
@@ -281,7 +289,8 @@ class SessionRepository(PaginatedRepository[SessionModel, Session], ISessionRepo
         user_id: UserId,
         query: str,
         pagination: PaginationParams | None = None,
-        project_id: str | None = None
+        project_id: str | None = None,
+        agent_id: str | None = None,
     ) -> list[Session]:
         """
         Search sessions by name/title only using ILIKE.
@@ -295,6 +304,10 @@ class SessionRepository(PaginatedRepository[SessionModel, Session], ISessionRepo
         # Optional project filtering
         if project_id is not None:
             base_query = base_query.filter(SessionModel.project_id == project_id)
+
+        # Optional agent filtering (embedded single-agent surface)
+        if agent_id is not None:
+            base_query = base_query.filter(SessionModel.agent_id == agent_id)
 
         # ILIKE search on session name
         search_pattern = f"%{query}%"
@@ -318,7 +331,8 @@ class SessionRepository(PaginatedRepository[SessionModel, Session], ISessionRepo
         db_session: DBSession,
         user_id: UserId,
         query: str,
-        project_id: str | None = None
+        project_id: str | None = None,
+        agent_id: str | None = None,
     ) -> int:
         """
         Count search results for pagination (title-only search).
@@ -331,6 +345,10 @@ class SessionRepository(PaginatedRepository[SessionModel, Session], ISessionRepo
 
         if project_id is not None:
             base_query = base_query.filter(SessionModel.project_id == project_id)
+
+        # Optional agent filtering (embedded single-agent surface)
+        if agent_id is not None:
+            base_query = base_query.filter(SessionModel.agent_id == agent_id)
 
         # ILIKE search on session name
         search_pattern = f"%{query}%"

--- a/src/solace_agent_mesh/gateway/http_sse/routers/sessions.py
+++ b/src/solace_agent_mesh/gateway/http_sse/routers/sessions.py
@@ -83,6 +83,7 @@ def _enrich_scheduler_sessions_with_task_info(db: Session, session_responses: li
 async def get_all_sessions(
     project_id: Optional[str] = Query(default=None, alias="project_id"),
     source: Optional[str] = Query(default=None, description="Filter by source: chat, scheduler, or omit for all"),
+    agent_id: Optional[str] = Query(default=None, alias="agent_id", description="Filter by agent (wire name); used by the embedded single-agent surface"),
     page_number: int = Query(default=1, ge=1, alias="pageNumber"),
     page_size: int = Query(default=20, ge=1, le=100, alias="pageSize"),
     db: Session = Depends(get_db),
@@ -116,11 +117,13 @@ async def get_all_sessions(
         log_msg += f" filtered by project_id={project_id}"
     if source:
         log_msg += f" filtered by source={source}"
+    if agent_id:
+        log_msg += f" filtered by agent_id={agent_id}"
     log.info(log_msg)
 
     try:
         pagination = PaginationParams(page_number=page_number, page_size=page_size)
-        paginated_response = session_service.get_user_sessions(db, user_id, pagination, project_id=project_id, source=source)
+        paginated_response = session_service.get_user_sessions(db, user_id, pagination, project_id=project_id, source=source, agent_id=agent_id)
 
         session_responses = []
         for session_domain in paginated_response.data:
@@ -155,6 +158,7 @@ async def get_all_sessions(
 async def search_sessions(
     query: str = Query(..., min_length=1, description="Search query"),
     project_id: Optional[str] = Query(default=None, alias="projectId"),
+    agent_id: Optional[str] = Query(default=None, alias="agent_id", description="Filter by agent (wire name); used by the embedded single-agent surface"),
     page_number: int = Query(default=1, ge=1, alias="pageNumber"),
     page_size: int = Query(default=20, ge=1, le=100, alias="pageSize"),
     db: Session = Depends(get_db),
@@ -176,7 +180,7 @@ async def search_sessions(
     try:
         pagination = PaginationParams(page_number=page_number, page_size=page_size)
         paginated_response = session_service.search_sessions(
-            db, user_id, query, pagination, project_id=project_id
+            db, user_id, query, pagination, project_id=project_id, agent_id=agent_id
         )
 
         session_responses = []

--- a/src/solace_agent_mesh/gateway/http_sse/services/session_service.py
+++ b/src/solace_agent_mesh/gateway/http_sse/services/session_service.py
@@ -101,6 +101,7 @@ class SessionService:
         pagination: PaginationParams | None = None,
         project_id: str | None = None,
         source: str | None = None,
+        agent_id: str | None = None,
     ) -> PaginatedResponse[Session]:
         """
         Get paginated sessions for a user with full metadata including project names and background task status.
@@ -113,6 +114,7 @@ class SessionService:
             pagination: Pagination parameters
             project_id: Optional project ID to filter sessions by (for project-specific views)
             source: Optional source filter ("chat", "scheduler", or None for all)
+            agent_id: Optional agent filter (wire name) for the embedded single-agent surface
         """
         if not user_id or user_id.strip() == "":
             raise ValueError("User ID cannot be empty")
@@ -120,9 +122,9 @@ class SessionService:
         pagination = get_pagination_or_default(pagination)
         session_repository = self._get_repositories(db)
 
-        # Fetch sessions with optional project and source filtering
-        sessions = session_repository.find_by_user(db, user_id, pagination, project_id=project_id, source=source)
-        total_count = session_repository.count_by_user(db, user_id, project_id=project_id, source=source)
+        # Fetch sessions with optional project, source and agent filtering
+        sessions = session_repository.find_by_user(db, user_id, pagination, project_id=project_id, source=source, agent_id=agent_id)
+        total_count = session_repository.count_by_user(db, user_id, project_id=project_id, source=source, agent_id=agent_id)
 
         # Enrich sessions with project names
         # Collect unique project IDs
@@ -425,7 +427,8 @@ class SessionService:
         user_id: UserId,
         query: str,
         pagination: PaginationParams | None = None,
-        project_id: str | None = None
+        project_id: str | None = None,
+        agent_id: str | None = None,
     ) -> PaginatedResponse[Session]:
         """
         Search sessions by name/title only.
@@ -450,8 +453,8 @@ class SessionService:
         session_repository = self._get_repositories(db)
 
         # Search sessions
-        sessions = session_repository.search(db, user_id, query.strip(), pagination, project_id)
-        total_count = session_repository.count_search_results(db, user_id, query.strip(), project_id)
+        sessions = session_repository.search(db, user_id, query.strip(), pagination, project_id, agent_id=agent_id)
+        total_count = session_repository.count_search_results(db, user_id, query.strip(), project_id, agent_id=agent_id)
 
         # Enrich sessions with project names
         project_ids = [s.project_id for s in sessions if s.project_id]

--- a/tests/unit/gateway/http_sse/repository/test_session_repository.py
+++ b/tests/unit/gateway/http_sse/repository/test_session_repository.py
@@ -99,3 +99,60 @@ class TestCountByUserSourceFilter:
         _seed_sessions(session)
         count = repo.count_by_user(session, USER_ID, source=None)
         assert count == 2
+
+
+# ---------------------------------------------------------------------------
+# agent_id filter tests (embedded single-agent surface)
+# ---------------------------------------------------------------------------
+
+def _seed_agent_sessions(session: DBSession):
+    """Insert chat sessions for USER_ID owned by different agents, plus one with no agent."""
+    session.add_all([
+        SessionModel(id="s-alpha", name="Alpha chat", user_id=USER_ID, source="chat", agent_id="AlphaAgent", created_time=1700000000000, updated_time=1700000000000),
+        SessionModel(id="s-beta", name="Beta chat", user_id=USER_ID, source="chat", agent_id="BetaAgent", created_time=1700000001000, updated_time=1700000001000),
+        SessionModel(id="s-none", name="No agent", user_id=USER_ID, source="chat", agent_id=None, created_time=1700000002000, updated_time=1700000002000),
+    ])
+    session.flush()
+
+
+class TestFindByUserAgentFilter:
+    def test_agent_filter_returns_only_that_agent(self, session, repo):
+        _seed_agent_sessions(session)
+        results = repo.find_by_user(session, USER_ID, agent_id="AlphaAgent")
+        assert [r.id for r in results] == ["s-alpha"]
+
+    def test_agent_filter_excludes_null_agent_sessions(self, session, repo):
+        _seed_agent_sessions(session)
+        results = repo.find_by_user(session, USER_ID, agent_id="BetaAgent")
+        assert {r.id for r in results} == {"s-beta"}
+
+    def test_agent_filter_none_returns_all(self, session, repo):
+        _seed_agent_sessions(session)
+        results = repo.find_by_user(session, USER_ID, agent_id=None)
+        assert len(results) == 3
+
+
+class TestCountByUserAgentFilter:
+    def test_count_agent_filter(self, session, repo):
+        _seed_agent_sessions(session)
+        assert repo.count_by_user(session, USER_ID, agent_id="AlphaAgent") == 1
+
+    def test_count_agent_none_returns_total(self, session, repo):
+        _seed_agent_sessions(session)
+        assert repo.count_by_user(session, USER_ID, agent_id=None) == 3
+
+
+class TestSearchAgentFilter:
+    def test_search_scoped_to_agent(self, session, repo):
+        _seed_agent_sessions(session)  # names: "Alpha chat", "Beta chat", "No agent"
+        results = repo.search(session, USER_ID, "chat", agent_id="AlphaAgent")
+        assert [r.id for r in results] == ["s-alpha"]
+
+    def test_search_without_agent_matches_all(self, session, repo):
+        _seed_agent_sessions(session)
+        results = repo.search(session, USER_ID, "chat")
+        assert {r.id for r in results} == {"s-alpha", "s-beta"}
+
+    def test_count_search_scoped_to_agent(self, session, repo):
+        _seed_agent_sessions(session)
+        assert repo.count_search_results(session, USER_ID, "chat", agent_id="BetaAgent") == 1

--- a/tests/unit/gateway/http_sse/routers/test_sessions_source_filter.py
+++ b/tests/unit/gateway/http_sse/routers/test_sessions_source_filter.py
@@ -134,3 +134,98 @@ class TestGetAllSessionsSourceFilter:
 
         assert result is not None
         mock_session_service.get_user_sessions.assert_called_once()
+
+
+class TestSessionsAgentFilter:
+    """The embedded surface scopes sessions to one agent via the `agent_id` query param.
+
+    These verify the param threads from the router into the service (the repo-level
+    filter is covered in test_session_repository.py). The FE sends snake_case
+    `agent_id`; these lock the router->service forwarding so that contract can't drift
+    silently.
+    """
+
+    @pytest.fixture
+    def mock_db(self):
+        return MagicMock()
+
+    @pytest.fixture
+    def mock_user(self):
+        return {"id": "test-user-id"}
+
+    @pytest.fixture
+    def mock_session_service(self):
+        service = MagicMock()
+        paginated = MagicMock()
+        paginated.data = []
+        paginated.meta = Meta(
+            pagination=PaginationMeta(
+                page_number=1, count=0, page_size=20, next_page=None, total_pages=0
+            )
+        )
+        service.get_user_sessions.return_value = paginated
+        service.search_sessions.return_value = paginated
+        return service
+
+    @pytest.mark.asyncio
+    async def test_get_all_sessions_forwards_agent_id(
+        self, mock_db, mock_session_service, mock_user
+    ):
+        from solace_agent_mesh.gateway.http_sse.routers.sessions import get_all_sessions
+
+        await get_all_sessions(
+            project_id=None,
+            source=None,
+            agent_id="WeatherAgent",
+            page_number=1,
+            page_size=20,
+            db=mock_db,
+            user=mock_user,
+            session_service=mock_session_service,
+            user_config={},
+            config_resolver=MagicMock(),
+        )
+
+        mock_session_service.get_user_sessions.assert_called_once()
+        assert mock_session_service.get_user_sessions.call_args.kwargs["agent_id"] == "WeatherAgent"
+
+    @pytest.mark.asyncio
+    async def test_get_all_sessions_agent_id_none_forwarded(
+        self, mock_db, mock_session_service, mock_user
+    ):
+        from solace_agent_mesh.gateway.http_sse.routers.sessions import get_all_sessions
+
+        await get_all_sessions(
+            project_id=None,
+            source=None,
+            agent_id=None,
+            page_number=1,
+            page_size=20,
+            db=mock_db,
+            user=mock_user,
+            session_service=mock_session_service,
+            user_config={},
+            config_resolver=MagicMock(),
+        )
+
+        assert mock_session_service.get_user_sessions.call_args.kwargs["agent_id"] is None
+
+    @pytest.mark.asyncio
+    async def test_search_sessions_forwards_agent_id(
+        self, mock_db, mock_session_service, mock_user
+    ):
+        from solace_agent_mesh.gateway.http_sse.routers.sessions import search_sessions
+
+        await search_sessions(
+            query="report",
+            project_id=None,
+            agent_id="WeatherAgent",
+            page_number=1,
+            page_size=20,
+            db=mock_db,
+            user=mock_user,
+            session_service=mock_session_service,
+        )
+
+        mock_session_service.search_sessions.assert_called_once()
+        assert mock_session_service.search_sessions.call_args.kwargs["agent_id"] == "WeatherAgent"


### PR DESCRIPTION
### What is the purpose of this change?
Adds an embedded chat surface — a focused, chat-only rendering of the SAM web UI locked to a single agent, intended for embedding SAM chat inside a host surface (e.g. a Teams tab / iframe). It's activated by dedicated hash routes (/#/embed/chat?agent=<wireName> and /#/embed/recent-chats?agent=…): the global navigation, agent selector, prompt library, and activity/workflow chrome are hidden, the chat is pinned to the agent named in ?agent=, and recent-chats/search/session-history are scoped to that agent.

### How was this change implemented?
Single source of truth for "which chrome to show." Instead of threading a boolean through every component, a typed ChatSurface capabilities struct is computed once at load from the route and consumed via a hook — components read intent (showActivityPanel, showAgentSelector, showRecentChatsPanel, pinnedAgent, sessionActions, …), never the mode itself.

lib/contexts/ChatSurfaceContext.ts, lib/providers/ChatSurfaceProvider.tsx, lib/hooks/useChatSurface.ts — the struct, a read-once provider (mounted high, never persisted), and the hook. Defaults to the full surface so nothing needs the provider to behave normally.
Activation: router.tsx adds /embed/chat and /embed/recent-chats (both reuse the existing ChatPage/RecentChatsPage); the provider keys off any /embed/* path so it's refresh-safe.
Consumers read capabilities — AppLayout (hides both nav variants), ChatInputArea (no agent selector / prompts; send-guard until the pinned agent resolves), ChatSidePanel + ChatMessage + InlineProgressUpdates (hide Activity/workflow), SessionActionMenu (allow-list), ChatProvider (pins to the captured agent so navigation can't silently re-route).

Embedded UX — a header toggle (left of New Chat) opens a dark RecentChatsSidePanel (Recent Chats + View All + User Account); a centered hero / connecting / "agent unavailable" / "no agent specified" state machine; useChatRoute() keeps all in-app navigation on /embed/chat?agent=… so the surface survives back/forward and refresh.

Agent-scoped history (backend). Sessions are already attributed via SessionModel.agent_id (the agent wire name). Added an agent_id filter through session_repository (find_by_user/count_by_user/search/count_search_results), session_service, and the /sessions + /sessions/search routers, threaded from the FE (getRecentSessions/getPaginatedSessions/SessionSearch). Embedded recent-chats and search are scoped to the pinned agent.

Login round-trip — stash/consumePostLoginRedirect preserve the embedded URL (incl. ?agent=) across the IdP redirect.

Covered by unit tests (capabilities computation, nav gating, agent pinning, the recent-chats drawer, session-key scoping) and backend repository tests for the agent_id filter.

### Key Design Decisions
Capabilities struct over a threaded agentMode boolean. A prior approach scattered if (agentMode) checks across ~7 components, which left gaps (e.g. the new-navigation sidebar wasn't hidden). One struct read as named intent closes those gaps and makes the surface a single, testable seam.
Route-based activation, read once. Deriving the surface from a dedicated /embed/* route (not a sticky/persisted flag and not server config) makes it refresh-safe and prevents an admin on the same origin from inheriting a sticky embedded mode; reading it once keeps the pinned agent stable even if in-app navigation drops the query string.
UI-only lock, but agent-scoped data is enforced server-side. The single-agent "lock" is a UI affordance (not a security boundary); however, recent-chats/search scoping uses a real server-side agent_id filter (mirroring the existing project_id/source filters) rather than client-side filtering, so pagination stays correct.
?agent= is required in embedded mode — a missing/unknown agent shows an explicit error state rather than silently falling back to a default, since the selector is hidden.

### How was this change tested?

- [x] Manual testing: [describe scenarios]
- [x] Unit tests: [new/modified tests]
- [ ] Integration tests: [if applicable]
- [ ] Known limitations: [what wasn't tested]

### Is there anything the reviewers should focus on/be aware of?

Demo posted here: https://solacedotcom.slack.com/archives/C0B71G76VKR/p1780333488835559
