### PR TITLE
docs: deprecate legacy 1.x docs site with version notice and noindex (DATAGO-139020)

### DIFF
--- a/docs/docusaurus.config.ts
+++ b/docs/docusaurus.config.ts
@@ -16,7 +16,12 @@ const config: Config = {
   url: "https://solacelabs.github.io",
   baseUrl: "/solace-agent-mesh",
   organizationName: "SolaceLabs",
-  projectName: "solace-agent-mesh", 
+  projectName: "solace-agent-mesh",
+
+  // Deprecation (DATAGO-139020): the 1.x docs have moved to docs.solace.com.
+  // Keep search engines from indexing this legacy site so users land on the
+  // current docs. Emits <meta name="robots" content="noindex, nofollow"> site-wide.
+  noIndex: true,
 
   onBrokenLinks: "throw",
   onBrokenMarkdownLinks: "throw",

--- a/docs/src/components/LegacyVersionNotice.tsx
+++ b/docs/src/components/LegacyVersionNotice.tsx
@@ -1,0 +1,22 @@
+import React from 'react';
+import Admonition from '@theme/Admonition';
+
+// DATAGO-139020: the 1.x docs have moved to docs.solace.com. This banner is
+// rendered at the top of every doc page (via the DocItem/Content swizzle) so
+// the whole legacy site is clearly marked as deprecated.
+export default function LegacyVersionNotice(): JSX.Element {
+  return (
+    <Admonition type="warning" title="This documentation is for Solace Agent Mesh 1.x">
+      <p>
+        You are viewing the documentation for <strong>Solace Agent Mesh 1.x</strong>. The
+        latest documentation for <strong>Solace Agent Mesh 2.x</strong> and later is now
+        hosted on docs.solace.com.
+      </p>
+      <a
+        className="button button--primary"
+        href="https://docs.solace.com/Agent-Mesh/agent-mesh.htm">
+        Go to the Solace Agent Mesh 2.x documentation →
+      </a>
+    </Admonition>
+  );
+}

--- a/docs/src/components/LegacyVersionNotice.tsx
+++ b/docs/src/components/LegacyVersionNotice.tsx
@@ -6,16 +6,18 @@ import Admonition from '@theme/Admonition';
 // the whole legacy site is clearly marked as deprecated.
 export default function LegacyVersionNotice(): JSX.Element {
   return (
-    <Admonition type="warning" title="This documentation is for Solace Agent Mesh 1.x">
+    <Admonition type="warning" title="The information on this page is for Solace Agent Mesh 1.x">
       <p>
-        You are viewing the documentation for <strong>Solace Agent Mesh 1.x</strong>. The
-        latest documentation for <strong>Solace Agent Mesh 2.x</strong> and later is now
-        hosted on docs.solace.com.
+        Visit the{' '}
+        <a href="https://docs.solace.com/Agent-Mesh/agent-mesh.htm">
+          Solace Documentation site
+        </a>{' '}
+        for information about <strong>Solace Agent Mesh 2.x</strong> and later.
       </p>
       <a
         className="button button--primary"
         href="https://docs.solace.com/Agent-Mesh/agent-mesh.htm">
-        Go to the Solace Agent Mesh 2.x documentation →
+        Explore the Agent Mesh 2.x docs →
       </a>
     </Admonition>
   );

--- a/docs/src/theme/DocItem/Content/index.tsx
+++ b/docs/src/theme/DocItem/Content/index.tsx
@@ -1,0 +1,19 @@
+import React from 'react';
+import Content from '@theme-original/DocItem/Content';
+import type ContentType from '@theme/DocItem/Content';
+import type {WrapperProps} from '@docusaurus/types';
+import LegacyVersionNotice from '@site/src/components/LegacyVersionNotice';
+
+type Props = WrapperProps<typeof ContentType>;
+
+// DATAGO-139020: the 1.x docs have moved to docs.solace.com. Render the legacy
+// version notice at the top of every doc page's content so the whole site is
+// clearly marked as deprecated (see also noIndex in docusaurus.config.ts).
+export default function ContentWrapper(props: Props): JSX.Element {
+  return (
+    <>
+      <LegacyVersionNotice />
+      <Content {...props} />
+    </>
+  );
+}


### PR DESCRIPTION
### What is the purpose of this change?

The Solace Agent Mesh documentation has moved to [docs.solace.com](https://docs.solace.com/Agent-Mesh/agent-mesh.htm). This marks the legacy 1.x docs site (`solacelabs.github.io/solace-agent-mesh`) as deprecated so customers aren't confused about which documentation is current.

Jira: [DATAGO-139020](https://sol-jira.atlassian.net/browse/DATAGO-139020)

### How was this change implemented?

- **`docs/src/components/LegacyVersionNotice.tsx`** _(new)_ — a `warning` admonition + primary button linking to the Agent Mesh 2.x docs on docs.solace.com.
- **`docs/src/theme/DocItem/Content/index.tsx`** _(new)_ — a `DocItem/Content` swizzle that renders the notice at the top of every doc page's content.
- **`docs/docusaurus.config.ts`** — `noIndex: true`, emitting `<meta name="robots" content="noindex, nofollow">` site-wide so search engines stop indexing the legacy site.

### Key Design Decisions

The notice is injected once via a theme swizzle rather than pasted into each of the ~94 markdown pages. This keeps a single source of truth, guarantees every current **and future** page is covered, and is trivial to remove when the 1.x site is retired.

The `noindex` follows Gil Yu's suggestion in the deprecation thread. The broader SEO/AEO/GEO work (community posts, GEO engines) remains tracked in **DOC-7980**.

### How was this change tested?

- [x] Manual testing: Clean `npm run build` (cache cleared) succeeds. Verified in the generated HTML that all **98 doc pages** render the banner **exactly once** (spot-checked getting-started, components, developing, deploying, migrations, enterprise + children) and that `noindex, nofollow` is present site-wide. Served the build and visually confirmed the banner + button render correctly on both enterprise and non-enterprise pages.
- [ ] Unit tests: n/a (docs-only change)
- [ ] Integration tests: n/a
- [x] Known limitations: the site root (`/`) is a redirect to Getting Started, so there is no separate banner there; coverage is all documentation pages.

### Is there anything the reviewers should focus on/be aware of?

- The banner renders above the page title (consistent with Docusaurus version banners).
- The wording lives entirely in `LegacyVersionNotice.tsx` if you'd like to tweak the copy or switch `warning` → `info`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[DATAGO-139020]: https://sol-jira.atlassian.net/browse/DATAGO-139020?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ