### PR TITLE
fix(DATAGO-140833): backfill agent id for chat sessions starting with artifact uploads

### DIFF
--- a/src/solace_agent_mesh/gateway/http_sse/repository/interfaces.py
+++ b/src/solace_agent_mesh/gateway/http_sse/repository/interfaces.py
@@ -61,6 +61,17 @@ class ISessionRepository(ABC):
         pass
 
     @abstractmethod
+    def update_agent(
+        self, session: DBSession, session_id: SessionId, user_id: UserId, agent_id: str
+    ) -> bool:
+        """Backfill the agent_id for a session created without one.
+
+        Only updates rows whose agent_id is currently NULL. Returns True if a
+        row was updated, False otherwise.
+        """
+        pass
+
+    @abstractmethod
     def search(
         self,
         session: DBSession,

--- a/src/solace_agent_mesh/gateway/http_sse/repository/session_repository.py
+++ b/src/solace_agent_mesh/gateway/http_sse/repository/session_repository.py
@@ -283,6 +283,39 @@ class SessionRepository(PaginatedRepository[SessionModel, Session], ISessionRepo
 
         return Session.model_validate(session_model)
 
+    def update_agent(
+        self, db_session: DBSession, session_id: SessionId, user_id: UserId, agent_id: str
+    ) -> bool:
+        """Backfill the agent_id for a session created without one.
+
+        Sessions created via the file-upload-before-first-message and fork
+        paths are persisted with agent_id=None, to be filled in when the first
+        message is sent. This sets that agent_id, but only for rows where it is
+        currently NULL so an agent already chosen is never overwritten (keeping
+        the operation idempotent and race-safe via the SQL ``agent_id IS NULL``
+        guard).
+
+        Uses a raw UPDATE -- like ``mark_viewed`` -- so the ORM's
+        ``onupdate=now_epoch_ms`` hook does not fire: this is a pure metadata
+        backfill, not user activity, so ``updated_time`` is deliberately left
+        unchanged (the message flow advances it separately via
+        ``save_task`` -> ``mark_activity``).
+
+        Returns True if a row was updated, False otherwise (session not found,
+        not owned by the user, soft-deleted, or already had an agent).
+        """
+        with MonitorLatency(DBMonitor.update(self.table_name)):
+            stmt = text(
+                "UPDATE sessions "
+                "SET agent_id = :agent_id "
+                "WHERE id = :sid AND user_id = :uid "
+                "AND deleted_at IS NULL AND agent_id IS NULL"
+            )
+            result = db_session.execute(
+                stmt, {"agent_id": agent_id, "sid": session_id, "uid": user_id}
+            )
+        return result.rowcount > 0
+
     def search(
         self,
         db_session: DBSession,

--- a/src/solace_agent_mesh/gateway/http_sse/routers/tasks.py
+++ b/src/solace_agent_mesh/gateway/http_sse/routers/tasks.py
@@ -677,6 +677,21 @@ async def _submit_task(
                             log_prefix,
                             session_id,
                         )
+                    elif not existing_session.agent_id:
+                        # Backfill agent_id for sessions created without one
+                        # (file-upload-before-first-message and fork paths defer
+                        # it until the first message is sent). Without this they
+                        # stay NULL and are excluded from agent-scoped filters.
+                        backfilled = session_service.update_session_agent(
+                            db, session_id, user_id, agent_name
+                        )
+                        db.commit()
+                        if backfilled:
+                            log.info(
+                                "%sBackfilled agent_id for session: %s",
+                                log_prefix,
+                                session_id,
+                            )
                 except Exception as e:
                     db.rollback()
                     log.warning(

--- a/src/solace_agent_mesh/gateway/http_sse/services/session_service.py
+++ b/src/solace_agent_mesh/gateway/http_sse/services/session_service.py
@@ -222,6 +222,32 @@ class SessionService:
         log.info("Updated session %s name to '%s'", session_id, name)
         return updated_session
 
+    def update_session_agent(
+        self, db: DbSession, session_id: SessionId, user_id: UserId, agent_id: str
+    ) -> bool:
+        """Backfill the agent for a session that was created without one.
+
+        Sessions created via the file-upload-before-first-message and fork
+        paths are persisted with agent_id=None, to be filled in when the first
+        message is sent. This sets that agent_id but never overwrites an agent
+        that is already set.
+
+        Returns True if the session's agent_id was backfilled, False otherwise
+        (session missing, not owned by the user, or already had an agent).
+        """
+        if not self._is_valid_session_id(session_id):
+            raise ValueError("Invalid session ID")
+
+        if not agent_id or agent_id.strip() == "":
+            raise ValueError("Agent ID cannot be empty")
+
+        session_repository = self._get_repositories(db)
+        updated = session_repository.update_agent(db, session_id, user_id, agent_id)
+
+        if updated:
+            log.info("Backfilled agent_id '%s' for session %s", agent_id, session_id)
+        return updated
+
     def mark_session_viewed(
         self, db: DbSession, session_id: SessionId, user_id: UserId
     ) -> int | None:

--- a/tests/integration/apis/persistence/test_session_agent_backfill.py
+++ b/tests/integration/apis/persistence/test_session_agent_backfill.py
@@ -1,0 +1,127 @@
+"""Database tests for SessionRepository.update_agent (agent_id backfill).
+
+Exercises the real backfill data path used when the first message arrives for a
+session that was created without an agent (the file-upload-before-first-message
+and fork paths persist ``agent_id=None``).
+"""
+
+import uuid
+
+from solace_agent_mesh.gateway.http_sse.repository.models import SessionModel
+from solace_agent_mesh.gateway.http_sse.repository.session_repository import (
+    SessionRepository,
+)
+
+
+def _insert_session(db_session, *, agent_id, user_id, deleted_at=None, updated_time=1000):
+    """Insert a session row directly and return its id."""
+    session_id = str(uuid.uuid4())
+    db_session.add(
+        SessionModel(
+            id=session_id,
+            name=None,
+            user_id=user_id,
+            agent_id=agent_id,
+            created_time=1000,
+            updated_time=updated_time,
+            deleted_at=deleted_at,
+        )
+    )
+    db_session.commit()
+    return session_id
+
+
+def test_update_agent_backfills_when_null(db_session_factory):
+    """A NULL agent_id is set, the call reports success, and updated_time is left alone."""
+    db_session = db_session_factory()
+    try:
+        user_id = f"user-{uuid.uuid4()}"
+        session_id = _insert_session(
+            db_session, agent_id=None, user_id=user_id, updated_time=1000
+        )
+
+        repo = SessionRepository()
+        updated = repo.update_agent(db_session, session_id, user_id, "TestAgent")
+        db_session.commit()
+
+        assert updated is True
+
+        row = db_session.query(SessionModel).filter_by(id=session_id).first()
+        assert row.agent_id == "TestAgent"
+        # Pure metadata backfill: updated_time must NOT be bumped.
+        assert row.updated_time == 1000
+    finally:
+        db_session.close()
+
+
+def test_update_agent_does_not_overwrite_existing_agent(db_session_factory):
+    """A session that already has an agent is left untouched and reports no update."""
+    db_session = db_session_factory()
+    try:
+        user_id = f"user-{uuid.uuid4()}"
+        session_id = _insert_session(
+            db_session, agent_id="OriginalAgent", user_id=user_id
+        )
+
+        repo = SessionRepository()
+        updated = repo.update_agent(db_session, session_id, user_id, "OtherAgent")
+        db_session.commit()
+
+        assert updated is False
+        row = db_session.query(SessionModel).filter_by(id=session_id).first()
+        assert row.agent_id == "OriginalAgent"
+    finally:
+        db_session.close()
+
+
+def test_update_agent_returns_false_for_unknown_session(db_session_factory):
+    """No matching session -> no update."""
+    db_session = db_session_factory()
+    try:
+        repo = SessionRepository()
+        updated = repo.update_agent(
+            db_session, str(uuid.uuid4()), f"user-{uuid.uuid4()}", "TestAgent"
+        )
+        assert updated is False
+    finally:
+        db_session.close()
+
+
+def test_update_agent_ignores_wrong_user(db_session_factory):
+    """A session owned by another user is not backfilled."""
+    db_session = db_session_factory()
+    try:
+        owner_id = f"user-{uuid.uuid4()}"
+        session_id = _insert_session(db_session, agent_id=None, user_id=owner_id)
+
+        repo = SessionRepository()
+        updated = repo.update_agent(
+            db_session, session_id, f"other-{uuid.uuid4()}", "TestAgent"
+        )
+        db_session.commit()
+
+        assert updated is False
+        row = db_session.query(SessionModel).filter_by(id=session_id).first()
+        assert row.agent_id is None
+    finally:
+        db_session.close()
+
+
+def test_update_agent_ignores_soft_deleted_session(db_session_factory):
+    """A soft-deleted session is not backfilled."""
+    db_session = db_session_factory()
+    try:
+        user_id = f"user-{uuid.uuid4()}"
+        session_id = _insert_session(
+            db_session, agent_id=None, user_id=user_id, deleted_at=2000
+        )
+
+        repo = SessionRepository()
+        updated = repo.update_agent(db_session, session_id, user_id, "TestAgent")
+        db_session.commit()
+
+        assert updated is False
+        row = db_session.query(SessionModel).filter_by(id=session_id).first()
+        assert row.agent_id is None
+    finally:
+        db_session.close()

--- a/tests/unit/services/test_session_service_update_agent.py
+++ b/tests/unit/services/test_session_service_update_agent.py
@@ -1,0 +1,79 @@
+"""Unit tests for SessionService.update_session_agent method."""
+
+import pytest
+from unittest.mock import Mock, patch
+from solace_agent_mesh.gateway.http_sse.services.session_service import SessionService
+
+
+class TestSessionServiceUpdateAgent:
+    """Test the update_session_agent backfill method."""
+
+    def setup_method(self):
+        """Set up test fixtures."""
+        self.mock_component = Mock()
+        self.service = SessionService(component=self.mock_component)
+        self.mock_db = Mock()
+        self.session_id = "test-session-123"
+        self.user_id = "user-123"
+        self.agent_id = "TestAgent"
+
+    def test_backfills_agent_and_delegates_to_repository(self):
+        """Backfill delegates to the repo with the right args and returns True."""
+        mock_repository = Mock()
+        mock_repository.update_agent.return_value = True
+
+        with patch.object(self.service, "_get_repositories", return_value=mock_repository):
+            result = self.service.update_session_agent(
+                db=self.mock_db,
+                session_id=self.session_id,
+                user_id=self.user_id,
+                agent_id=self.agent_id,
+            )
+
+        mock_repository.update_agent.assert_called_once_with(
+            self.mock_db, self.session_id, self.user_id, self.agent_id
+        )
+        assert result is True
+
+    def test_returns_false_when_no_row_updated(self):
+        """When the repo updates no row (missing or already had agent), returns False."""
+        mock_repository = Mock()
+        mock_repository.update_agent.return_value = False
+
+        with patch.object(self.service, "_get_repositories", return_value=mock_repository):
+            result = self.service.update_session_agent(
+                db=self.mock_db,
+                session_id=self.session_id,
+                user_id=self.user_id,
+                agent_id=self.agent_id,
+            )
+
+        assert result is False
+
+    @pytest.mark.parametrize("invalid_session_id", [None, "", "   ", "null", "undefined"])
+    def test_raises_on_invalid_session_id(self, invalid_session_id):
+        """Invalid session IDs are rejected before touching the repository."""
+        mock_repository = Mock()
+        with patch.object(self.service, "_get_repositories", return_value=mock_repository):
+            with pytest.raises(ValueError, match="Invalid session ID"):
+                self.service.update_session_agent(
+                    db=self.mock_db,
+                    session_id=invalid_session_id,
+                    user_id=self.user_id,
+                    agent_id=self.agent_id,
+                )
+        mock_repository.update_agent.assert_not_called()
+
+    @pytest.mark.parametrize("invalid_agent_id", [None, "", "   "])
+    def test_raises_on_empty_agent_id(self, invalid_agent_id):
+        """Empty agent IDs are rejected before touching the repository."""
+        mock_repository = Mock()
+        with patch.object(self.service, "_get_repositories", return_value=mock_repository):
+            with pytest.raises(ValueError, match="Agent ID cannot be empty"):
+                self.service.update_session_agent(
+                    db=self.mock_db,
+                    session_id=self.session_id,
+                    user_id=self.user_id,
+                    agent_id=invalid_agent_id,
+                )
+        mock_repository.update_agent.assert_not_called()


### PR DESCRIPTION
## Problem
A chat session's agent_id was only written when the session row is first created. Two creation paths intentionally defer it as agent_id=NULL, expecting it to be filled in when the first message is sent — but that backfill was never implemented:

File upload before first message — routers/artifacts.py creates the session with agent_id=None (the agent isn't known to the server yet).
Forking a shared chat — services/share_service.py creates the session with no agent.
When the first message later arrived for an existing session, routers/tasks.py only set agent_id on its create branch — so these rows stayed NULL forever.

**Impact:** with agent-scoped session filtering, NULL-agent_id sessions are silently excluded from recent-chats lists and search filters (SQL agent_id = :agent never matches NULL).

Repro

1. Start a brand-new chat, attach/upload a file before sending any message.
2. Send a message.
3. Session's agent_id is still NULL in the DB → session missing from agent-scoped lists.

## Fix
Backfill on first message: when a message is sent to an existing session whose agent_id is falsy, set it to the message's agent_name.

SessionRepository.update_agent(...) — raw SQL UPDATE sessions SET agent_id WHERE id AND user_id AND deleted_at IS NULL AND agent_id IS NULL, returns whether a row was updated. Raw SQL (mirroring the existing mark_viewed) is deliberate: SessionModel.updated_time has onupdate=now_epoch_ms, and this is a pure metadata backfill that must not bump updated_time / reorder recent-chats. The agent_id IS NULL guard makes it idempotent and race-safe, and never overwrites an agent already set.
SessionService.update_session_agent(...) — validates the session id and non-empty agent id, delegates, logs.
routers/tasks.py — existing-session branch now backfills agent_id when it's missing, inside the pre-existing try/except/finally. Best-effort: a failure is logged and does not block message send.

**Tests**
tests/unit/services/test_session_service_update_agent.py — delegation, false-on-no-update, validation guards.
tests/integration/apis/persistence/test_session_agent_backfill.py — real-DB cases: backfill-when-NULL (asserts updated_time unchanged), no-overwrite-existing, unknown session, wrong user, soft-deleted.
Note: integration tests are parameterized over sqlite + postgres; the postgres variants require Docker (testcontainers). All sqlite variants pass locally; run the postgres variants in CI.

**Notes / out of scope**
Existing rows already sitting NULL in the DB are not retroactively backfilled — this fixes new sessions going forward. A one-time migration can be added separately if needed.
Considered setting agent_id at creation time instead; rejected because the file-upload path's agent can be empty or change before the first message is sent, so the first message remains the authoritative source.