### PR TITLE
chore(DATAGO-140559): backporting addition of disclaimer text to embedded mode

### DIFF
--- a/cli/commands/init_cmd/webui_gateway_step.py
+++ b/cli/commands/init_cmd/webui_gateway_step.py
@@ -173,6 +173,9 @@ def create_webui_gateway_config(
             "__FRONTEND_WELCOME_MESSAGE__": str(
                 options.get("webui_frontend_welcome_message", '${FRONTEND_WELCOME_MESSAGE, "Hello, how can I assist you?"}')
             ),
+            "__FRONTEND_DISCLAIMER_TEXT__": str(
+                options.get("webui_frontend_disclaimer_text", '${FRONTEND_DISCLAIMER_TEXT, ""}')
+            ),
             "__FRONTEND_BOT_NAME__": str(
                 options.get("webui_frontend_bot_name", "${FRONTEND_BOT_NAME, Solace Agent Mesh}")
             ),

--- a/client/webui/frontend/src/lib/components/pages/ChatPage.tsx
+++ b/client/webui/frontend/src/lib/components/pages/ChatPage.tsx
@@ -27,6 +27,7 @@ import {
 import { Button, ChatMessageList, CHAT_STYLES, ResizablePanelGroup, ResizablePanel, ResizableHandle, Spinner, Tooltip, TooltipContent, TooltipTrigger } from "@/lib/components/ui";
 import { PageLayout } from "@/lib/components/layout";
 import { EmptyState } from "@/lib/components/common/EmptyState";
+import { MarkdownHTMLConverter } from "@/lib/components/common/MarkdownHTMLConverter";
 import type { ChatMessageListRef } from "@/lib/components/ui/chat/chat-message-list";
 import { useShareLink, useShareUsers } from "@/lib/api/share";
 import { api } from "@/lib/api";
@@ -70,7 +71,7 @@ export function ChatPage() {
     const navigate = useNavigate();
     const { value: inlineActivityTimelineEnabled } = useBooleanFlagDetails("inline_activity_timeline", false);
     const surface = useChatSurface();
-    const { configWelcomeMessage } = useConfigContext();
+    const { configWelcomeMessage, configDisclaimerText } = useConfigContext();
     const {
         agents,
         agentsRefetch,
@@ -570,6 +571,11 @@ export function ChatPage() {
                 <div className="mt-4 w-full" style={CHAT_STYLES}>
                     <ChatInputArea agents={agents} scrollToBottom={chatMessageListRef.current?.scrollToBottom} />
                 </div>
+                {configDisclaimerText && (
+                    <div className="w-full px-16 text-center">
+                        <MarkdownHTMLConverter className="inline-block text-left text-xs">{configDisclaimerText}</MarkdownHTMLConverter>
+                    </div>
+                )}
             </div>
         </div>
     );

--- a/client/webui/frontend/src/lib/contexts/ConfigContext.ts
+++ b/client/webui/frontend/src/lib/contexts/ConfigContext.ts
@@ -17,11 +17,6 @@ export interface ConfigContextValue {
     configAuthLoginUrl: string;
     configUseAuthorization: boolean;
     configWelcomeMessage: string;
-    /**
-     * Operator-configured disclaimer rendered on the chat welcome screen.
-     * Markdown (links supported); empty string means no disclaimer is shown.
-     * Set via the gateway's `frontend_disclaimer_text` config key.
-     */
     configDisclaimerText: string;
     configRedirectUrl: string;
     configCollectFeedback: boolean;

--- a/client/webui/frontend/src/lib/contexts/ConfigContext.ts
+++ b/client/webui/frontend/src/lib/contexts/ConfigContext.ts
@@ -17,6 +17,12 @@ export interface ConfigContextValue {
     configAuthLoginUrl: string;
     configUseAuthorization: boolean;
     configWelcomeMessage: string;
+    /**
+     * Operator-configured disclaimer rendered on the chat welcome screen.
+     * Markdown (links supported); empty string means no disclaimer is shown.
+     * Set via the gateway's `frontend_disclaimer_text` config key.
+     */
+    configDisclaimerText: string;
     configRedirectUrl: string;
     configCollectFeedback: boolean;
     configBotName: string;

--- a/client/webui/frontend/src/lib/providers/ConfigProvider.tsx
+++ b/client/webui/frontend/src/lib/providers/ConfigProvider.tsx
@@ -10,6 +10,7 @@ interface BackendConfig {
     frontend_auth_login_url: string;
     frontend_use_authorization: boolean;
     frontend_welcome_message: string;
+    frontend_disclaimer_text?: string;
     frontend_redirect_url: string;
     frontend_collect_feedback: boolean;
     frontend_bot_name: string;
@@ -115,6 +116,7 @@ export function ConfigProvider({ children }: Readonly<ConfigProviderProps>) {
                     configAuthLoginUrl: data.frontend_auth_login_url,
                     configUseAuthorization: effectiveUseAuthorization,
                     configWelcomeMessage: data.frontend_welcome_message,
+                    configDisclaimerText: data.frontend_disclaimer_text ?? "",
                     configRedirectUrl: data.frontend_redirect_url,
                     configCollectFeedback: data.frontend_collect_feedback,
                     configBotName: data.frontend_bot_name,

--- a/client/webui/frontend/src/stories/chat/ArtifactsPage.test.tsx
+++ b/client/webui/frontend/src/stories/chat/ArtifactsPage.test.tsx
@@ -22,6 +22,7 @@ const mockConfig: ConfigContextValue = {
     configAuthLoginUrl: "",
     configUseAuthorization: false,
     configWelcomeMessage: "",
+    configDisclaimerText: "",
     configRedirectUrl: "",
     configCollectFeedback: false,
     configBotName: "",

--- a/client/webui/frontend/src/stories/chat/ChatPage.stories.tsx
+++ b/client/webui/frontend/src/stories/chat/ChatPage.stories.tsx
@@ -499,9 +499,6 @@ export const EmbeddedAgent: Story = {
     },
 };
 
-// Operator-configured disclaimer (frontend_disclaimer_text) rendered as Markdown
-// below the embedded hero input. A Markdown link must open in a new tab with a
-// safe rel.
 export const WithDisclaimer: Story = {
     parameters: {
         chatContext: {
@@ -531,7 +528,6 @@ export const WithDisclaimer: Story = {
     },
 };
 
-// A Markdown bulleted disclaimer renders as a <ul> list.
 export const WithBulletedDisclaimer: Story = {
     parameters: {
         chatContext: {

--- a/client/webui/frontend/src/stories/chat/ChatPage.stories.tsx
+++ b/client/webui/frontend/src/stories/chat/ChatPage.stories.tsx
@@ -498,3 +498,63 @@ export const EmbeddedAgent: Story = {
         expect(canvas.queryByLabelText("Start voice recording")).toBeNull();
     },
 };
+
+// Operator-configured disclaimer (frontend_disclaimer_text) rendered as Markdown
+// below the embedded hero input. A Markdown link must open in a new tab with a
+// safe rel.
+export const WithDisclaimer: Story = {
+    parameters: {
+        chatContext: {
+            sessionId: "mock-embedded-disclaimer-session",
+            messages: [],
+            isResponding: false,
+            isCancelling: false,
+            selectedAgentName: "OrchestratorAgent",
+            agents: [{ name: "OrchestratorAgent", displayName: "Orchestrator" }],
+            isSidePanelCollapsed: true,
+            activeSidePanelTab: "files",
+        },
+        configContext: {
+            persistenceEnabled: false,
+            configWelcomeMessage: "How can I help you with your code today?",
+            configDisclaimerText: "AI can make mistakes. See our [terms](https://example.com/terms).",
+        },
+    },
+    decorators: [(Story: StoryFn, context: StoryContext) => <ChatSurfaceContext.Provider value={EMBEDDED_SURFACE}>{Story(context.args, context)}</ChatSurfaceContext.Provider>],
+    play: async ({ canvasElement }) => {
+        const canvas = within(canvasElement);
+
+        const link = await canvas.findByRole("link", { name: "terms" });
+        expect(link).toHaveAttribute("href", "https://example.com/terms");
+        expect(link).toHaveAttribute("target", "_blank");
+        expect(link.getAttribute("rel")).toContain("noopener");
+    },
+};
+
+// A Markdown bulleted disclaimer renders as a <ul> list.
+export const WithBulletedDisclaimer: Story = {
+    parameters: {
+        chatContext: {
+            sessionId: "mock-embedded-bulleted-disclaimer-session",
+            messages: [],
+            isResponding: false,
+            isCancelling: false,
+            selectedAgentName: "OrchestratorAgent",
+            agents: [{ name: "OrchestratorAgent", displayName: "Orchestrator" }],
+            isSidePanelCollapsed: true,
+            activeSidePanelTab: "files",
+        },
+        configContext: {
+            persistenceEnabled: false,
+            configWelcomeMessage: "How can I help you with your code today?",
+            configDisclaimerText: "- Do not share secrets\n- Responses may be inaccurate",
+        },
+    },
+    decorators: [(Story: StoryFn, context: StoryContext) => <ChatSurfaceContext.Provider value={EMBEDDED_SURFACE}>{Story(context.args, context)}</ChatSurfaceContext.Provider>],
+    play: async ({ canvasElement }) => {
+        const canvas = within(canvasElement);
+
+        const item = await canvas.findByText("Do not share secrets");
+        expect(item.closest("ul")).not.toBeNull();
+    },
+};

--- a/client/webui/frontend/src/stories/hooks/useIsChatSharingEnabled.test.tsx
+++ b/client/webui/frontend/src/stories/hooks/useIsChatSharingEnabled.test.tsx
@@ -16,6 +16,7 @@ function makeConfigValue(overrides: Partial<ConfigContextValue> = {}): ConfigCon
         configAuthLoginUrl: "",
         configUseAuthorization: false,
         configWelcomeMessage: "",
+        configDisclaimerText: "",
         configRedirectUrl: "",
         configCollectFeedback: false,
         configBotName: "",

--- a/client/webui/frontend/src/stories/mocks/MockConfigProvider.tsx
+++ b/client/webui/frontend/src/stories/mocks/MockConfigProvider.tsx
@@ -9,6 +9,7 @@ const defaultMockConfigContext: ConfigContextValue = {
     configAuthLoginUrl: "http://localhost:8000/auth/login",
     configUseAuthorization: false,
     configWelcomeMessage: "Welcome to the mock Solace Agent Mesh!",
+    configDisclaimerText: "",
     configRedirectUrl: "http://localhost:3000",
     configCollectFeedback: false,
     configBotName: "Mock Bot",

--- a/examples/gateways/webui_gateway_example.yaml
+++ b/examples/gateways/webui_gateway_example.yaml
@@ -88,6 +88,7 @@ apps:
 
       # --- Frontend Config Passthrough ---
       frontend_welcome_message: ${FRONTEND_WELCOME_MESSAGE}
+      frontend_disclaimer_text: ${FRONTEND_DISCLAIMER_TEXT, ""}
       frontend_bot_name: ${FRONTEND_BOT_NAME}
       frontend_collect_feedback: true
       frontend_logo_url: "${WEBUI_FRONTEND_LOGO_URL}"

--- a/preset/agents/basic/webui.yaml
+++ b/preset/agents/basic/webui.yaml
@@ -63,6 +63,7 @@ apps:
 
       # --- Frontend Config Passthrough ---
       frontend_welcome_message: ${FRONTEND_WELCOME_MESSAGE, "Hello, how can I assist you?"}
+      frontend_disclaimer_text: ${FRONTEND_DISCLAIMER_TEXT, ""}
       frontend_bot_name: ${FRONTEND_BOT_NAME, Solace Agent Mesh}
       frontend_collect_feedback: ${FRONTEND_COLLECT_FEEDBACK, false}
       frontend_logo_url: "${WEBUI_FRONTEND_LOGO_URL}"

--- a/src/solace_agent_mesh/gateway/http_sse/app.py
+++ b/src/solace_agent_mesh/gateway/http_sse/app.py
@@ -125,6 +125,13 @@ class WebUIBackendApp(BaseGatewayApp):
             "description": "Enable/disable the feedback buttons in the UI.",
         },
         {
+            "name": "frontend_disclaimer_text",
+            "required": False,
+            "type": "string",
+            "default": "",
+            "description": "Operator-configured disclaimer rendered (as Markdown) on the chat welcome screen. Empty disables it. Capped at 500 chars.",
+        },
+        {
             "name": "frontend_auth_login_url",
             "required": False,
             "type": "string",

--- a/src/solace_agent_mesh/gateway/http_sse/routers/config.py
+++ b/src/solace_agent_mesh/gateway/http_sse/routers/config.py
@@ -564,7 +564,10 @@ async def get_app_config(
         platform_config = component.get_config("platform_service", {})
         platform_service_url = platform_config.get("url", "")
 
-        disclaimer_text = component.get_config("frontend_disclaimer_text", "") or ""
+        # Coerce to str: get_config returns the raw YAML value, so a hand-edited
+        # non-string literal (int/bool/list) would otherwise raise on len()/slice
+        # below and 500 the whole /api/v1/config endpoint.
+        disclaimer_text = str(component.get_config("frontend_disclaimer_text", "") or "")
         if len(disclaimer_text) > MAX_FRONTEND_DISCLAIMER_TEXT_LEN:
             log.warning(
                 "%sfrontend_disclaimer_text exceeds %d chars (%d); truncating.",

--- a/src/solace_agent_mesh/gateway/http_sse/routers/config.py
+++ b/src/solace_agent_mesh/gateway/http_sse/routers/config.py
@@ -26,6 +26,11 @@ if TYPE_CHECKING:
 
 log = logging.getLogger(__name__)
 
+# Bounds the operator-configured disclaimer shown on the chat welcome screen.
+# Over-long values are truncated (with a warning) rather than rejected so a
+# cosmetic misconfiguration can't block startup.
+MAX_FRONTEND_DISCLAIMER_TEXT_LEN = 500
+
 router = APIRouter()
 
 
@@ -559,6 +564,14 @@ async def get_app_config(
         platform_config = component.get_config("platform_service", {})
         platform_service_url = platform_config.get("url", "")
 
+        disclaimer_text = component.get_config("frontend_disclaimer_text", "") or ""
+        if len(disclaimer_text) > MAX_FRONTEND_DISCLAIMER_TEXT_LEN:
+            log.warning(
+                "%sfrontend_disclaimer_text exceeds %d chars (%d); truncating.",
+                log_prefix, MAX_FRONTEND_DISCLAIMER_TEXT_LEN, len(disclaimer_text),
+            )
+            disclaimer_text = disclaimer_text[:MAX_FRONTEND_DISCLAIMER_TEXT_LEN]
+
         config_data = {
             "frontend_server_url": component.frontend_server_url,
             "frontend_platform_server_url": platform_service_url,
@@ -573,6 +586,7 @@ async def get_app_config(
             "frontend_collect_feedback": feedback_enabled,
             "frontend_bot_name": component.get_config("frontend_bot_name", "A2A Agent"),
             "frontend_logo_url": component.get_config("frontend_logo_url", ""),
+            "frontend_disclaimer_text": disclaimer_text,
             "frontend_feature_enablement": feature_enablement,
             "persistence_enabled": api_config.get("persistence_enabled", False),
             "validation_limits": _get_validation_limits(component),

--- a/templates/webui.yaml
+++ b/templates/webui.yaml
@@ -67,6 +67,7 @@ apps:
 
       # --- Frontend Config Passthrough ---
       frontend_welcome_message: __FRONTEND_WELCOME_MESSAGE__
+      frontend_disclaimer_text: __FRONTEND_DISCLAIMER_TEXT__
       frontend_bot_name: __FRONTEND_BOT_NAME__
       frontend_collect_feedback: __FRONTEND_COLLECT_FEEDBACK__
       frontend_logo_url: __FRONTEND_LOGO_URL__

--- a/tests/unit/gateway/http_sse/test_config_router_frontend_url.py
+++ b/tests/unit/gateway/http_sse/test_config_router_frontend_url.py
@@ -215,3 +215,12 @@ class TestConfigRouterDisclaimerText:
         response = await get_app_config(mock_component, mock_api_config)
 
         assert response["frontend_disclaimer_text"] == at_limit
+
+    @pytest.mark.asyncio
+    async def test_non_string_value_is_coerced_not_crashing(self, mock_component, mock_api_config):
+        """A hand-edited non-string YAML literal must be coerced, not 500 the endpoint."""
+        _set_disclaimer(mock_component, 42)
+
+        response = await get_app_config(mock_component, mock_api_config)
+
+        assert response["frontend_disclaimer_text"] == "42"

--- a/tests/unit/gateway/http_sse/test_config_router_frontend_url.py
+++ b/tests/unit/gateway/http_sse/test_config_router_frontend_url.py
@@ -7,10 +7,15 @@ from the component. By default, frontend_server_url is empty, allowing
 the frontend to use relative URLs for same-origin requests.
 """
 
+import logging
+
 import pytest
 from unittest.mock import MagicMock
 
-from solace_agent_mesh.gateway.http_sse.routers.config import get_app_config
+from solace_agent_mesh.gateway.http_sse.routers.config import (
+    MAX_FRONTEND_DISCLAIMER_TEXT_LEN,
+    get_app_config,
+)
 
 
 @pytest.fixture
@@ -31,6 +36,7 @@ def mock_component():
         "frontend_redirect_url": "",
         "frontend_bot_name": "A2A Agent",
         "frontend_logo_url": "",
+        "frontend_disclaimer_text": "",
         "speech": {},
     }.get(key, default)
     return component
@@ -140,3 +146,72 @@ class TestConfigRouterFrontendServerUrl:
 
         assert response["frontend_server_url"] == "http://localhost:8000"
         assert response["frontend_platform_server_url"] == ""
+
+
+def _set_disclaimer(mock_component, value: str) -> None:
+    """Point the mock's get_config at a map carrying the given disclaimer text."""
+    mock_component.get_config.side_effect = lambda key, default=None: {
+        "platform_service": {"url": "http://localhost:8001"},
+        "frontend_feature_enablement": {},
+        "task_logging": {},
+        "prompt_library": {"enabled": False},
+        "frontend_collect_feedback": False,
+        "session_service": {"type": "memory"},
+        "frontend_auth_login_url": "",
+        "frontend_use_authorization": False,
+        "frontend_welcome_message": "",
+        "frontend_redirect_url": "",
+        "frontend_bot_name": "A2A Agent",
+        "frontend_logo_url": "",
+        "frontend_disclaimer_text": value,
+        "speech": {},
+    }.get(key, default)
+
+
+class TestConfigRouterDisclaimerText:
+    """Tests for frontend_disclaimer_text in /api/v1/config response."""
+
+    @pytest.mark.asyncio
+    async def test_returns_empty_string_by_default(self, mock_component, mock_api_config):
+        """Test that the disclaimer is empty by default."""
+        response = await get_app_config(mock_component, mock_api_config)
+
+        assert response["frontend_disclaimer_text"] == ""
+
+    @pytest.mark.asyncio
+    async def test_round_trip(self, mock_component, mock_api_config):
+        """Test that a configured disclaimer surfaces unchanged on the response."""
+        disclaimer = "This assistant may produce inaccurate information."
+        _set_disclaimer(mock_component, disclaimer)
+
+        response = await get_app_config(mock_component, mock_api_config)
+
+        assert response["frontend_disclaimer_text"] == disclaimer
+
+    @pytest.mark.asyncio
+    async def test_truncates_over_long_value_with_warning(
+        self, mock_component, mock_api_config, caplog
+    ):
+        """Test that a >500-char value is truncated to exactly 500 chars and warns."""
+        over_long = "x" * (MAX_FRONTEND_DISCLAIMER_TEXT_LEN + 123)
+        _set_disclaimer(mock_component, over_long)
+
+        with caplog.at_level(logging.WARNING):
+            response = await get_app_config(mock_component, mock_api_config)
+
+        assert len(response["frontend_disclaimer_text"]) == MAX_FRONTEND_DISCLAIMER_TEXT_LEN
+        assert response["frontend_disclaimer_text"] == over_long[:MAX_FRONTEND_DISCLAIMER_TEXT_LEN]
+        assert any(
+            "frontend_disclaimer_text exceeds" in record.getMessage()
+            for record in caplog.records
+        )
+
+    @pytest.mark.asyncio
+    async def test_value_at_limit_is_not_truncated(self, mock_component, mock_api_config):
+        """Test that a value exactly at the limit is returned unchanged."""
+        at_limit = "y" * MAX_FRONTEND_DISCLAIMER_TEXT_LEN
+        _set_disclaimer(mock_component, at_limit)
+
+        response = await get_app_config(mock_component, mock_api_config)
+
+        assert response["frontend_disclaimer_text"] == at_limit


### PR DESCRIPTION
Ports Go PR [solace-agent-mesh-go#2395](https://github.com/SolaceDev/solace-agent-mesh-go/pull/2395) into the Python/React SAM ecosystem.

### What & why
Operators can now configure a disclaimer string (legal/compliance fine-print, AI-accuracy notice) that renders on the chat welcome screen — no code change or image rebuild. It follows the existing frontend_* passthrough pattern: operator YAML → /api/v1/config → React ConfigContext → rendered as sanitized Markdown.

New key: frontend_disclaimer_text (backend) → configDisclaimerText (React). Capped at 500 chars, truncated-with-warning rather than rejected so a cosmetic misconfig can't block startup.

### Backend (gateway/http_sse/)
app.py: new frontend_disclaimer_text schema param (string, default "").
routers/config.py: MAX_FRONTEND_DISCLAIMER_TEXT_LEN = 500, truncate-with-warning, and the value added to the /api/v1/config payload.
Tests: round-trip, truncation-to-500 + warning (via caplog), and at-limit.
Frontend (@SolaceLabs/solace-agent-mesh-ui source)
ConfigContext.ts / ConfigProvider.tsx: new configDisclaimerText field + backend→context mapping.
ChatPage.tsx: rendered as sanitized Markdown (MarkdownHTMLConverter) below the input on the embedded welcome hero. Links open in a new tab with rel="noopener noreferrer".
Mocks/tests updated; two new Storybook play-tests (WithDisclaimer, WithBulletedDisclaimer).
Config / CLI
Added frontend_disclaimer_text: ${FRONTEND_DISCLAIMER_TEXT, ""} to the webui gateway example/preset YAMLs and the CLI init template (env-driven; no init prompt by design).

### Design note — render placement
The disclaimer renders only on the embedded chat surface (/agent-mode/chat?agent=…), where the welcome hero lives. The full web UI seeds the welcome as a chat bubble instead, and per product decision the disclaimer is suppressed there. The backend/context plumbing is surface-agnostic, so extending to the full UI later (via the welcome bubble) is a small follow-up.

⚠️ Env var uses the unprefixed FRONTEND_DISCLAIMER_TEXT convention (matches FRONTEND_WELCOME_MESSAGE etc.), not WEBUI_FRONTEND_*.

### Testing
pytest: 23 passed (config router + CLI init).
Frontend: tsc + eslint clean; ChatPage stories 13/13 (incl. 2 new); affected unit tests 28/28.

### Example

<img width="1718" height="893" alt="image" src="https://github.com/user-attachments/assets/02e16abd-6d1a-4ddf-804e-fc3380449055" />
