### PR TITLE
feat: Rename embedded chat surface route from /embed to /agent-mode

### DIFF
--- a/client/webui/frontend/src/AppLayout.tsx
+++ b/client/webui/frontend/src/AppLayout.tsx
@@ -100,7 +100,7 @@ function AppLayoutContent() {
 
     const getActiveItem = () => {
         const path = location.pathname;
-        if (path === "/" || path.startsWith("/chat") || path.startsWith("/embed/chat") || path.startsWith("/recent-chats")) return "chat";
+        if (path === "/" || path.startsWith("/chat") || path.startsWith("/agent-mode/chat") || path.startsWith("/recent-chats")) return "chat";
         if (path.startsWith("/projects")) return "projects";
         if (path.startsWith("/artifacts")) return "artifacts";
         if (path.startsWith("/prompts")) return "prompts";
@@ -152,7 +152,7 @@ function AppLayoutContent() {
 
     return (
         <div className={`relative flex h-screen`}>
-            {/* Keeps the embedded surface locked to /embed/* (redirects any drift back). No-op in full UI. */}
+            {/* Keeps the embedded surface locked to /agent-mode/* (redirects any drift back). No-op in full UI. */}
             <EmbeddedRouteGuard />
             {/* surface.showNav gates BOTH nav variants, so the embedded surface is chat-only
                 (no sidebar) regardless of the new_navigation flag. */}

--- a/client/webui/frontend/src/lib/components/chat/RecentChatsSidePanel.tsx
+++ b/client/webui/frontend/src/lib/components/chat/RecentChatsSidePanel.tsx
@@ -17,7 +17,7 @@ export const RecentChatsSidePanel: React.FC = () => {
     const { pinnedAgent } = useChatSurface();
     const [isSettingsOpen, setIsSettingsOpen] = useState(false);
 
-    const viewAllTo = pinnedAgent ? `/embed/recent-chats?agent=${encodeURIComponent(pinnedAgent)}` : "/embed/recent-chats";
+    const viewAllTo = pinnedAgent ? `/agent-mode/recent-chats?agent=${encodeURIComponent(pinnedAgent)}` : "/agent-mode/recent-chats";
 
     return (
         <div className="flex h-full w-100 flex-col border-r border-(--darkSurface-border) bg-(--darkSurface-bg)">

--- a/client/webui/frontend/src/lib/components/chat/useChatAttachments.ts
+++ b/client/webui/frontend/src/lib/components/chat/useChatAttachments.ts
@@ -79,7 +79,7 @@ export interface UseChatAttachmentsResult {
  * `restoreFromCapture`.
  */
 export function useChatAttachments({ addNotification, displayError, handleSwitchSession, navigate }: UseChatAttachmentsOptions): UseChatAttachmentsResult {
-    // Embedded-aware chat route so "Go to Chat" keeps the /embed/chat?agent= URL.
+    // Embedded-aware chat route so "Go to Chat" keeps the /agent-mode/chat?agent= URL.
     const chatRoute = useChatRoute();
     const [selectedFiles, setSelectedFiles] = useState<File[]>([]);
     const [selectedArtifactRefs, setSelectedArtifactRefs] = useState<ArtifactWithSession[]>([]);

--- a/client/webui/frontend/src/lib/components/navigation/EmbeddedRouteGuard.tsx
+++ b/client/webui/frontend/src/lib/components/navigation/EmbeddedRouteGuard.tsx
@@ -4,9 +4,9 @@ import { useLocation, useNavigate } from "react-router-dom";
 import { useChatSurface } from "@/lib/hooks";
 
 /**
- * Keeps the embedded surface "locked" to the `/embed/*` routes. If an in-app navigation
- * drifts off the embed routes — or lands on an embed route that dropped the pinned `?agent=`
- * — it redirects back to `/embed/chat?agent=<pinned>`. This is a backstop for any link or
+ * Keeps the embedded surface "locked" to the `/agent-mode/*` routes. If an in-app navigation
+ * drifts off the agent-mode routes — or lands on an agent-mode route that dropped the pinned `?agent=`
+ * — it redirects back to `/agent-mode/chat?agent=<pinned>`. This is a backstop for any link or
  * `navigate(...)` not already routed through `useChatRoute()`; it does NOT affect full-page
  * navigations (e.g. the IdP login round-trip), which reload and re-derive the surface.
  *
@@ -20,13 +20,13 @@ export const EmbeddedRouteGuard = () => {
     useEffect(() => {
         if (surface.variant !== "embedded") return;
 
-        const offEmbed = !location.pathname.startsWith("/embed/");
+        const offEmbed = !location.pathname.startsWith("/agent-mode/");
         // Only enforce agent presence when there's a pinned agent to re-append — otherwise a
-        // genuine no-agent embed (`/embed/chat` with no ?agent=) would redirect to itself forever.
+        // genuine no-agent embed (`/agent-mode/chat` with no ?agent=) would redirect to itself forever.
         const lostAgent = !!surface.pinnedAgent && !new URLSearchParams(location.search).get("agent");
 
         if (offEmbed || lostAgent) {
-            const target = surface.pinnedAgent ? `/embed/chat?agent=${encodeURIComponent(surface.pinnedAgent)}` : "/embed/chat";
+            const target = surface.pinnedAgent ? `/agent-mode/chat?agent=${encodeURIComponent(surface.pinnedAgent)}` : "/agent-mode/chat";
             console.warn("Embedded surface: blocked navigation off the embedded route, returning to", target);
             navigate(target, { replace: true });
         }

--- a/client/webui/frontend/src/lib/components/pages/RecentChatsPage.tsx
+++ b/client/webui/frontend/src/lib/components/pages/RecentChatsPage.tsx
@@ -98,7 +98,7 @@ export const RecentChatsPage: React.FC = () => {
     const { generateTitle } = useTitleGeneration();
     const chatSharingEnabled = useIsChatSharingEnabled();
     const newNavigationEnabled = useIsNewNavigationEnabled();
-    // Embedded "View All": agent-scoped, trimmed chrome, and navigations stay on /embed/chat.
+    // Embedded "View All": agent-scoped, trimmed chrome, and navigations stay on /agent-mode/chat.
     const surface = useChatSurface();
     const isEmbedded = surface.variant === "embedded";
     const chatRoute = useChatRoute();

--- a/client/webui/frontend/src/lib/contexts/ChatSurfaceContext.ts
+++ b/client/webui/frontend/src/lib/contexts/ChatSurfaceContext.ts
@@ -13,9 +13,9 @@ export type SessionAction = "goToProject" | "rename" | "renameWithAI" | "move" |
  * Components read *intent* (e.g. `showActivityPanel`) rather than the activation
  * mechanism, so suppression decisions live here in one struct instead of being
  * threaded as scattered `if (embedded)` checks. The activation mechanism (today the
- * `/embed/*` routes) can change without touching consumers.
+ * `/agent-mode/*` routes) can change without touching consumers.
  *
- * Derived once at load from the hash route (`/#/embed/chat?agent=Foo`), never
+ * Derived once at load from the hash route (`/#/agent-mode/chat?agent=Foo`), never
  * persisted, and deliberately NOT part of server config — so an admin on the same
  * origin can't inherit a sticky embedded surface.
  */

--- a/client/webui/frontend/src/lib/hooks/useChatRoute.ts
+++ b/client/webui/frontend/src/lib/hooks/useChatRoute.ts
@@ -2,11 +2,11 @@ import { useChatSurface } from "./useChatSurface";
 
 /**
  * The route to navigate to when opening a chat. In the embedded surface this stays on
- * `/embed/chat?agent=<pinned>` so the URL keeps the embedded route + pinned agent (survives
+ * `/agent-mode/chat?agent=<pinned>` so the URL keeps the embedded route + pinned agent (survives
  * a refresh and back/forward); in the full UI it's the normal `/chat`.
  */
 export function useChatRoute(): string {
     const surface = useChatSurface();
     if (surface.variant !== "embedded") return "/chat";
-    return surface.pinnedAgent ? `/embed/chat?agent=${encodeURIComponent(surface.pinnedAgent)}` : "/embed/chat";
+    return surface.pinnedAgent ? `/agent-mode/chat?agent=${encodeURIComponent(surface.pinnedAgent)}` : "/agent-mode/chat";
 }

--- a/client/webui/frontend/src/lib/providers/ChatSurfaceProvider.tsx
+++ b/client/webui/frontend/src/lib/providers/ChatSurfaceProvider.tsx
@@ -5,14 +5,14 @@ import { getHashPath, getHashQueryParams } from "@/lib/utils/url";
 
 const EMBEDDED_SESSION_ACTIONS: ReadonlyArray<SessionAction> = ["rename", "renameWithAI", "delete"];
 
-/** Hash-route prefix for embedded surfaces (`/embed/chat`, `/embed/recent-chats`, …). */
-export const EMBEDDED_ROUTE_PREFIX = "/embed/";
+/** Hash-route prefix for embedded surfaces (`/agent-mode/chat`, `/agent-mode/recent-chats`, …). */
+export const EMBEDDED_ROUTE_PREFIX = "/agent-mode/";
 
 /**
  * Compute the chat surface once at load from the hash-route path. Read-once (no
  * full-UI flash, no later recompute), so the pinned agent is stable even if
- * in-app navigation later strips the hash query. Any `/embed/*` route is embedded,
- * so View All (`/embed/recent-chats`) stays embedded on direct load / refresh.
+ * in-app navigation later strips the hash query. Any `/agent-mode/*` route is embedded,
+ * so View All (`/agent-mode/recent-chats`) stays embedded on direct load / refresh.
  */
 function computeChatSurface(): ChatSurface {
     const embedded = getHashPath().startsWith(EMBEDDED_ROUTE_PREFIX);

--- a/client/webui/frontend/src/lib/utils/url.test.ts
+++ b/client/webui/frontend/src/lib/utils/url.test.ts
@@ -10,13 +10,13 @@ describe("getHashQueryParams", () => {
     });
 
     it("parses the query segment that follows the hash route", () => {
-        window.history.replaceState({}, "", "/#/embed/chat?agent=Foo");
+        window.history.replaceState({}, "", "/#/agent-mode/chat?agent=Foo");
         const params = getHashQueryParams();
         expect(params.get("agent")).toBe("Foo");
     });
 
     it("returns no params when the hash route carries no query", () => {
-        window.history.replaceState({}, "", "/#/embed/chat");
+        window.history.replaceState({}, "", "/#/agent-mode/chat");
         const params = getHashQueryParams();
         expect(params.get("agent")).toBeNull();
     });
@@ -24,7 +24,7 @@ describe("getHashQueryParams", () => {
     it("ignores a real query string before the hash (reads hash, not search)", () => {
         // Params in window.location.search (the rejected before-# form) must not be read —
         // the embedded surface's ?agent= travels with the hash route.
-        window.history.replaceState({}, "", "/?agent=Foo#/embed/chat");
+        window.history.replaceState({}, "", "/?agent=Foo#/agent-mode/chat");
         expect(window.location.search).toBe("?agent=Foo"); // precondition
         expect(getHashQueryParams().get("agent")).toBeNull();
     });
@@ -36,8 +36,8 @@ describe("getHashPath", () => {
     });
 
     it("returns the route path without the leading # or query segment", () => {
-        window.history.replaceState({}, "", "/#/embed/chat?agent=Foo");
-        expect(getHashPath()).toBe("/embed/chat");
+        window.history.replaceState({}, "", "/#/agent-mode/chat?agent=Foo");
+        expect(getHashPath()).toBe("/agent-mode/chat");
     });
 
     it("returns the path when there is no query", () => {
@@ -58,16 +58,16 @@ describe("post-login redirect stash/restore", () => {
     });
 
     it("stashes the current URL and restores it once", () => {
-        window.history.replaceState({}, "", "/#/embed/chat?agent=Foo");
+        window.history.replaceState({}, "", "/#/agent-mode/chat?agent=Foo");
         stashPostLoginRedirect();
-        expect(localStorage.getItem(POST_LOGIN_REDIRECT_KEY)).toContain("/embed/chat");
+        expect(localStorage.getItem(POST_LOGIN_REDIRECT_KEY)).toContain("/agent-mode/chat");
 
         const restored = consumePostLoginRedirect();
-        expect(restored).toContain("/#/embed/chat?agent=Foo");
+        expect(restored).toContain("/#/agent-mode/chat?agent=Foo");
     });
 
     it("is one-shot — the key is cleared after the first read", () => {
-        window.history.replaceState({}, "", "/#/embed/chat?agent=Foo");
+        window.history.replaceState({}, "", "/#/agent-mode/chat?agent=Foo");
         stashPostLoginRedirect();
 
         consumePostLoginRedirect();
@@ -81,7 +81,7 @@ describe("post-login redirect stash/restore", () => {
     });
 
     it("rejects a cross-origin stashed value (open-redirect guard)", () => {
-        localStorage.setItem(POST_LOGIN_REDIRECT_KEY, "https://evil.example.com/#/embed/chat?agent=Foo");
+        localStorage.setItem(POST_LOGIN_REDIRECT_KEY, "https://evil.example.com/#/agent-mode/chat?agent=Foo");
         expect(consumePostLoginRedirect()).toBe("/");
     });
 

--- a/client/webui/frontend/src/lib/utils/url.ts
+++ b/client/webui/frontend/src/lib/utils/url.ts
@@ -34,7 +34,7 @@ export function getFaviconUrl(domain: string, size: number = 32): string {
 
 /**
  * Embedded chat params live in the query segment of the hash route, after the
- * route path: `/#/embed/chat?agent=Foo`. We read them from window.location.hash
+ * route path: `/#/agent-mode/chat?agent=Foo`. We read them from window.location.hash
  * (not window.location.search) so the params travel with the hash route.
  * Synchronous + read-once-at-load, so no full-UI flash.
  */
@@ -46,7 +46,7 @@ export function getHashQueryParams(): URLSearchParams {
 
 /**
  * The route path inside the hash, without the leading "#" or any query segment.
- * `/#/embed/chat?agent=Foo` → `/embed/chat`. Used to detect the embedded surface
+ * `/#/agent-mode/chat?agent=Foo` → `/agent-mode/chat`. Used to detect the embedded surface
  * route synchronously at load (read-once, no flash).
  */
 export function getHashPath(): string {

--- a/client/webui/frontend/src/router.tsx
+++ b/client/webui/frontend/src/router.tsx
@@ -27,14 +27,14 @@ export const createRouter = () => {
                 },
                 {
                     // Embedded, chat-only single-agent surface (?agent=Foo). Reuses ChatPage;
-                    // ChatSurfaceProvider keys the embedded layout off the /embed/* route path.
-                    path: "embed/chat",
+                    // ChatSurfaceProvider keys the embedded layout off the /agent-mode/* route path.
+                    path: "agent-mode/chat",
                     element: <ChatPage />,
                 },
                 {
                     // Embedded "View All" — agent-scoped recent chats. Reuses RecentChatsPage,
                     // which trims its chrome and scopes to ?agent= when the surface is embedded.
-                    path: "embed/recent-chats",
+                    path: "agent-mode/recent-chats",
                     element: <RecentChatsPage />,
                 },
                 {

--- a/client/webui/frontend/src/stories/chat/ChatPage.stories.tsx
+++ b/client/webui/frontend/src/stories/chat/ChatPage.stories.tsx
@@ -454,7 +454,7 @@ export const CollaborativeChat: Story = {
     },
 };
 
-// The embedded, single-agent surface (`/embed/chat?agent=…`): pinned to one agent
+// The embedded, single-agent surface (`/agent-mode/chat?agent=…`): pinned to one agent
 const EMBEDDED_SURFACE: ChatSurface = {
     ...FULL_CHAT_SURFACE,
     variant: "embedded",

--- a/client/webui/frontend/src/stories/navigation/EmbeddedRouteGuard.test.tsx
+++ b/client/webui/frontend/src/stories/navigation/EmbeddedRouteGuard.test.tsx
@@ -32,24 +32,24 @@ describe("EmbeddedRouteGuard", () => {
     beforeEach(() => vi.spyOn(console, "warn").mockImplementation(() => {}));
     afterEach(() => vi.restoreAllMocks());
 
-    test("redirects an off-embed route back to /embed/chat with the pinned agent", async () => {
+    test("redirects an off-embed route back to /agent-mode/chat with the pinned agent", async () => {
         renderAt("/projects", EMBEDDED);
-        await waitFor(() => expect(screen.getByTestId("loc")).toHaveTextContent("/embed/chat?agent=WeatherAgent"));
+        await waitFor(() => expect(screen.getByTestId("loc")).toHaveTextContent("/agent-mode/chat?agent=WeatherAgent"));
     });
 
     test("re-appends a dropped ?agent= on an embed route", async () => {
-        renderAt("/embed/chat", EMBEDDED);
-        await waitFor(() => expect(screen.getByTestId("loc")).toHaveTextContent("/embed/chat?agent=WeatherAgent"));
+        renderAt("/agent-mode/chat", EMBEDDED);
+        await waitFor(() => expect(screen.getByTestId("loc")).toHaveTextContent("/agent-mode/chat?agent=WeatherAgent"));
     });
 
     test("leaves a valid embed route (with agent) untouched", () => {
-        renderAt("/embed/recent-chats?agent=WeatherAgent", EMBEDDED);
-        expect(screen.getByTestId("loc")).toHaveTextContent("/embed/recent-chats?agent=WeatherAgent");
+        renderAt("/agent-mode/recent-chats?agent=WeatherAgent", EMBEDDED);
+        expect(screen.getByTestId("loc")).toHaveTextContent("/agent-mode/recent-chats?agent=WeatherAgent");
     });
 
-    test("no-agent embed does not loop on /embed/chat", () => {
-        renderAt("/embed/chat", EMBEDDED_NO_AGENT);
-        expect(screen.getByTestId("loc")).toHaveTextContent("/embed/chat");
+    test("no-agent embed does not loop on /agent-mode/chat", () => {
+        renderAt("/agent-mode/chat", EMBEDDED_NO_AGENT);
+        expect(screen.getByTestId("loc")).toHaveTextContent("/agent-mode/chat");
     });
 
     test("full surface never redirects (no-op off embed)", () => {

--- a/client/webui/frontend/src/stories/providers/ChatSurfaceProvider.test.tsx
+++ b/client/webui/frontend/src/stories/providers/ChatSurfaceProvider.test.tsx
@@ -47,8 +47,8 @@ describe("ChatSurfaceProvider", () => {
         expect(surface.seedWelcomeBubble).toBe(true);
     });
 
-    test("computes an embedded surface from the /embed/chat route and captures the pinned agent", () => {
-        window.history.replaceState({}, "", "/#/embed/chat?agent=WeatherAgent");
+    test("computes an embedded surface from the /agent-mode/chat route and captures the pinned agent", () => {
+        window.history.replaceState({}, "", "/#/agent-mode/chat?agent=WeatherAgent");
         render(
             <ChatSurfaceProvider>
                 <SurfaceProbe />
@@ -66,8 +66,8 @@ describe("ChatSurfaceProvider", () => {
         expect(surface.sessionActions).toEqual(["rename", "renameWithAI", "delete"]);
     });
 
-    test("treats the /embed/recent-chats route as embedded too (View All stays embedded)", () => {
-        window.history.replaceState({}, "", "/#/embed/recent-chats?agent=WeatherAgent");
+    test("treats the /agent-mode/recent-chats route as embedded too (View All stays embedded)", () => {
+        window.history.replaceState({}, "", "/#/agent-mode/recent-chats?agent=WeatherAgent");
         render(
             <ChatSurfaceProvider>
                 <SurfaceProbe />
@@ -81,7 +81,7 @@ describe("ChatSurfaceProvider", () => {
 
     test("keeps the pinned agent stable after the hash query is later stripped (issue #3)", () => {
         // Embedded tab pins to WeatherAgent...
-        window.history.replaceState({}, "", "/#/embed/chat?agent=WeatherAgent");
+        window.history.replaceState({}, "", "/#/agent-mode/chat?agent=WeatherAgent");
         render(
             <ChatSurfaceProvider>
                 <SurfaceProbe />


### PR DESCRIPTION
### What is the purpose of this change?

Per product owner feedback, rename the embedded chat surface URL prefix from `/embed/` to `/agent-mode/`, so the entry point is now:

- `https://<host>/#/agent-mode/chat?agent=MermaidAgent` (was `/#/embed/chat?agent=MermaidAgent`)
- `https://<host>/#/agent-mode/recent-chats?agent=MermaidAgent` (was `/#/embed/recent-chats?agent=MermaidAgent`)

### How was this change implemented?

URL-only rename — the internal "embedded" surface concept and component/variable names (`ChatSurface.variant === "embedded"`, `EmbeddedRouteGuard`, `EMBEDDED_ROUTE_PREFIX`, etc.) are unchanged.

Updated:
- `router.tsx`: route paths `embed/chat` → `agent-mode/chat`, `embed/recent-chats` → `agent-mode/recent-chats`
- `ChatSurfaceProvider.tsx`: `EMBEDDED_ROUTE_PREFIX = "/embed/"` → `"/agent-mode/"` (the value the surface detector keys off)
- `EmbeddedRouteGuard.tsx`: redirect target + drift check use `/agent-mode/*`
- `useChatRoute.ts` and `RecentChatsSidePanel.tsx`: links/navigations point at the new prefix
- `AppLayout.tsx`: nav-active check matches `/agent-mode/chat`
- Corresponding tests, comments, and JSDoc updated

A follow-up PR in `solace-agent-mesh-enterprise` mirrors the route-path change for the enterprise webui shell.

### How was this change tested?

- [x] Unit/Storybook tests: `url.test.ts`, `ChatSurfaceProvider.test.tsx`, `EmbeddedRouteGuard.test.tsx` all pass under the new prefix
- [x] Ran the full unit test suite — only pre-existing, locale-related failure in `userFormatting.test.ts` (unrelated)
- [x] `npm run lint` — no new errors
- [ ] Manual: open `/#/agent-mode/chat?agent=<agent>` and `/#/agent-mode/recent-chats?agent=<agent>` once deployed to verify embedded chrome / drift-guard

### Is there anything the reviewers should focus on/be aware of?

- No backwards-compatibility shim: hitting the old `/#/embed/chat?agent=…` URL now falls through the catch-all and lands on `/chat` (full UI). If consumers have bookmarked the old URL, we'll need a separate redirect.
- The internal name "embedded" is intentionally kept; only the URL is product-facing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)