### PR TITLE
fix(security): upgrade turbo-stream to 3.0.0 (CVE-2026-3407)

### DIFF
--- a/config_portal/frontend/package-lock.json
+++ b/config_portal/frontend/package-lock.json
@@ -2158,12 +2158,14 @@
       "version": "15.7.15",
       "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.15.tgz",
       "integrity": "sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/react": {
       "version": "18.3.28",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.28.tgz",
       "integrity": "sha512-z9VXpC7MWrhfWipitjNdgCauoMLRdIILQsAEV+ZesIzBq/oUlxk0m3ApZuMFCXdnS4U7KrI+l3WRUEGQ8K1QKw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/prop-types": "*",
@@ -4377,6 +4379,7 @@
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/damerau-levenshtein": {
@@ -14391,10 +14394,10 @@
       "optional": true
     },
     "node_modules/turbo-stream": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/turbo-stream/-/turbo-stream-2.4.1.tgz",
-      "integrity": "sha512-v8kOJXpG3WoTN/+at8vK7erSzo6nW6CIaeOvNOkHQVDajfz1ZVeSxCbc6tOH4hrGZW7VUCV0TOXd8CPzYnYkrw==",
-      "license": "ISC"
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/turbo-stream/-/turbo-stream-3.0.0.tgz",
+      "integrity": "sha512-cD7s7mh0XtUa+sE5Ej1ShRrWGKiAZ1X/l4clV7Dyg4A+u9jf2pbTTKDApeW0B7Za5o/tNCGzNTLFHBAVxeQC6g==",
+      "license": "MIT"
     },
     "node_modules/type-check": {
       "version": "0.4.0",
@@ -14518,7 +14521,7 @@
       "version": "5.9.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
-      "devOptional": true,
+      "dev": true,
       "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",

--- a/config_portal/frontend/package.json
+++ b/config_portal/frontend/package.json
@@ -48,6 +48,7 @@
   },
   "overrides": {
     "undici": ">=6.24.0",
+    "//turbo-stream": "CVE-2026-3407: major-version pin is safe here because vite.config.ts sets ssr:false (SPA mode). turbo-stream's encode/decode are only invoked by Remix for SSR deferred streaming; with no server runtime those code paths are never reached. @remix-run 2.17.5 is the latest release and has no compatible update; React Router v7 (the migration target) drops this dep entirely.",
     "turbo-stream": "3.0.0"
   },
   "engines": {

--- a/config_portal/frontend/package.json
+++ b/config_portal/frontend/package.json
@@ -48,7 +48,6 @@
   },
   "overrides": {
     "undici": ">=6.24.0",
-    "//turbo-stream": "CVE-2026-3407: major-version pin is safe here because vite.config.ts sets ssr:false (SPA mode). turbo-stream's encode/decode are only invoked by Remix for SSR deferred streaming; with no server runtime those code paths are never reached. @remix-run 2.17.5 is the latest release and has no compatible update; React Router v7 (the migration target) drops this dep entirely.",
     "turbo-stream": "3.0.0"
   },
   "engines": {

--- a/config_portal/frontend/package.json
+++ b/config_portal/frontend/package.json
@@ -47,7 +47,8 @@
     "@rollup/rollup-linux-x64-gnu": "4.36.0"
   },
   "overrides": {
-    "undici": ">=6.24.0"
+    "undici": ">=6.24.0",
+    "turbo-stream": "3.0.0"
   },
   "engines": {
     "node": ">=25.5.0 <26"


### PR DESCRIPTION
## Summary

- Adds `turbo-stream: 3.0.0` to the npm `overrides` in `config_portal/frontend/package.json`
- Upgrades the resolved version in `package-lock.json` from 2.4.1 → 3.0.0
- `turbo-stream` is a transitive dependency of `@remix-run/node` and `@remix-run/react`

**CVE:** CVE-2026-3407
**Affected package:** `turbo-stream` 2.4.1
**Fix:** Upgrade to 3.0.0

## Test plan

- [ ] `npm ci` in `config_portal/frontend/` installs without errors
- [ ] `node -e "require('./node_modules/turbo-stream/package.json').version"` prints `3.0.0`
- [ ] `npm run build` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)