### PR TITLE
fix(artifacts): load per-session artifact metadata concurrently

### DIFF
--- a/src/solace_agent_mesh/agent/utils/artifact_helpers.py
+++ b/src/solace_agent_mesh/agent/utils/artifact_helpers.py
@@ -1102,7 +1102,6 @@ async def get_artifact_info_list(
         A list of ArtifactInfo objects.
     """
     log_prefix = f"[ArtifactHelper:get_info_list] App={app_name}, User={user_id}, Session={session_id} -"
-    artifact_info_list: List[ArtifactInfo] = []
 
     try:
         list_keys_method = getattr(artifact_service, "list_artifact_keys")
@@ -1113,18 +1112,29 @@ async def get_artifact_info_list(
             "%s Found %d artifact keys. Fetching details...", log_prefix, len(keys)
         )
 
-        for filename in keys:
-            if filename.endswith(METADATA_SUFFIX):
-                continue
+        artifact_filenames = [
+            filename for filename in keys if not filename.endswith(METADATA_SUFFIX)
+        ]
+        if not artifact_filenames:
+            return []
 
+        async def _load_single_info(filename: str) -> Optional[ArtifactInfo]:
+            """Load version count + latest metadata for one artifact.
+
+            Returns an ArtifactInfo on success, None to skip (file not found),
+            or a placeholder ArtifactInfo on unexpected error. Bounded by the
+            shared metadata-load semaphore so these run concurrently rather than
+            one-at-a-time — the previous serial loop issued 1 + 3N sequential S3
+            round-trips per session and starved the gateway worker pool.
+            """
             log_identifier_item = f"{log_prefix} [{filename}]"
             try:
-
+                # A single list_versions call yields both the count and the
+                # latest version, so the previously-separate
+                # get_latest_artifact_version() round-trip (which also listed
+                # versions) is dropped.
                 version_count: int = 0
-                latest_version_num: Optional[int] = await get_latest_artifact_version(
-                    artifact_service, app_name, user_id, session_id, filename
-                )
-
+                latest_version_num: Optional[int] = None
                 if hasattr(artifact_service, "list_versions"):
                     try:
                         available_versions = await artifact_service.list_versions(
@@ -1134,6 +1144,8 @@ async def get_artifact_info_list(
                             filename=filename,
                         )
                         version_count = len(available_versions)
+                        if available_versions:
+                            latest_version_num = max(available_versions)
                     except Exception as list_ver_err:
                         log.error(
                             "%s Error listing versions for count: %s.",
@@ -1141,65 +1153,36 @@ async def get_artifact_info_list(
                             list_ver_err,
                         )
 
-                data = await load_artifact_content_or_metadata(
-                    artifact_service=artifact_service,
+                async with _METADATA_LOAD_SEMAPHORE:
+                    data = await load_artifact_content_or_metadata(
+                        artifact_service=artifact_service,
+                        app_name=app_name,
+                        user_id=user_id,
+                        session_id=session_id,
+                        filename=filename,
+                        version="latest",
+                        load_metadata_only=True,
+                        log_identifier_prefix=log_identifier_item,
+                    )
+
+                info = _metadata_to_artifact_info(
+                    filename,
+                    data.get("metadata", {}),
+                    version=data.get("version", latest_version_num),
+                    version_count=version_count,
+                )
+                # Omit `?version=N` so the translator resolves "latest" at fetch
+                # time (same rationale as the fast path).
+                info.uri = _format_artifact_path_uri(
                     app_name=app_name,
                     user_id=user_id,
                     session_id=session_id,
                     filename=filename,
-                    version="latest",
-                    load_metadata_only=True,
-                    log_identifier_prefix=log_identifier_item,
-                )
-
-                metadata = data.get("metadata", {})
-                mime_type = metadata.get("mime_type", "application/data")
-                size = metadata.get("size_bytes", 0)
-                schema_definition = metadata.get("schema", {})
-                description = metadata.get("description", "No description provided")
-                loaded_version_num = data.get("version", latest_version_num)
-
-                last_modified_ts = metadata.get("timestamp_utc")
-                last_modified_ts = metadata.get("timestamp_utc")
-                last_modified_iso = (
-                    datetime.fromtimestamp(
-                        last_modified_ts, tz=timezone.utc
-                    ).isoformat()
-                    if last_modified_ts
-                    else None
-                )
-
-                # Extract source and tags from metadata
-                source = metadata.get("source")
-                tags = metadata.get("tags")
-                source_project_id = metadata.get("source_project_id")
-
-                artifact_info_list.append(
-                    ArtifactInfo(
-                        filename=filename,
-                        mime_type=mime_type,
-                        size=size,
-                        last_modified=last_modified_iso,
-                        schema_definition=schema_definition,
-                        description=description,
-                        version=loaded_version_num,
-                        version_count=version_count,
-                        source=source,
-                        tags=tags,
-                        source_project_id=source_project_id,
-                        # Same rationale as the fast path: omit `?version=N`
-                        # so the translator resolves "latest" at fetch time.
-                        uri=_format_artifact_path_uri(
-                            app_name=app_name,
-                            user_id=user_id,
-                            session_id=session_id,
-                            filename=filename,
-                        ),
-                    )
                 )
                 log.debug(
                     "%s Successfully processed artifact info.", log_identifier_item
                 )
+                return info
 
             except FileNotFoundError:
                 log.warning(
@@ -1207,6 +1190,7 @@ async def get_artifact_info_list(
                     log_prefix,
                     filename,
                 )
+                return None
             except Exception as detail_e:
                 log.error(
                     "%s Error processing details for artifact '%s': %s\n%s",
@@ -1215,14 +1199,30 @@ async def get_artifact_info_list(
                     detail_e,
                     traceback.format_exc(),
                 )
-                artifact_info_list.append(
-                    ArtifactInfo(
-                        filename=filename,
-                        size=0,
-                        description=f"Error loading details: {detail_e}",
-                        mime_type="application/octet-stream",
-                    )
+                return ArtifactInfo(
+                    filename=filename,
+                    size=0,
+                    description=f"Error loading details: {detail_e}",
+                    mime_type="application/octet-stream",
                 )
+
+        # gather preserves input order, so the returned list keeps key order.
+        results = await asyncio.gather(
+            *(_load_single_info(f) for f in artifact_filenames),
+            return_exceptions=True,
+        )
+
+        artifact_info_list: List[ArtifactInfo] = []
+        for result in results:
+            if isinstance(result, Exception):
+                log.warning(
+                    "%s Artifact info task failed with %s",
+                    log_prefix,
+                    type(result).__name__,
+                )
+                continue
+            if result is not None:
+                artifact_info_list.append(result)
 
     except Exception as e:
         log.exception(

--- a/src/solace_agent_mesh/agent/utils/artifact_helpers.py
+++ b/src/solace_agent_mesh/agent/utils/artifact_helpers.py
@@ -1129,31 +1129,36 @@ async def get_artifact_info_list(
             """
             log_identifier_item = f"{log_prefix} [{filename}]"
             try:
-                # A single list_versions call yields both the count and the
-                # latest version, so the previously-separate
-                # get_latest_artifact_version() round-trip (which also listed
-                # versions) is dropped.
-                version_count: int = 0
-                latest_version_num: Optional[int] = None
-                if hasattr(artifact_service, "list_versions"):
-                    try:
-                        available_versions = await artifact_service.list_versions(
-                            app_name=app_name,
-                            user_id=user_id,
-                            session_id=session_id,
-                            filename=filename,
-                        )
-                        version_count = len(available_versions)
-                        if available_versions:
-                            latest_version_num = max(available_versions)
-                    except Exception as list_ver_err:
-                        log.error(
-                            "%s Error listing versions for count: %s.",
-                            log_identifier_item,
-                            list_ver_err,
-                        )
-
+                # Hold one semaphore permit across BOTH S3 round-trips for this
+                # artifact (version listing + metadata load) so the per-session
+                # fan-out can't exceed the shared cap and exhaust the botocore
+                # connection pool — list_versions is an S3 listing too, not just
+                # the metadata GET.
                 async with _METADATA_LOAD_SEMAPHORE:
+                    # A single list_versions call yields both the count and the
+                    # latest version, so the previously-separate
+                    # get_latest_artifact_version() round-trip (which also listed
+                    # versions) is dropped.
+                    version_count: int = 0
+                    latest_version_num: Optional[int] = None
+                    if hasattr(artifact_service, "list_versions"):
+                        try:
+                            available_versions = await artifact_service.list_versions(
+                                app_name=app_name,
+                                user_id=user_id,
+                                session_id=session_id,
+                                filename=filename,
+                            )
+                            version_count = len(available_versions)
+                            if available_versions:
+                                latest_version_num = max(available_versions)
+                        except Exception as list_ver_err:
+                            log.error(
+                                "%s Error listing versions for count: %s.",
+                                log_identifier_item,
+                                list_ver_err,
+                            )
+
                     data = await load_artifact_content_or_metadata(
                         artifact_service=artifact_service,
                         app_name=app_name,

--- a/tests/unit/agent/utils/test_artifact_helpers.py
+++ b/tests/unit/agent/utils/test_artifact_helpers.py
@@ -28,6 +28,7 @@ from solace_agent_mesh.agent.utils.artifact_helpers import (
     decode_and_get_bytes,
     get_latest_artifact_version,
     get_artifact_counts_batch,
+    get_artifact_info_list,
     get_artifact_info_list_fast,
     load_artifact_content_or_metadata,
     DEFAULT_SCHEMA_MAX_KEYS,
@@ -1799,3 +1800,138 @@ class TestGetArtifactInfoListFast:
             )
 
         assert mock_load.call_args.kwargs["version"] == "latest"
+
+
+# ---------------------------------------------------------------------------
+# get_artifact_info_list (per-session list — now parallel)
+# ---------------------------------------------------------------------------
+
+class TestGetArtifactInfoList:
+    """Tests for the per-session artifact listing after the serial->parallel fix.
+
+    Same response shape as before (incl. version + version_count); the change is
+    that per-artifact metadata loads run concurrently and the redundant
+    get_latest_artifact_version() round-trip is dropped.
+    """
+
+    @pytest.fixture
+    def mock_service(self):
+        svc = AsyncMock(spec=BaseArtifactService)
+        svc.list_artifact_keys = AsyncMock(return_value=[])
+        svc.list_versions = AsyncMock(return_value=[0])
+        return svc
+
+    @pytest.mark.asyncio
+    async def test_empty_session(self, mock_service):
+        mock_service.list_artifact_keys.return_value = []
+        result = await get_artifact_info_list(
+            artifact_service=mock_service, app_name="app", user_id="user", session_id="sess"
+        )
+        assert result == []
+
+    @pytest.mark.asyncio
+    async def test_preserves_version_and_count_and_filters_metadata(self, mock_service):
+        """version_count comes from list_versions; version from the loaded metadata.
+        Metadata sidecar keys are excluded."""
+        mock_service.list_artifact_keys.return_value = [
+            "report.csv",
+            "report.csv.metadata.json",
+        ]
+        mock_service.list_versions.return_value = [0, 1, 2]
+        with patch(
+            "solace_agent_mesh.agent.utils.artifact_helpers.load_artifact_content_or_metadata",
+            new_callable=AsyncMock,
+        ) as mock_load:
+            mock_load.return_value = {
+                "metadata": {"mime_type": "text/csv", "size_bytes": 100},
+                "version": 2,
+            }
+            result = await get_artifact_info_list(
+                artifact_service=mock_service, app_name="app", user_id="user", session_id="sess"
+            )
+        assert len(result) == 1
+        assert result[0].filename == "report.csv"
+        assert result[0].mime_type == "text/csv"
+        assert result[0].version == 2
+        assert result[0].version_count == 3
+
+    @pytest.mark.asyncio
+    async def test_parallel_loading_preserves_order(self, mock_service):
+        """All artifacts load (concurrently) and key order is preserved."""
+        mock_service.list_artifact_keys.return_value = ["a.txt", "b.csv", "c.json"]
+        with patch(
+            "solace_agent_mesh.agent.utils.artifact_helpers.load_artifact_content_or_metadata",
+            new_callable=AsyncMock,
+        ) as mock_load:
+            mock_load.return_value = {
+                "metadata": {"mime_type": "text/plain", "size_bytes": 50},
+                "version": 0,
+            }
+            result = await get_artifact_info_list(
+                artifact_service=mock_service, app_name="app", user_id="user", session_id="sess"
+            )
+        assert [r.filename for r in result] == ["a.txt", "b.csv", "c.json"]
+        assert mock_load.call_count == 3
+
+    @pytest.mark.asyncio
+    async def test_redundant_latest_version_call_dropped(self, mock_service):
+        """The old per-artifact get_latest_artifact_version() round-trip is gone;
+        the latest version is derived from the single list_versions call."""
+        mock_service.list_artifact_keys.return_value = ["a.txt"]
+        mock_service.list_versions.return_value = [0, 1]
+        with patch(
+            "solace_agent_mesh.agent.utils.artifact_helpers.load_artifact_content_or_metadata",
+            new_callable=AsyncMock,
+        ) as mock_load, patch(
+            "solace_agent_mesh.agent.utils.artifact_helpers.get_latest_artifact_version",
+            new_callable=AsyncMock,
+        ) as mock_latest:
+            mock_load.return_value = {"metadata": {"mime_type": "text/plain"}, "version": 1}
+            result = await get_artifact_info_list(
+                artifact_service=mock_service, app_name="app", user_id="user", session_id="sess"
+            )
+        mock_latest.assert_not_called()
+        assert result[0].version == 1
+
+    @pytest.mark.asyncio
+    async def test_partial_failure_returns_placeholder(self, mock_service):
+        """One artifact failing yields an error placeholder; others still succeed."""
+        mock_service.list_artifact_keys.return_value = ["good.txt", "bad.txt"]
+
+        async def _side_effect(**kwargs):
+            if kwargs.get("filename") == "bad.txt":
+                raise RuntimeError("storage error")
+            return {"metadata": {"mime_type": "text/plain", "size_bytes": 10}, "version": 0}
+
+        with patch(
+            "solace_agent_mesh.agent.utils.artifact_helpers.load_artifact_content_or_metadata",
+            new_callable=AsyncMock,
+            side_effect=_side_effect,
+        ):
+            result = await get_artifact_info_list(
+                artifact_service=mock_service, app_name="app", user_id="user", session_id="sess"
+            )
+        assert {r.filename for r in result} == {"good.txt", "bad.txt"}
+        bad = next(r for r in result if r.filename == "bad.txt")
+        assert "Error" in bad.description
+
+    @pytest.mark.asyncio
+    async def test_file_not_found_skipped(self, mock_service):
+        mock_service.list_artifact_keys.return_value = ["gone.txt"]
+        with patch(
+            "solace_agent_mesh.agent.utils.artifact_helpers.load_artifact_content_or_metadata",
+            new_callable=AsyncMock,
+            side_effect=FileNotFoundError("not found"),
+        ):
+            result = await get_artifact_info_list(
+                artifact_service=mock_service, app_name="app", user_id="user", session_id="sess"
+            )
+        assert result == []
+
+    @pytest.mark.asyncio
+    async def test_list_keys_failure_returns_empty(self, mock_service):
+        mock_service.list_artifact_keys.side_effect = RuntimeError("S3 down")
+        result = await get_artifact_info_list(
+            artifact_service=mock_service, app_name="app", user_id="user", session_id="sess"
+        )
+        assert result == []

--- a/tests/unit/agent/utils/test_artifact_helpers.py
+++ b/tests/unit/agent/utils/test_artifact_helpers.py
@@ -1935,3 +1935,48 @@ class TestGetArtifactInfoList:
             artifact_service=mock_service, app_name="app", user_id="user", session_id="sess"
         )
         assert result == []
+
+    @pytest.mark.asyncio
+    async def test_list_versions_failure_is_nonfatal(self, mock_service):
+        """If list_versions raises, the artifact still resolves with
+        version_count=0 and the version sourced from the loaded metadata."""
+        mock_service.list_artifact_keys.return_value = ["a.txt"]
+        mock_service.list_versions.side_effect = RuntimeError("listing failed")
+        with patch(
+            "solace_agent_mesh.agent.utils.artifact_helpers.load_artifact_content_or_metadata",
+            new_callable=AsyncMock,
+        ) as mock_load:
+            mock_load.return_value = {
+                "metadata": {"mime_type": "text/plain", "size_bytes": 5},
+                "version": 4,
+            }
+            result = await get_artifact_info_list(
+                artifact_service=mock_service, app_name="app", user_id="user", session_id="sess"
+            )
+        assert len(result) == 1
+        assert result[0].filename == "a.txt"
+        assert result[0].version_count == 0
+        assert result[0].version == 4
+
+    @pytest.mark.asyncio
+    async def test_service_without_list_versions(self):
+        """A service lacking list_versions still lists: version_count stays 0
+        and the version comes from the loaded metadata (parity with the
+        original serial implementation)."""
+        # spec restricted to just list_artifact_keys → hasattr(list_versions) is False.
+        svc = AsyncMock(spec=["list_artifact_keys"])
+        svc.list_artifact_keys = AsyncMock(return_value=["a.txt"])
+        with patch(
+            "solace_agent_mesh.agent.utils.artifact_helpers.load_artifact_content_or_metadata",
+            new_callable=AsyncMock,
+        ) as mock_load:
+            mock_load.return_value = {
+                "metadata": {"mime_type": "text/plain", "size_bytes": 5},
+                "version": 0,
+            }
+            result = await get_artifact_info_list(
+                artifact_service=svc, app_name="app", user_id="user", session_id="sess"
+            )
+        assert len(result) == 1
+        assert result[0].version_count == 0
+        assert result[0].version == 0


### PR DESCRIPTION
## Problem

In **solace-chat prod** the WebUI degrades to a crawl whenever real concurrency climbs above ~15–20 users (observed twice this week). Investigation:

- Every DB-backed endpoint was slow — `/api/v1/sessions` took **17–51s** even though its SQL runs in **~3ms** (measured directly against the DB). `/artifacts/all` took **70–113s**.
- The DB server, Aurora, and downstream agents were all healthy (no locks, `ClientRead` waits, no failover). CPU/memory on the gateway pod were not saturated.
- Root cause is app-side **pool starvation**: `get_artifact_info_list` fetches each artifact's version list + metadata with **1 + 3N sequential** awaited storage round-trips. On the WebUI gateway (sync handlers on a bounded worker pool, each holding a DB connection via the request-scoped session), a few concurrent `/artifacts/*` requests on sessions with many artifacts take tens of seconds **while holding a worker thread and a DB connection**, exhausting both pools. Unrelated endpoints then queue, and the long idle-in-transaction connections get reaped by the server → `psycopg2 ... SSL connection has been closed unexpectedly` → HTTP 503, in bursts that line up with concurrency spikes.
- A pod restart only relieves it for minutes (re-saturates under load).

## Fix

Make the per-session listing load metadata **concurrently** instead of one-at-a-time, mirroring the existing `get_artifact_info_list_fast` (used by the `/all` endpoint):

- Fan out the per-artifact work with `asyncio.gather`, bounded by the existing shared `_METADATA_LOAD_SEMAPHORE`.
- Derive the latest version from the single `list_versions()` call instead of an extra `get_latest_artifact_version()` round-trip.
- Net: **1 + 3N sequential → ~1 + 2N concurrent.** A 50-artifact session drops from seconds of serial S3 I/O to ≈ one artifact's latency, which removes the thread/DB-pool starvation that was making *all* endpoints slow.

The `ArtifactInfo` response shape (`version`, `version_count`, `uri`, `source`, `tags`, `schema_definition`, …) and key ordering are **unchanged** — unlike the fast path, this retains `version`/`version_count` that the per-session UI needs.

## Tests

- New `TestGetArtifactInfoList` class covering: version/version_count preservation, metadata-suffix filtering, parallel load + order preservation, the dropped `get_latest_artifact_version` round-trip, partial-failure placeholder, `FileNotFoundError` skip, and list-keys failure.
- Full `tests/unit/agent/utils/test_artifact_helpers.py` (122) and `tests/unit/gateway/http_sse/routers/test_artifacts.py` (88) pass.