### PR TITLE
fix(DATAGO-144858): bump mcp to 1.28.1 for CVE-2026-59950/52870/52869

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,7 @@ classifiers = [
 ]
 dependencies = [
     "google-adk==1.18.0",
+    "mcp==1.28.1",  # [CVE-2026-59950, CVE-2026-52870, CVE-2026-52869] Security fix: pins transitive dep (from google-adk) to 1.28.1
     "a2a-sdk[http-server]==0.3.7",
     "pydantic==2.12.5",
     "click==8.3.3",  # [CVE-2026-7246] Security fix

--- a/uv.lock
+++ b/uv.lock
@@ -2691,7 +2691,7 @@ wheels = [
 
 [[package]]
 name = "mcp"
-version = "1.27.0"
+version = "1.28.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
@@ -2709,9 +2709,9 @@ dependencies = [
     { name = "typing-inspection" },
     { name = "uvicorn", marker = "sys_platform != 'emscripten'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/8b/eb/c0cfc62075dc6e1ec1c64d352ae09ac051d9334311ed226f1f425312848a/mcp-1.27.0.tar.gz", hash = "sha256:d3dc35a7eec0d458c1da4976a48f982097ddaab87e278c5511d5a4a56e852b83", size = 607509, upload-time = "2026-04-02T14:48:08.88Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/6e/77/9450b8f251a13affb6281997d0523c4615f8a8b35d0b21ff30db3a5aac9d/mcp-1.28.1.tar.gz", hash = "sha256:d51e36a5f5644faea4f85ea649bfffa6bc6c26770d42798ad6a3de3d2ba69683", size = 638501, upload-time = "2026-06-26T12:57:29.093Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/9c/46/f6b4ad632c67ef35209a66127e4bddc95759649dd595f71f13fba11bdf9a/mcp-1.27.0-py3-none-any.whl", hash = "sha256:5ce1fa81614958e267b21fb2aa34e0aea8e2c6ede60d52aba45fd47246b4d741", size = 215967, upload-time = "2026-04-02T14:48:07.24Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/5e/d118fce19f87a2e7d8101c35c8ae0ec289098a4df0ff244cec23e415aca0/mcp-1.28.1-py3-none-any.whl", hash = "sha256:2726bca5e7193f61c5dde8b12500a6de2d9acf6d1a1c0be9e8c2e706437991df", size = 222620, upload-time = "2026-06-26T12:57:27.218Z" },
 ]
 
 [[package]]
@@ -4742,6 +4742,7 @@ dependencies = [
     { name = "mako" },
     { name = "markdownify" },
     { name = "markitdown", extra = ["all"] },
+    { name = "mcp" },
     { name = "mermaid-cli" },
     { name = "nanoid" },
     { name = "numpy" },
@@ -4850,6 +4851,7 @@ requires-dist = [
     { name = "mako", specifier = ">=1.3.12" },
     { name = "markdownify", specifier = "==1.2.0" },
     { name = "markitdown", extras = ["all"], specifier = "==0.1.4" },
+    { name = "mcp", specifier = "==1.28.1" },
     { name = "mermaid-cli", specifier = "==0.1.2" },
     { name = "nanoid", specifier = "==2.0.0" },
     { name = "numpy", specifier = "==2.2.6" },


### PR DESCRIPTION
### What is the purpose of this change?

Resolves [DATAGO-144858](https://sol-jira.atlassian.net/browse/DATAGO-144858). The image ships `mcp` **1.27.0**, which the vulnerability scan flags for three High-severity CVEs:

- **CVE-2026-59950** (CVSS 7.6) — deprecated websocket transport accepts handshakes without Host/Origin validation
- **CVE-2026-52870** (CVSS 7.6) — `enable_tasks()` handlers operate across sessions, letting any client enumerate/read/cancel other clients' tasks
- **CVE-2026-52869** (CVSS 7.1) — SSE / stateful Streamable HTTP transports route by session id without verifying the authenticated principal

All three are fixed at **≥ 1.28.1**.

### How was this change implemented?

`mcp` is a transitive dependency (from `google-adk`, and `fastmcp` in the test extra). Following this repo's convention of pinning security-sensitive transitive deps directly in `dependencies` with a `# [CVE-...]` comment:

- `pyproject.toml`: added `mcp==1.28.1` with a CVE reference comment
- `uv.lock`: regenerated via `uv lock --upgrade-package mcp` — `mcp` 1.27.0 → 1.28.1, no other package changed

`google-adk==1.18.0` requires `mcp<2.0.0,>=1.8.0`, so 1.28.1 fits within its constraint with no conflict.

### How was this change tested?

- [x] Dependency resolution: `uv lock` resolved all 279 packages cleanly with `mcp==1.28.1`
- [ ] No code changes required — SAM uses `mcp` only as a client (`StdioServerParameters` / MCP toolsets), not the vulnerable server transports; the bump satisfies the scanner and closes the CVEs regardless.

### Is there anything the reviewers should focus on/be aware of?

- This is a version-only bump; no behavioral change expected.
- The ticket is filed against `solace-agent-mesh-enterprise:main`; `mcp` originates here (open-source SAM), so enterprise picks this up once it consumes a SAM build with this lock. Enterprise may need the same pin if it resolves `mcp`/SAM independently.


[DATAGO-144858]: https://sol-jira.atlassian.net/browse/DATAGO-144858?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ