### PR TITLE
fix: normalize IPv4-mapped IPv6 addresses in SSRF protection

### DIFF
--- a/src/solace_agent_mesh/gateway/http_sse/services/scheduler/notification_service.py
+++ b/src/solace_agent_mesh/gateway/http_sse/services/scheduler/notification_service.py
@@ -52,6 +52,13 @@ _BROKER_TOPIC_PREFIX = "scheduled-tasks/"
 def _check_ip_blocked(ip_str: str) -> None:
     """Raise ValueError if the IP falls within a blocked network range."""
     ip = ipaddress.ip_address(ip_str)
+    # Normalize IPv4-mapped IPv6 addresses (e.g. ::ffff:127.0.0.1) to
+    # their embedded IPv4 address so they are matched by IPv4 blocked
+    # networks.  Without this, addresses like ::ffff:10.0.0.1 bypass
+    # the private-range check because an IPv6Address is not considered
+    # part of an IPv4 network.
+    if isinstance(ip, ipaddress.IPv6Address) and ip.ipv4_mapped is not None:
+        ip = ip.ipv4_mapped
     for network in _BLOCKED_IP_NETWORKS:
         if ip in network:
             raise ValueError(


### PR DESCRIPTION
## Problem

The webhook SSRF protection in `_check_ip_blocked()` can be bypassed using IPv4-mapped IPv6 address notation (e.g. `::ffff:127.0.0.1`).

Root cause: `ipaddress.ip_address("::ffff:127.0.0.1")` returns an `IPv6Address`, which is not considered part of the `127.0.0.0/8` IPv4 network. This allows bypassing all IPv4 blocked ranges.

## Fix

Normalize IPv4-mapped IPv6 addresses to their embedded IPv4 address before checking against blocked networks, using `IPv6Address.ipv4_mapped`. This handles all IPv4 ranges in a single check rather than maintaining a parallel list of `::ffff:` prefixed networks.

7 lines added, no behavior change for non-mapped addresses.

Fixes #1517