### PR TITLE
fix(DATAGO-145007): bump python-liquid to 2.2.1 for CVE-2026-55865

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,7 @@ dependencies = [
     "pyjwt>=2.13.0",  # [CVE-2026-48526] Security fix: rejects JWK JSON passed as an HMAC secret
     "asteval==1.0.6",
     "pystache==0.6.8",
-    "python-liquid==2.2.0",  # [CVE-2026-45017] Security fix
+    "python-liquid==2.2.1",  # [CVE-2026-55865] Security fix: DoS via malformed {% case %} tag (parse-time infinite loop)
     "pandas==2.3.2",
     "numpy==2.2.6",
     "plotly==6.3.0",

--- a/uv.lock
+++ b/uv.lock
@@ -4107,7 +4107,7 @@ wheels = [
 
 [[package]]
 name = "python-liquid"
-version = "2.2.0"
+version = "2.2.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "babel" },
@@ -4115,9 +4115,9 @@ dependencies = [
     { name = "python-dateutil" },
     { name = "pytz" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/96/15/f76284f919bd1eda0490b4fc34b416ccb10dcb20628b4afe133bf1c03366/python_liquid-2.2.0.tar.gz", hash = "sha256:ee3cda2ce6e9ef873a9d0e5180ad1de38dc39bf05044d8a6459ca1b999dbe13e", size = 95137, upload-time = "2026-05-06T17:51:28.888Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/f6/05/38a825b18c6a08d4b42b9b8a4ec0fb08babe2e815ab47d866af09b8bfd63/python_liquid-2.2.1.tar.gz", hash = "sha256:a800c3aa47f7614893f3dc3381ec07587ef04d5e076a8e4b266a81cdbe512c8c", size = 95136, upload-time = "2026-06-16T16:07:59.429Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e2/1b/33701a1ee066054a1e6ae1ec27540dd86f63c6138d214985599440c2a0dc/python_liquid-2.2.0-py3-none-any.whl", hash = "sha256:4d71b3f2c0147ffe150ba84e252b8c71e04f12c60a1d770962b0c8c977419f09", size = 140932, upload-time = "2026-05-06T17:51:27.468Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/18/ee9c53e015ad4b2be471107714ce4db562090fee7b1fd4cb1f299e2b0e78/python_liquid-2.2.1-py3-none-any.whl", hash = "sha256:35da55dc42c47ebc86086b18838d1921135f48940599b7537f9a55645974e49c", size = 140932, upload-time = "2026-06-16T16:07:58.18Z" },
 ]
 
 [[package]]
@@ -4878,7 +4878,7 @@ requires-dist = [
     { name = "python-docx", specifier = "==1.2.0" },
     { name = "python-dotenv", specifier = "==1.2.2" },
     { name = "python-jwt", specifier = "==4.1.0" },
-    { name = "python-liquid", specifier = "==2.2.0" },
+    { name = "python-liquid", specifier = "==2.2.1" },
     { name = "python-multipart", specifier = "==0.0.30" },
     { name = "python-pptx", specifier = "==1.0.2" },
     { name = "pyyaml", specifier = "==6.0.2" },


### PR DESCRIPTION
### What is the purpose of this change?

Resolves **DATAGO-145007** / **CVE-2026-55865** (High, CVSS 7.1), a denial-of-service vulnerability in `python-liquid`. Prior to 2.2.1, a malformed `{% case %}` tag with no associated `{% when %}`/`{% else %}` block and no terminating `{% endcase %}` tag causes the parser to hang in an infinite loop at parse time, allowing a malicious template author to craft a template that hangs the process.

### How was this change implemented?

- `pyproject.toml`: bumped `python-liquid==2.2.0` → `==2.2.1` (the fixed version) and updated the security-fix comment to reference CVE-2026-55865.
- `uv.lock`: regenerated via `uv lock` (patch bump only; transitive dependencies unchanged).

### How was this change tested?

- [x] Dependency resolution: `uv lock` resolved 279 packages cleanly with the new pin.
- [ ] Manual testing: n/a — patch-level upstream release with no API changes.
- [ ] Unit tests: none added; this is a security patch bump.

### Is there anything the reviewers should focus on/be aware of?

Straightforward patch-level version bump for a security fix. `python-liquid` 2.2.1 introduces no API changes over 2.2.0, so no functional impact is expected.
