### PR TITLE
fix(DATAGO-138846): bump pyjwt, react-router-dom, @remix-run/*, openssl to clear CVEs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -78,6 +78,7 @@ RUN echo "deb http://deb.debian.org/debian unstable main" > /etc/apt/sources.lis
     libsqlite3-0=3.46.1-7+deb13u1 \
     libssl3t64=3.5.5-1~deb13u2 \
     libvpx9=1.15.0-2.1+deb13u1 \
+    openssl-provider-legacy=3.5.5-1~deb13u2 \
     openssl=3.5.5-1~deb13u2 && \
     curl -LsSf https://astral.sh/uv/install.sh | sh && \
     mv /root/.local/bin/uv /usr/local/bin/uv && \
@@ -178,6 +179,7 @@ RUN echo "deb http://deb.debian.org/debian unstable main" > /etc/apt/sources.lis
     libsqlite3-0=3.46.1-7+deb13u1 \
     libssl3t64=3.5.5-1~deb13u2 \
     libvpx9=1.15.0-2.1+deb13u1 \
+    openssl-provider-legacy=3.5.5-1~deb13u2 \
     openssl=3.5.5-1~deb13u2 && \
     if [ "${INSTALL_LIBREOFFICE}" = "true" ]; then \
         echo "============================================================" && \

--- a/client/webui/frontend/package-lock.json
+++ b/client/webui/frontend/package-lock.json
@@ -43,7 +43,7 @@
                 "react-json-view-lite": "^2.4.1",
                 "react-pdf": "9.2.1",
                 "react-resizable-panels": "^3.0.3",
-                "react-router-dom": "7.12.0",
+                "react-router-dom": "7.15.0",
                 "tailwind-merge": "^3.3.0",
                 "tailwind-scrollbar-hide": "^4.0.0",
                 "tailwindcss": "^4.1.17",
@@ -119,7 +119,7 @@
                 "@types/react-dom": "19.0.0",
                 "react": "19.0.0",
                 "react-dom": "19.0.0",
-                "react-router-dom": "7.12.0"
+                "react-router-dom": "7.15.0"
             }
         },
         "node_modules/@a2a-js/sdk": {
@@ -11652,9 +11652,9 @@
             }
         },
         "node_modules/react-router": {
-            "version": "7.12.0",
-            "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.12.0.tgz",
-            "integrity": "sha512-kTPDYPFzDVGIIGNLS5VJykK0HfHLY5MF3b+xj0/tTyNYL1gF1qs7u67Z9jEhQk2sQ98SUaHxlG31g1JtF7IfVw==",
+            "version": "7.15.0",
+            "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.15.0.tgz",
+            "integrity": "sha512-HW9vYwuM8f4yx66Izy8xfrzCM+SBJluoZcCbww9A1TySax11S5Vgw6fi3ZjMONw9J4gQwngL7PzkyIpJJpJ7RQ==",
             "license": "MIT",
             "dependencies": {
                 "cookie": "^1.0.1",
@@ -11674,12 +11674,12 @@
             }
         },
         "node_modules/react-router-dom": {
-            "version": "7.12.0",
-            "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.12.0.tgz",
-            "integrity": "sha512-pfO9fiBcpEfX4Tx+iTYKDtPbrSLLCbwJ5EqP+SPYQu1VYCXdy79GSj0wttR0U4cikVdlImZuEZ/9ZNCgoaxwBA==",
+            "version": "7.15.0",
+            "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.15.0.tgz",
+            "integrity": "sha512-VcrVg64Fo8nwBvDscajG8gRTLIuTC6N50nb22l2HOOV4PTOHgoGp8mUjy9wLiHYoYTSYI36tUnXZgasSRFZorQ==",
             "license": "MIT",
             "dependencies": {
-                "react-router": "7.12.0"
+                "react-router": "7.15.0"
             },
             "engines": {
                 "node": ">=20.0.0"

--- a/client/webui/frontend/package.json
+++ b/client/webui/frontend/package.json
@@ -101,7 +101,7 @@
         "react-json-view-lite": "^2.4.1",
         "react-pdf": "9.2.1",
         "react-resizable-panels": "^3.0.3",
-        "react-router-dom": "7.12.0",
+        "react-router-dom": "7.15.0",
         "tailwind-merge": "^3.3.0",
         "tailwind-scrollbar-hide": "^4.0.0",
         "tailwindcss": "^4.1.17",
@@ -116,7 +116,7 @@
         "@types/react-dom": "19.0.0",
         "react": "19.0.0",
         "react-dom": "19.0.0",
-        "react-router-dom": "7.12.0"
+        "react-router-dom": "7.15.0"
     },
     "devDependencies": {
         "@a2a-js/sdk": "^0.3.2",

--- a/config_portal/frontend/package-lock.json
+++ b/config_portal/frontend/package-lock.json
@@ -6,8 +6,8 @@
     "": {
       "name": "solace-agent-mesh-config-portal-frontend",
       "dependencies": {
-        "@remix-run/node": "2.17.4",
-        "@remix-run/react": "2.17.4",
+        "@remix-run/node": "2.17.5",
+        "@remix-run/react": "2.17.5",
         "isbot": "^4",
         "lucide-react": "^0.542.0",
         "react": "^18.2.0",
@@ -15,7 +15,7 @@
         "react-markdown": "^10.1.0"
       },
       "devDependencies": {
-        "@remix-run/dev": "2.17.4",
+        "@remix-run/dev": "2.17.5",
         "@types/react": "^18.2.20",
         "@types/react-dom": "^18.2.7",
         "@typescript-eslint/eslint-plugin": "^6.7.4",
@@ -1457,9 +1457,9 @@
       }
     },
     "node_modules/@remix-run/dev": {
-      "version": "2.17.4",
-      "resolved": "https://registry.npmjs.org/@remix-run/dev/-/dev-2.17.4.tgz",
-      "integrity": "sha512-El7r5W6ErX9KIy27+urbc4SIZnIlVDgTOUqzA7Zbv7caKYrsvgj/Z3i/LPy4VNfv0G1EdawPOrygJgIKT4r2FA==",
+      "version": "2.17.5",
+      "resolved": "https://registry.npmjs.org/@remix-run/dev/-/dev-2.17.5.tgz",
+      "integrity": "sha512-yEDrKcIICHnaJdUOdBAXQTNXoehB0J3FBcZr4CnK6Alic6cVJGGBGMtJdIO7DUwNySwoYvkUTS3qnXuk2zGYZA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1473,9 +1473,9 @@
         "@babel/types": "^7.22.5",
         "@mdx-js/mdx": "^2.3.0",
         "@npmcli/package-json": "^4.0.1",
-        "@remix-run/node": "2.17.4",
-        "@remix-run/router": "1.23.2",
-        "@remix-run/server-runtime": "2.17.4",
+        "@remix-run/node": "2.17.5",
+        "@remix-run/router": "1.23.3",
+        "@remix-run/server-runtime": "2.17.5",
         "@types/mdx": "^2.0.5",
         "@vanilla-extract/integration": "^6.2.0",
         "arg": "^5.0.1",
@@ -1549,12 +1549,12 @@
       }
     },
     "node_modules/@remix-run/node": {
-      "version": "2.17.4",
-      "resolved": "https://registry.npmjs.org/@remix-run/node/-/node-2.17.4.tgz",
-      "integrity": "sha512-9A29JaYiGHDEmaiQuD1IlO/TrQxnnkj98GpytihU+Nz6yTt6RwzzyMMqTAoasRd1dPD4OeSaSqbwkcim/eE76Q==",
+      "version": "2.17.5",
+      "resolved": "https://registry.npmjs.org/@remix-run/node/-/node-2.17.5.tgz",
+      "integrity": "sha512-CwOUCDJqh9o8r/n5N1l+vz4Jh7DFU52/jo7MN56+OL9gM+14aQKdq1aLAh+4V6GuI/qtki9PPk02GmULimmDkw==",
       "license": "MIT",
       "dependencies": {
-        "@remix-run/server-runtime": "2.17.4",
+        "@remix-run/server-runtime": "2.17.5",
         "@remix-run/web-fetch": "^4.4.2",
         "@web3-storage/multipart-parser": "^1.0.0",
         "cookie-signature": "^1.1.0",
@@ -1575,15 +1575,15 @@
       }
     },
     "node_modules/@remix-run/react": {
-      "version": "2.17.4",
-      "resolved": "https://registry.npmjs.org/@remix-run/react/-/react-2.17.4.tgz",
-      "integrity": "sha512-MeXHacIBoohr9jzec5j/Rmk57xk34korkPDDb0OPHgkdvh20lO5fJoSAcnZfjTIOH+Vsq1ZRQlmvG5PRQ/64Sw==",
+      "version": "2.17.5",
+      "resolved": "https://registry.npmjs.org/@remix-run/react/-/react-2.17.5.tgz",
+      "integrity": "sha512-ya6OQ+T9yS4u8www75f4dH11NIYeK8K0eMrei+q4BTp6NrY2lqLTBfHqVlc23ZsUnWqdLUII4hzySVv+AJbTWA==",
       "license": "MIT",
       "dependencies": {
-        "@remix-run/router": "1.23.2",
-        "@remix-run/server-runtime": "2.17.4",
-        "react-router": "6.30.3",
-        "react-router-dom": "6.30.3",
+        "@remix-run/router": "1.23.3",
+        "@remix-run/server-runtime": "2.17.5",
+        "react-router": "6.30.4",
+        "react-router-dom": "6.30.4",
         "turbo-stream": "2.4.1"
       },
       "engines": {
@@ -1601,21 +1601,21 @@
       }
     },
     "node_modules/@remix-run/router": {
-      "version": "1.23.2",
-      "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.23.2.tgz",
-      "integrity": "sha512-Ic6m2U/rMjTkhERIa/0ZtXJP17QUi2CbWE7cqx4J58M8aA3QTfW+2UlQ4psvTX9IO1RfNVhK3pcpdjej7L+t2w==",
+      "version": "1.23.3",
+      "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.23.3.tgz",
+      "integrity": "sha512-4An71tdz9X8+3sI4Qqqd2LWd9vS39J7sqd9EU4Scw7TJE/qB10Flv/UuqbPVgfQV9XoK8Np6jNquZitnZq5i+Q==",
       "license": "MIT",
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@remix-run/server-runtime": {
-      "version": "2.17.4",
-      "resolved": "https://registry.npmjs.org/@remix-run/server-runtime/-/server-runtime-2.17.4.tgz",
-      "integrity": "sha512-oCsFbPuISgh8KpPKsfBChzjcntvTz5L+ggq9VNYWX8RX3yA7OgQpKspRHOSxb05bw7m0Hx+L1KRHXjf3juKX8w==",
+      "version": "2.17.5",
+      "resolved": "https://registry.npmjs.org/@remix-run/server-runtime/-/server-runtime-2.17.5.tgz",
+      "integrity": "sha512-SyJ5n2pQyo4ERGvjjLvL2PpRWBzlC2qzO5KkkOE2ygOiNcgOu9WQnnom9GI8KgsTRCO8JnIeLHFRcmxZnVBjfw==",
       "license": "MIT",
       "dependencies": {
-        "@remix-run/router": "1.23.2",
+        "@remix-run/router": "1.23.3",
         "@types/cookie": "^0.6.0",
         "@web3-storage/multipart-parser": "^1.0.0",
         "cookie": "^0.7.2",
@@ -12617,12 +12617,12 @@
       }
     },
     "node_modules/react-router": {
-      "version": "6.30.3",
-      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.30.3.tgz",
-      "integrity": "sha512-XRnlbKMTmktBkjCLE8/XcZFlnHvr2Ltdr1eJX4idL55/9BbORzyZEaIkBFDhFGCEWBBItsVrDxwx3gnisMitdw==",
+      "version": "6.30.4",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.30.4.tgz",
+      "integrity": "sha512-SVUsDe+DybHM/WmYKIVYhZh1o5Dcuf16yM6WjG02Q9XVFMZIJyHYhwrr6bFBXZkVP6z69kNkMyBCujt8FaFLJA==",
       "license": "MIT",
       "dependencies": {
-        "@remix-run/router": "1.23.2"
+        "@remix-run/router": "1.23.3"
       },
       "engines": {
         "node": ">=14.0.0"
@@ -12632,13 +12632,13 @@
       }
     },
     "node_modules/react-router-dom": {
-      "version": "6.30.3",
-      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.30.3.tgz",
-      "integrity": "sha512-pxPcv1AczD4vso7G4Z3TKcvlxK7g7TNt3/FNGMhfqyntocvYKj+GCatfigGDjbLozC4baguJ0ReCigoDJXb0ag==",
+      "version": "6.30.4",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.30.4.tgz",
+      "integrity": "sha512-q4HvNl+mmDdkS0g+MqiBZNteQJCuimWoOyHMy4T/RQLAn9Z29+E91QXRaxOujeMl2HTzRSS0KFPd7lxX3PjV0Q==",
       "license": "MIT",
       "dependencies": {
-        "@remix-run/router": "1.23.2",
-        "react-router": "6.30.3"
+        "@remix-run/router": "1.23.3",
+        "react-router": "6.30.4"
       },
       "engines": {
         "node": ">=14.0.0"
@@ -14555,12 +14555,12 @@
       }
     },
     "node_modules/undici": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-8.0.0.tgz",
-      "integrity": "sha512-RGabV5g1ggSX5mU4k+B8BLWgb418gDbg0wAVFeiU00iOxtw4ufGsE6GFsuSd2uqOKooWSLf71JGapOFYpE8f+A==",
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.27.1.tgz",
+      "integrity": "sha512-UDdpiex+mzigiyrXrGbiUaF4HzTNhKbh2vRNFaTMzcqmLIPrZxaCtwo/1TMSuWoM1Xz3WiTo9KdgI3kRqYzJGg==",
       "license": "MIT",
       "engines": {
-        "node": ">=22.19.0"
+        "node": ">=20.18.1"
       }
     },
     "node_modules/undici-types": {

--- a/config_portal/frontend/package.json
+++ b/config_portal/frontend/package.json
@@ -11,8 +11,8 @@
     "typecheck": "tsc"
   },
   "dependencies": {
-    "@remix-run/node": "2.17.4",
-    "@remix-run/react": "2.17.4",
+    "@remix-run/node": "2.17.5",
+    "@remix-run/react": "2.17.5",
     "isbot": "^4",
     "lucide-react": "^0.542.0",
     "react": "^18.2.0",
@@ -20,7 +20,7 @@
     "react-markdown": "^10.1.0"
   },
   "devDependencies": {
-    "@remix-run/dev": "2.17.4",
+    "@remix-run/dev": "2.17.5",
     "@types/react": "^18.2.20",
     "@types/react-dom": "^18.2.7",
     "@typescript-eslint/eslint-plugin": "^6.7.4",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ dependencies = [
     "idna==3.15",  # [CVE-2026-45409] Security fix (transitive from httpx, requests)
     "jwcrypto==1.5.7",  # [CVE-2026-39373] Security fix
     "python-jwt==4.1.0",
-    "pyjwt>=2.12.0",  # [CVE-2026-32597] Security fix: validates the crit (Critical) Header Parameter in JWS tokens (transitive from a2a-sdk, msal)
+    "pyjwt>=2.13.0",  # [CVE-2026-48526] Security fix: rejects JWK JSON passed as an HMAC secret
     "asteval==1.0.6",
     "pystache==0.6.8",
     "python-liquid==2.2.0",  # [CVE-2026-45017] Security fix

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = ">=3.10.16, <3.14"
 resolution-markers = [
     "python_full_version >= '3.13' and sys_platform == 'win32'",
@@ -3879,14 +3879,14 @@ wheels = [
 
 [[package]]
 name = "pyjwt"
-version = "2.12.1"
+version = "2.13.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "typing-extensions", marker = "python_full_version < '3.11'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/c2/27/a3b6e5bf6ff856d2509292e95c8f57f0df7017cf5394921fc4e4ef40308a/pyjwt-2.12.1.tar.gz", hash = "sha256:c74a7a2adf861c04d002db713dd85f84beb242228e671280bf709d765b03672b", size = 102564, upload-time = "2026-03-13T19:27:37.25Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/3b/81/58d0ac84e1ef3a3843791d6954d94c0b33d526c75eeb1efbce9d0a4c4077/pyjwt-2.13.0.tar.gz", hash = "sha256:41571c89ca91598c79e8ef18a2d07367d4810fbbd6f637794879baf1b7703423", size = 107515, upload-time = "2026-05-21T19:54:36.618Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e5/7a/8dd906bd22e79e47397a61742927f6747fe93242ef86645ee9092e610244/pyjwt-2.12.1-py3-none-any.whl", hash = "sha256:28ca37c070cad8ba8cd9790cd940535d40274d22f80ab87f3ac6a713e6e8454c", size = 29726, upload-time = "2026-03-13T19:27:35.677Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/5e/ecf12fdb62546d64385c158514e9b2b671f7832108ef2ecd2020ce0af2d1/pyjwt-2.13.0-py3-none-any.whl", hash = "sha256:66adcc2aff09b3f1bbd95fc1e1577df8ac8723c978552fd43304c8a290ac5728", size = 31274, upload-time = "2026-05-21T19:54:35.362Z" },
 ]
 
 [package.optional-dependencies]
@@ -4855,7 +4855,7 @@ requires-dist = [
     { name = "pyasn1", specifier = ">=0.6.3" },
     { name = "pydantic", specifier = "==2.12.5" },
     { name = "pydub", specifier = "==0.25.1" },
-    { name = "pyjwt", specifier = ">=2.12.0" },
+    { name = "pyjwt", specifier = ">=2.13.0" },
     { name = "pymysql", marker = "extra == 'test'", specifier = ">=1.1.0" },
     { name = "pypdf", specifier = "==6.10.2" },
     { name = "pystache", specifier = "==0.6.8" },


### PR DESCRIPTION
### What is the purpose of this change?

https://sol-jira.atlassian.net/browse/DATAGO-138846 - pyjwt
https://sol-jira.atlassian.net/browse/DATAGO-137908 - openssl
(could not find tickets for react router or remix)

Clears 5 BLOCKING FOSSA CVEs and 7 Prisma openssl CVEs flagged against SAM community (`solace-agent-mesh`):

| Package | CVE(s) | Severity | Source | Current → Fix |
|---|---|---|---|---|
| `pyjwt` | CVE-2026-48526 | HIGH (BLOCKING) | FOSSA | `>=2.12.0` → `>=2.13.0` |
| `react-router-dom` | CVE-2026-42211, CVE-2026-33245, CVE-2026-42342 | HIGH (BLOCKING) | FOSSA | `7.12.0` → `7.15.0` |
| `@remix-run/server-runtime` (transitive via `@remix-run/{node,react,dev}`) | CVE-2026-42342 | HIGH (BLOCKING) | FOSSA | `2.17.4` → `2.17.5` |
| `openssl-provider-legacy` | CVE-2026-31789 (crit), CVE-2026-28387/-28388/-28389/-28390/-31790 (high), CVE-2026-2673 (med) | CRIT/HIGH/MED (non-blocking) | Prisma | `3.5.4-1~deb13u2` → `3.5.5-1~deb13u2` |

CVE-2026-48526 in PyJWT allows a JWK passed as raw JSON to be accepted as an HMAC secret; fixed in 2.13.0.

The Prisma openssl CVEs were not cleared by the existing `openssl` + `libssl3t64` pins because `openssl-provider-legacy` is a separate binary package from the same Debian openssl source — apt won't upgrade it just because its siblings did.

### How was this change implemented?

- `pyproject.toml` — bumped `pyjwt` constraint to `>=2.13.0` and updated the inline CVE comment.
- `client/webui/frontend/package.json` — bumped `react-router-dom` in both `dependencies` and `peerDependencies`.
- `config_portal/frontend/package.json` — bumped `@remix-run/node`, `@remix-run/react`, and `@remix-run/dev` to 2.17.5; this resolves `@remix-run/server-runtime` to 2.17.5 transitively.
- `Dockerfile` — added explicit pin `openssl-provider-legacy=3.5.5-1~deb13u2` to both the builder and runtime apt-get install lists, alongside the existing `openssl` and `libssl3t64` pins.
- Lockfiles regenerated: `uv.lock`, `client/webui/frontend/package-lock.json`, `config_portal/frontend/package-lock.json`.

### Key Design Decisions

Pinned each package to the **CVE-fix minimum** (2.13.0 / 7.15.0 / 2.17.5 / 3.5.5-1~deb13u2) rather than latest stable, so the version number itself documents the security reason for the bump.

### How was this change tested?

- [ ] Manual testing: [describe scenarios]
- [ ] Unit tests: [new/modified tests]
- [ ] Integration tests: [if applicable]
- [ ] Known limitations: [what wasn't tested]

🤖 Generated with [Claude Code](https://claude.com/claude-code)