### PR TITLE
Add Atlas Cloud model provider

### DIFF
--- a/client/webui/frontend/src/lib/components/models/modelProviderUtils.ts
+++ b/client/webui/frontend/src/lib/components/models/modelProviderUtils.ts
@@ -308,6 +308,15 @@ const PROVIDER_CONFIGS: Record<string, ProviderConfig> = {
         modelNamePlaceholder: "gpt-4o-mini",
         allowedAuthTypes: ["apikey"],
     },
+    atlascloud: {
+        id: "atlascloud",
+        label: "Atlas Cloud",
+        description: "OpenAI-compatible hosted models through Atlas Cloud",
+        showApiBase: false,
+        fields: [],
+        modelNamePlaceholder: "qwen/qwen3.5-flash",
+        allowedAuthTypes: ["apikey"],
+    },
     anthropic: {
         id: "anthropic",
         label: "Anthropic",

--- a/config_portal/frontend/app/common/providerModels.ts
+++ b/config_portal/frontend/app/common/providerModels.ts
@@ -1,5 +1,6 @@
 export const PROVIDER_ENDPOINTS: Record<string, string> = {
   openai: "https://api.openai.com/v1",
+  atlascloud: "https://api.atlascloud.ai/v1",
   anthropic: "https://api.anthropic.com",
   google: "https://generativelanguage.googleapis.com/v1beta/openai",
   aws: "https://bedrock-runtime.us-east-1.amazonaws.com",
@@ -9,6 +10,7 @@ export const PROVIDER_ENDPOINTS: Record<string, string> = {
 export const LLM_PROVIDER_OPTIONS = [
   { value: "", label: "Setup Later" },
   { value: "openai", label: "OpenAI" },
+  { value: "atlascloud", label: "Atlas Cloud" },
   { value: "anthropic", label: "Anthropic" },
   { value: "google", label: "Google Gemini" },
   { value: "azure", label: "Azure" },
@@ -17,6 +19,7 @@ export const LLM_PROVIDER_OPTIONS = [
 ];
 export const PROVIDER_PREFIX_MAP: Record<string, string> = {
   openai: "openai",
+  atlascloud: "openai",
   anthropic: "anthropic",
   google: "openai", //using googles open ai compatible endpoint
   openai_compatible: "openai",
@@ -34,6 +37,10 @@ export const PROVIDER_MODELS: Record<string, string[]> = {
     "gpt-4.1-nano",
     "o4-mini",
     "o3",
+  ],
+  atlascloud: [
+    "qwen/qwen3.5-flash",
+    "deepseek-ai/deepseek-v4-pro",
   ],
   anthropic: [
     "claude-sonnet-4-5-20250929",
@@ -71,6 +78,7 @@ export const PROVIDER_MODELS: Record<string, string[]> = {
 
 export const PROVIDER_NAMES: Record<string, string> = {
   openai: "OpenAI",
+  atlascloud: "Atlas Cloud",
   anthropic: "Anthropic",
   google: "Google Vertex AI",
   aws: "AWS Bedrock",

--- a/config_portal/frontend/app/common/providerModels.ts
+++ b/config_portal/frontend/app/common/providerModels.ts
@@ -136,10 +136,10 @@ export const formatModelName = (
   modelName: string,
   provider: string
 ): string => {
-  if (modelName.includes("/")) {
+  const providerPrefix = PROVIDER_PREFIX_MAP[provider] || provider;
+  if (modelName.startsWith(`${providerPrefix}/`)) {
     return modelName;
   }
 
-  const providerPrefix = PROVIDER_PREFIX_MAP[provider] || provider;
   return `${providerPrefix}/${modelName}`;
 };

--- a/src/solace_agent_mesh/services/platform/services/model_config_service.py
+++ b/src/solace_agent_mesh/services/platform/services/model_config_service.py
@@ -36,6 +36,7 @@ log = logging.getLogger(__name__)
 # Without the correct prefix, LiteLLM may route to the wrong provider
 # (e.g., a bare "gemini-pro" routes to Vertex AI instead of Google AI Studio).
 _LITELLM_PROVIDER_PREFIXES = {
+    "atlascloud": "openai/",
     "google_ai_studio": "gemini/",
     "vertex_ai": "vertex_ai/",
     "bedrock": "bedrock/",
@@ -60,7 +61,7 @@ def _resolve_litellm_model_name(provider: Optional[str], model_name: str) -> str
     if not provider or not model_name:
         return model_name
     required_prefix = _LITELLM_PROVIDER_PREFIXES.get(provider)
-    if required_prefix and not model_name.startswith(required_prefix) and "/" not in model_name:
+    if required_prefix and not model_name.startswith(required_prefix):
         return f"{required_prefix}{model_name}"
     return model_name
 
@@ -68,6 +69,7 @@ def _resolve_litellm_model_name(provider: Optional[str], model_name: str) -> str
 # Default API bases for known providers
 _DEFAULT_API_BASES = {
     "openai": "https://api.openai.com/v1",
+    "atlascloud": "https://api.atlascloud.ai/v1",
     "anthropic": "https://api.anthropic.com",
     "google_ai_studio": "https://generativelanguage.googleapis.com/v1beta",
     "vertex_ai": "https://us-central1-aiplatform.googleapis.com/v1",

--- a/src/solace_agent_mesh/services/platform/services/model_configuration_seeder.py
+++ b/src/solace_agent_mesh/services/platform/services/model_configuration_seeder.py
@@ -50,6 +50,8 @@ def _infer_provider(api_base: str, model_name: str = "") -> str:
         # Exact hostname matches
         if hostname == "api.openai.com":
             return "openai"
+        elif hostname == "api.atlascloud.ai":
+            return "atlascloud"
         elif hostname == "api.anthropic.com":
             return "anthropic"
         elif ".openai.azure.com" in hostname:
@@ -90,7 +92,7 @@ def _get_default_auth_type(provider: str) -> str:
     """
     provider_lower = provider.lower()
 
-    if provider_lower in ("openai", "anthropic", "google_ai_studio", "azure_openai"):
+    if provider_lower in ("openai", "atlascloud", "anthropic", "google_ai_studio", "azure_openai"):
         return "apikey"
     elif provider_lower == "vertex_ai":
         return "gcp_service_account"
@@ -118,6 +120,8 @@ def _get_default_api_base(provider: str) -> Optional[str]:
     # Providers with standard endpoints
     if provider_lower == "openai":
         return "https://api.openai.com/v1"
+    elif provider_lower == "atlascloud":
+        return "https://api.atlascloud.ai/v1"
     elif provider_lower == "anthropic":
         return "https://api.anthropic.com/v1"
     elif provider_lower == "google_ai_studio":

--- a/src/solace_agent_mesh/services/platform/services/model_list_service.py
+++ b/src/solace_agent_mesh/services/platform/services/model_list_service.py
@@ -22,6 +22,7 @@ log = logging.getLogger(__name__)
 class ModelProviders:
     """Provider ID constants."""
     OPENAI = "openai"
+    ATLAS_CLOUD = "atlascloud"
     ANTHROPIC = "anthropic"
     GOOGLE_AI_STUDIO = "google_ai_studio"
     VERTEX_AI = "vertex_ai"
@@ -29,6 +30,12 @@ class ModelProviders:
     BEDROCK = "bedrock"
     OLLAMA = "ollama"
     CUSTOM = "custom"
+
+
+ATLAS_CLOUD_MODELS = [
+    "qwen/qwen3.5-flash",
+    "deepseek-ai/deepseek-v4-pro",
+]
 
 
 class ModelListService:
@@ -170,6 +177,7 @@ class ModelListService:
         """Get the default API base URL for a provider."""
         api_bases = {
             ModelProviders.OPENAI: "https://api.openai.com/v1",
+            ModelProviders.ATLAS_CLOUD: "https://api.atlascloud.ai/v1",
             ModelProviders.ANTHROPIC: "https://api.anthropic.com",
             ModelProviders.GOOGLE_AI_STUDIO: "https://generativelanguage.googleapis.com/v1beta/models",
             ModelProviders.AZURE_OPENAI: None,  # Requires custom api_base
@@ -234,7 +242,7 @@ class ModelListService:
 
         # Build endpoint URL and prepare query params based on provider
         query_params = {}
-        if provider == ModelProviders.OPENAI or provider == ModelProviders.CUSTOM:
+        if provider in (ModelProviders.OPENAI, ModelProviders.ATLAS_CLOUD, ModelProviders.CUSTOM):
             endpoint = f"{api_base}/models"
         elif provider == ModelProviders.ANTHROPIC:
             endpoint = f"{api_base}/v1/models"
@@ -258,7 +266,7 @@ class ModelListService:
                 response.raise_for_status()
 
                 # Parse response based on provider format
-                if provider == ModelProviders.OPENAI or provider == ModelProviders.CUSTOM:
+                if provider in (ModelProviders.OPENAI, ModelProviders.ATLAS_CLOUD, ModelProviders.CUSTOM):
                     data = response.json()
                     return [model["id"] for model in data.get("data", [])]
 
@@ -412,6 +420,7 @@ class ModelListService:
 
         # Map our provider IDs to litellm's where they differ
         litellm_provider_map = {
+            ModelProviders.ATLAS_CLOUD: "openai",
             ModelProviders.GOOGLE_AI_STUDIO: "gemini",
             ModelProviders.AZURE_OPENAI: "azure",
         }
@@ -435,6 +444,9 @@ class ModelListService:
         Used as a fallback when the provider's API cannot be reached or doesn't
         support listing models (e.g., Vertex AI Model Garden not enabled).
         """
+        if provider == ModelProviders.ATLAS_CLOUD:
+            return ATLAS_CLOUD_MODELS
+
         if litellm is None:
             return []
         try:

--- a/src/solace_agent_mesh/services/platform/services/model_list_service.py
+++ b/src/solace_agent_mesh/services/platform/services/model_list_service.py
@@ -173,7 +173,7 @@ class ModelListService:
                 return [{"id": m, "label": m, "provider": provider} for m in fallback_models]
             raise RuntimeError(f"Failed to fetch models from {provider} API and LiteLLM registry: {str(e)}")
 
-    def _get_provider_api_base(self, provider: str) -> str:
+    def _get_provider_api_base(self, provider: str) -> Optional[str]:
         """Get the default API base URL for a provider."""
         api_bases = {
             ModelProviders.OPENAI: "https://api.openai.com/v1",

--- a/tests/unit/services/platform/test_model_config_service.py
+++ b/tests/unit/services/platform/test_model_config_service.py
@@ -15,6 +15,9 @@ from unittest.mock import AsyncMock, Mock, patch
 
 import pytest
 
+from solace_agent_mesh.services.platform.api.routers.dto.requests import (
+    ModelConfigurationCreateRequest,
+)
 from solace_agent_mesh.services.platform.services.model_config_service import (
     ModelConfigService,
     _resolve_litellm_model_name,
@@ -144,6 +147,19 @@ class TestToRawLitellmConfig:
         result = ModelConfigService._to_raw_litellm_config(db_model)
         assert result["model"] == "bedrock/anthropic.claude-3"
 
+    def test_atlascloud_model_with_vendor_slash_gets_openai_prefix(self):
+        db_model = _make_db_model(
+            provider="atlascloud",
+            model_name="qwen/qwen3.5-flash",
+            api_base="https://api.atlascloud.ai/v1",
+            model_auth_config=None,
+            model_params=None,
+        )
+
+        result = ModelConfigService._to_raw_litellm_config(db_model)
+
+        assert result["model"] == "openai/qwen/qwen3.5-flash"
+
     def test_gcp_vertex_credentials_passed_through(self):
         """GCP vertex_credentials is passed through directly to LiteLLM config."""
         db_model = _make_db_model(
@@ -157,6 +173,26 @@ class TestToRawLitellmConfig:
         )
         result = ModelConfigService._to_raw_litellm_config(db_model)
         assert result["vertex_credentials"] == '{"project_id": "test"}'
+
+
+class TestCreate:
+    def test_atlascloud_uses_default_api_base(self):
+        service = ModelConfigService()
+        service.repository = Mock()
+        service.repository.exists_by_alias.return_value = False
+        service._to_response = Mock(return_value="created")
+        request = ModelConfigurationCreateRequest(
+            alias="atlas-model",
+            provider="atlascloud",
+            model_name="qwen/qwen3.5-flash",
+            auth_config={"type": "apikey", "api_key": "test-key"},
+        )
+
+        result = service.create(Mock(), request, "admin")
+
+        created = service.repository.create.call_args.args[1]
+        assert created.api_base == "https://api.atlascloud.ai/v1"
+        assert result == "created"
 
 
 class TestGetByAlias:
@@ -602,5 +638,4 @@ class TestToRawLitellmConfigPlaceholderStripping:
         result = ModelConfigService._to_raw_litellm_config(db_model)
         # _resolve_litellm_model_name(None, None) returns None
         assert result["model"] is None
-
 

--- a/tests/unit/services/platform/test_model_configuration_seeder.py
+++ b/tests/unit/services/platform/test_model_configuration_seeder.py
@@ -66,6 +66,11 @@ class TestInferProvider:
         assert _infer_provider("https://api.openai.com/v1") == "openai"
         assert _infer_provider("https://api.openai.com/v1/chat/completions") == "openai"
 
+    def test_known_provider_atlascloud(self):
+        """Detect Atlas Cloud from api.atlascloud.ai hostname."""
+        assert _infer_provider("https://api.atlascloud.ai/v1") == "atlascloud"
+        assert _infer_provider("https://api.atlascloud.ai/v1/chat/completions") == "atlascloud"
+
     def test_known_provider_anthropic(self):
         """Detect Anthropic from api.anthropic.com hostname."""
         assert _infer_provider("https://api.anthropic.com/v1") == "anthropic"

--- a/tests/unit/services/platform/test_model_list_service.py
+++ b/tests/unit/services/platform/test_model_list_service.py
@@ -22,6 +22,11 @@ class TestModelListServiceAuthHeaders:
         headers = self.service._build_auth_headers("openai", "apikey", {"api_key": "sk-test"})
         assert headers["Authorization"] == "Bearer sk-test"
 
+    def test_atlascloud_uses_bearer_token(self):
+        """Atlas Cloud uses OpenAI-compatible Bearer token auth."""
+        headers = self.service._build_auth_headers("atlascloud", "apikey", {"api_key": "ac-test"})
+        assert headers["Authorization"] == "Bearer ac-test"
+
     def test_anthropic_uses_x_api_key_header(self):
         """Anthropic uses X-API-Key header instead of Bearer."""
         headers = self.service._build_auth_headers("anthropic", "apikey", {"api_key": "sk-test"})
@@ -62,6 +67,7 @@ class TestModelListServiceApiBase:
     def test_known_providers_return_correct_urls(self):
         """Each known provider returns its correct API base."""
         assert self.service._get_provider_api_base("openai") == "https://api.openai.com/v1"
+        assert self.service._get_provider_api_base("atlascloud") == "https://api.atlascloud.ai/v1"
         assert self.service._get_provider_api_base("anthropic") == "https://api.anthropic.com"
         assert self.service._get_provider_api_base("ollama") is None
         assert self.service._get_provider_api_base("google_ai_studio") == "https://generativelanguage.googleapis.com/v1beta/models"
@@ -203,6 +209,37 @@ class TestModelListServiceResponseParsing:
 
             assert len(result) == 1
             assert result[0]["id"] == "gemini-pro"
+
+    def test_parse_atlascloud_openai_compatible_response(self):
+        """Atlas Cloud returns OpenAI-compatible model list responses."""
+        with patch("solace_agent_mesh.services.platform.services.model_list_service.httpx.Client") as mock_client_class:
+            mock_client = MagicMock()
+            mock_client.__enter__.return_value = mock_client
+            mock_client.__exit__.return_value = None
+
+            mock_response = MagicMock()
+            mock_response.json.return_value = {
+                "data": [
+                    {"id": "qwen/qwen3.5-flash"},
+                    {"id": "deepseek-ai/deepseek-v4-pro"},
+                ]
+            }
+            mock_response.status_code = 200
+            mock_client.get.return_value = mock_response
+            mock_client_class.return_value = mock_client
+
+            result = self.service.get_models_by_provider_with_config(
+                provider="atlascloud",
+                api_base=None,
+                auth_type="apikey",
+                auth_config={"api_key": "ac-test"},
+            )
+
+            assert [model["id"] for model in result] == [
+                "qwen/qwen3.5-flash",
+                "deepseek-ai/deepseek-v4-pro",
+            ]
+            assert all(model["provider"] == "atlascloud" for model in result)
 
 
 class TestModelListServiceValidation:
@@ -457,6 +494,44 @@ class TestModelListServiceTrailingSlash:
             url = mock_client.get.call_args[0][0]
             assert url == "https://custom.example.com/models"
 
+    def test_atlascloud_trailing_slash_stripped(self):
+        """Atlas Cloud api_base with trailing slash should not produce double-slash URL."""
+        with patch("solace_agent_mesh.services.platform.services.model_list_service.httpx.Client") as mock_cls:
+            mock_client = self._mock_http_client({"data": [{"id": "qwen/qwen3.5-flash"}]})
+            mock_cls.return_value = mock_client
+
+            self.service.get_models_by_provider_with_config(
+                provider="atlascloud",
+                api_base="https://api.atlascloud.ai/v1/",
+                auth_type="apikey",
+                auth_config={"api_key": "ac-test"},
+            )
+
+            url = mock_client.get.call_args[0][0]
+            assert url == "https://api.atlascloud.ai/v1/models"
+
+    def test_atlascloud_falls_back_to_curated_models(self):
+        """Atlas Cloud has a curated fallback when live model listing fails."""
+        with patch("solace_agent_mesh.services.platform.services.model_list_service.httpx.Client") as mock_cls:
+            mock_client = MagicMock()
+            mock_client.__enter__.return_value = mock_client
+            mock_client.__exit__.return_value = None
+            mock_client.get.side_effect = RuntimeError("network unavailable")
+            mock_cls.return_value = mock_client
+
+            result = self.service.get_models_by_provider_with_config(
+                provider="atlascloud",
+                api_base=None,
+                auth_type="apikey",
+                auth_config={"api_key": "ac-test"},
+            )
+
+            assert [model["id"] for model in result] == [
+                "qwen/qwen3.5-flash",
+                "deepseek-ai/deepseek-v4-pro",
+            ]
+            assert all(model["provider"] == "atlascloud" for model in result)
+
     def test_anthropic_trailing_slash_stripped(self):
         """Anthropic api_base with trailing slash should not produce double-slash URL."""
         with patch("solace_agent_mesh.services.platform.services.model_list_service.httpx.Client") as mock_cls:
@@ -488,3 +563,25 @@ class TestModelListServiceTrailingSlash:
 
             url = mock_client.get.call_args[0][0]
             assert url == "http://localhost:11434/api/tags"
+
+
+class TestModelListServiceSupportedParams:
+    """Tests for LiteLLM provider mapping when fetching supported params."""
+
+    def setup_method(self):
+        self.service = ModelListService()
+
+    def test_atlascloud_uses_openai_param_mapping(self):
+        """Atlas Cloud is OpenAI-compatible for supported parameter lookup."""
+        with patch(
+            "solace_agent_mesh.services.platform.services.model_list_service.litellm"
+        ) as mock_litellm:
+            mock_litellm.get_supported_openai_params.return_value = ["temperature", "max_tokens"]
+
+            result = self.service.get_supported_params("atlascloud", "qwen/qwen3.5-flash")
+
+            assert result == ["max_tokens", "temperature"]
+            mock_litellm.get_supported_openai_params.assert_called_once_with(
+                model="qwen/qwen3.5-flash",
+                custom_llm_provider="openai",
+            )


### PR DESCRIPTION
## Summary
- add Atlas Cloud as a built-in OpenAI-compatible model provider
- wire Atlas Cloud into model listing, seeding, setup provider choices, and web model configuration
- add focused tests for Atlas Cloud auth, default endpoint, model listing, fallback models, and provider inference

## Validation
- uv run --extra test python -m pytest tests/unit/services/platform/test_model_list_service.py tests/unit/services/platform/test_model_configuration_seeder.py -q
- python3 -m compileall -q src/solace_agent_mesh/services/platform/services/model_list_service.py src/solace_agent_mesh/services/platform/services/model_configuration_seeder.py
- npm run build (client/webui/frontend)
- npx eslint app/common/providerModels.ts (config_portal/frontend)
- git diff --check
- Atlas live /v1/models check confirmed qwen/qwen3.5-flash and deepseek-ai/deepseek-v4-pro

Note: config_portal/frontend npm run typecheck currently reports existing unrelated AddAgentFlow/AddGatewayFlow type errors before this change.