### PR TITLE
fix(DATAGO-138845): handle async session DB engine in readiness health check

### DIFF
--- a/src/solace_agent_mesh/common/app_base.py
+++ b/src/solace_agent_mesh/common/app_base.py
@@ -1,5 +1,6 @@
 """Base App class for all SAM applications with broker and database health checks."""
 
+import asyncio
 import importlib
 import logging
 from concurrent.futures import ThreadPoolExecutor
@@ -9,6 +10,8 @@ from solace_ai_connector.common.messaging.solace_messaging import ConnectionStat
 from solace_ai_connector.common.monitoring import Monitoring
 from solace_ai_connector.flow.app import App
 from sqlalchemy import text
+from sqlalchemy.ext.asyncio import AsyncEngine, create_async_engine
+from sqlalchemy.pool import NullPool
 
 log = logging.getLogger(__name__)
 
@@ -173,15 +176,46 @@ class SamAppBase(App):
         """
         Test a single database connection.
 
+        Supports both synchronous ``Engine`` and asynchronous ``AsyncEngine``
+        objects. ADK 2.x's ``DatabaseSessionService`` is async-only, so an
+        agent's ``session_service.db_engine`` is an ``AsyncEngine`` that cannot
+        be used with a synchronous ``with engine.connect()`` — doing so raises
+        "'AsyncConnection' object does not support the context manager
+        protocol". Async engines are probed over a short-lived connection on a
+        throwaway event loop instead.
+
         Args:
-            engine: SQLAlchemy engine to test
+            engine: SQLAlchemy Engine or AsyncEngine to test.
 
         Returns:
-            True if connection successful, False otherwise.
+            True if the connection succeeds.
         """
-        with engine.connect() as conn:
-            conn.execute(text("SELECT 1"))
+        if isinstance(engine, AsyncEngine):
+            asyncio.run(self._test_single_async_db_connection(engine.url))
+        else:
+            with engine.connect() as conn:
+                conn.execute(text("SELECT 1"))
         return True
+
+    @staticmethod
+    async def _test_single_async_db_connection(url) -> None:
+        """
+        Probe an async database URL by opening a short-lived connection.
+
+        A throwaway ``NullPool`` engine is used so the connection is bound only
+        to this temporary event loop and is never returned to a shared pool —
+        a pooled async connection reused on a later probe's (different) event
+        loop would raise "Event loop is closed"/"attached to a different loop".
+
+        Args:
+            url: SQLAlchemy URL of the async engine to test.
+        """
+        probe_engine = create_async_engine(url, poolclass=NullPool)
+        try:
+            async with probe_engine.connect() as conn:
+                await conn.execute(text("SELECT 1"))
+        finally:
+            await probe_engine.dispose()
 
     def _get_health_check_executor(self) -> ThreadPoolExecutor:
         """

--- a/tests/unit/common/test_app_base.py
+++ b/tests/unit/common/test_app_base.py
@@ -1,5 +1,6 @@
 """Tests for SamAppBase health check methods."""
 
+import asyncio
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -400,26 +401,28 @@ class TestSamAppBaseDatabaseHealthChecks:
 
         from solace_agent_mesh.common.app_base import SamAppBase
 
-        async_engine = create_async_engine("sqlite+aiosqlite://")
+        async_engine = create_async_engine("sqlite+aiosqlite:///:memory:")
+        try:
+            app = object.__new__(SamAppBase)
 
-        app = object.__new__(SamAppBase)
+            # Agent pattern: component exposes session_service.db_engine (async).
+            mock_session_service = MagicMock()
+            mock_session_service.db_engine = async_engine
 
-        # Agent pattern: component exposes session_service.db_engine (async).
-        mock_session_service = MagicMock()
-        mock_session_service.db_engine = async_engine
+            mock_component = MagicMock(spec=[])  # No get_db_engine method
+            mock_component.session_service = mock_session_service
 
-        mock_component = MagicMock(spec=[])  # No get_db_engine method
-        mock_component.session_service = mock_session_service
+            mock_wrapper = MagicMock()
+            mock_wrapper.component = mock_component
 
-        mock_wrapper = MagicMock()
-        mock_wrapper.component = mock_component
+            mock_flow = MagicMock()
+            mock_flow.component_groups = [[mock_wrapper]]
+            app.flows = [mock_flow]
 
-        mock_flow = MagicMock()
-        mock_flow.component_groups = [[mock_wrapper]]
-        app.flows = [mock_flow]
-
-        result = app._is_database_connected()
-        assert result is True
+            result = app._is_database_connected()
+            assert result is True
+        finally:
+            asyncio.run(async_engine.dispose())
 
     @patch("solace_agent_mesh.common.app_base.App.__init__")
     def test_test_single_db_connection_accepts_async_engine(self, mock_app_init):
@@ -430,12 +433,15 @@ class TestSamAppBaseDatabaseHealthChecks:
 
         from solace_agent_mesh.common.app_base import SamAppBase
 
-        async_engine = create_async_engine("sqlite+aiosqlite://")
-        assert isinstance(async_engine, AsyncEngine)
+        async_engine = create_async_engine("sqlite+aiosqlite:///:memory:")
+        try:
+            assert isinstance(async_engine, AsyncEngine)
 
-        app = object.__new__(SamAppBase)
+            app = object.__new__(SamAppBase)
 
-        assert app._test_single_db_connection(async_engine) is True
+            assert app._test_single_db_connection(async_engine) is True
+        finally:
+            asyncio.run(async_engine.dispose())
 
 
 class TestSamAppBaseDatabaseTimeoutConfig:

--- a/tests/unit/common/test_app_base.py
+++ b/tests/unit/common/test_app_base.py
@@ -383,6 +383,60 @@ class TestSamAppBaseDatabaseHealthChecks:
         result = app._is_database_connected(timeout=0.1)
         assert result is False
 
+    @patch("solace_agent_mesh.common.app_base.App.__init__")
+    def test_is_database_connected_with_real_async_engine_returns_true(
+        self, mock_app_init
+    ):
+        """Regression (DATAGO-138845 / #1602): a real async session engine is healthy.
+
+        ADK 2.x's DatabaseSessionService is async-only, so an agent's
+        session_service.db_engine is a real SQLAlchemy AsyncEngine. The health
+        check must probe it without raising "'AsyncConnection' object does not
+        support the context manager protocol".
+        """
+        mock_app_init.return_value = None
+
+        from sqlalchemy.ext.asyncio import create_async_engine
+
+        from solace_agent_mesh.common.app_base import SamAppBase
+
+        async_engine = create_async_engine("sqlite+aiosqlite://")
+
+        app = object.__new__(SamAppBase)
+
+        # Agent pattern: component exposes session_service.db_engine (async).
+        mock_session_service = MagicMock()
+        mock_session_service.db_engine = async_engine
+
+        mock_component = MagicMock(spec=[])  # No get_db_engine method
+        mock_component.session_service = mock_session_service
+
+        mock_wrapper = MagicMock()
+        mock_wrapper.component = mock_component
+
+        mock_flow = MagicMock()
+        mock_flow.component_groups = [[mock_wrapper]]
+        app.flows = [mock_flow]
+
+        result = app._is_database_connected()
+        assert result is True
+
+    @patch("solace_agent_mesh.common.app_base.App.__init__")
+    def test_test_single_db_connection_accepts_async_engine(self, mock_app_init):
+        """_test_single_db_connection routes an AsyncEngine through the async probe."""
+        mock_app_init.return_value = None
+
+        from sqlalchemy.ext.asyncio import AsyncEngine, create_async_engine
+
+        from solace_agent_mesh.common.app_base import SamAppBase
+
+        async_engine = create_async_engine("sqlite+aiosqlite://")
+        assert isinstance(async_engine, AsyncEngine)
+
+        app = object.__new__(SamAppBase)
+
+        assert app._test_single_db_connection(async_engine) is True
+
 
 class TestSamAppBaseDatabaseTimeoutConfig:
     """Tests for configurable database health check timeout."""


### PR DESCRIPTION
### What is the purpose of this change?

Follow-up to **[DATAGO-138845](https://sol-jira.atlassian.net/browse/DATAGO-138845)** / #1602.

That PR upgraded google-adk to 2.x, whose `DatabaseSessionService` is **async-only** — so an agent's `session_service.db_engine` is now a SQLAlchemy `AsyncEngine`. But the readiness DB health check (`SamAppBase._test_single_db_connection`, added in #861) still opened the engine with a **synchronous** `with engine.connect()`, which raises:

```
'AsyncConnection' object does not support the context manager protocol
```

The health check therefore reported the database as never-connected, the pod never became `Ready`, and `helm upgrade --wait` timed out. This broke the `rc-sam-community` RC deploy of image `1.28.5-878121f258` (helm `--wait` hit its 10-minute timeout).

### How was this change implemented?

`src/solace_agent_mesh/common/app_base.py` — `_test_single_db_connection` now branches on engine type:

- **`AsyncEngine`** → probed via a new `async with engine.connect()` coroutine (`SELECT 1`) run with `asyncio.run`.
- **sync `Engine`** → unchanged existing path.

The async probe uses a short-lived **`NullPool`** engine created from the engine's URL, so no async connection is returned to a pool bound to the probe's temporary event loop (which would raise `Event loop is closed` on the next health tick).

### Key Design Decisions _(optional - delete if not applicable)_

- **Throwaway engine instead of connecting on the shared engine:** the check runs in a `ThreadPoolExecutor` worker via `asyncio.run`, which creates a fresh event loop each tick; reusing the shared async pool across loops is unsafe.
- **Kept the async driver instead of converting to a sync URL (`to_sync_db_url`):** the async driver the engine already uses (asyncpg/aiosqlite/aiomysql) is guaranteed installed in that process, whereas a sync driver (e.g. psycopg2) may not be present in an agent-only process.
- I grepped `common/` for other sync-`connect()`-on-async-engine spots — this was the only one the #1602 migration missed.

### How was this change tested?

- [x] Unit tests: two new cases in `tests/unit/common/test_app_base.py` exercise a **real** `aiosqlite` `AsyncEngine` (via `_is_database_connected` and via `_test_single_db_connection` directly). They **fail against the pre-fix code** with the exact `'AsyncConnection' object does not support the context manager protocol` error and **pass** with the fix.
- [x] `uv run --extra test pytest tests/unit/common/test_app_base.py -k database` → 16 passed.
- [x] `ruff check` clean on the changed lines.
- [ ] Not yet re-run against the live RC deploy (the chart-side schema fix is tracked separately in `rc-sam-community`).

### Is there anything the reviewers should focus on/be aware of?

- The async probe opens (and disposes) one throwaway connection per health tick per async engine. That's intentional for isolation; flag if you'd prefer a shared dedicated event loop instead.
- Sync-engine behavior (the http_sse gateway's `create_engine`) is intentionally unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[DATAGO-138845]: https://sol-jira.atlassian.net/browse/DATAGO-138845?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ