### PR TITLE
fix(DATAGO-145097): bump soupsieve to 2.8.4 for CVE-2026-49476, CVE-2026-49477

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,6 +53,7 @@ dependencies = [
     "litellm==1.84.0",  # bumped from 1.83.14 to relax its aiohttp==3.13.4 pin, allowing aiohttp >=3.14.0 (locked to 3.14.1) [CVE-2026-34993, CVE-2026-47265]
     "markdownify==1.2.0",
     "beautifulsoup4==4.13.5",
+    "soupsieve==2.8.4",  # [CVE-2026-49476, CVE-2026-49477] Security fix (transitive from beautifulsoup4): DoS via unbounded memory in selector-list compile & regex catastrophic backtracking
     "jsonpath-ng==1.7.0",
     "pydub==0.25.1",
     "toml==0.10.2",

--- a/uv.lock
+++ b/uv.lock
@@ -4771,6 +4771,7 @@ dependencies = [
     { name = "rouge" },
     { name = "setuptools" },
     { name = "solace-ai-connector" },
+    { name = "soupsieve" },
     { name = "sqlalchemy" },
     { name = "sse-starlette" },
     { name = "starlette" },
@@ -4890,6 +4891,7 @@ requires-dist = [
     { name = "ruff", marker = "extra == 'test'" },
     { name = "setuptools", specifier = "==80.10.2" },
     { name = "solace-ai-connector", specifier = "==3.3.12" },
+    { name = "soupsieve", specifier = "==2.8.4" },
     { name = "sqlalchemy", specifier = "==2.0.40" },
     { name = "sse-starlette", specifier = "==3.0.2" },
     { name = "starlette", specifier = "==0.49.1" },
@@ -4940,11 +4942,11 @@ wheels = [
 
 [[package]]
 name = "soupsieve"
-version = "2.8.3"
+version = "2.8.4"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/7b/ae/2d9c981590ed9999a0d91755b47fc74f74de286b0f5cee14c9269041e6c4/soupsieve-2.8.3.tar.gz", hash = "sha256:3267f1eeea4251fb42728b6dfb746edc9acaffc4a45b27e19450b676586e8349", size = 118627, upload-time = "2026-01-20T04:27:02.457Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/47/2c/0a5f6f8ee0d5589e48c7640213ed5175d52cf540a06725b628cc1a45d6ce/soupsieve-2.8.4.tar.gz", hash = "sha256:e121fd02e975c695e4e9e8774a5ee35d74714b59307868dcc5319ad2d9e3328e", size = 121110, upload-time = "2026-05-24T13:55:57.154Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/46/2c/1462b1d0a634697ae9e55b3cecdcb64788e8b7d63f54d923fcd0bb140aed/soupsieve-2.8.3-py3-none-any.whl", hash = "sha256:ed64f2ba4eebeab06cc4962affce381647455978ffc1e36bb79a545b91f45a95", size = 37016, upload-time = "2026-01-20T04:27:01.012Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/f5/0c41cb68dcae6b7de4fac4188a3a9589e21fb31df21ea3a2e888db95e6c9/soupsieve-2.8.4-py3-none-any.whl", hash = "sha256:e7e6b0769c8f51ed59acab6e994b00621096cfb1c640a7509295987388fbaf65", size = 37304, upload-time = "2026-05-24T13:55:55.406Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
### What is the purpose of this change?

Resolves [DATAGO-145097](https://sol-jira.atlassian.net/browse/DATAGO-145097) — two High-severity DoS vulnerabilities in `soupsieve` 2.8.3, both fixed in 2.8.4:

- **CVE-2026-49476** (CVSS 7.5): unbounded heap allocation when compiling large comma-separated selector lists.
- **CVE-2026-49477** (CVSS 7.5): regex catastrophic backtracking on an attribute selector with an unterminated quoted value → CPU exhaustion.

### How was this change implemented?

`soupsieve` is a **transitive** dependency — pulled in by `beautifulsoup4==4.13.5` (and also used by `markdownify`/`markitdown`). It was resolving to the vulnerable 2.8.3.

`beautifulsoup4` only constrains it with a loose lower bound (`soupsieve>1.2`; even the latest bs4 4.15.0 declares `soupsieve>=1.6.1`), so upgrading the parent would **not** force the fixed version. Instead, I pinned the fixed version directly:

- `pyproject.toml`: added `"soupsieve==2.8.4"` to `dependencies` with a CVE comment.
- `uv.lock`: regenerated — `soupsieve 2.8.3 → 2.8.4` (only change; 279 packages re-resolved cleanly).

### Key Design Decisions

Pinning the transitive dependency directly (rather than bumping `beautifulsoup4`) follows the existing convention in this file for transitive security fixes — see `idna`, `mako`, `pillow`, and `cryptography`. It is the only approach that deterministically forces the fixed version, and it avoids the unrelated behavioral churn of a bs4 major-line bump.

### How was this change tested?

- [x] `uv lock` re-resolved the full graph (279 packages) with no conflicts; `beautifulsoup4`/`markdownify`/`markitdown` all accept soupsieve 2.8.4.
- [ ] Unit tests: none added (dependency version pin only).
- [ ] Manual testing: n/a.
- [ ] Known limitations: relies on CI to run the existing suite against the updated lock.

### Is there anything the reviewers should focus on/be aware of?

Pure dependency pin — no application code changed. The enterprise repo inherits this transitive pin from community, so no separate enterprise change is required.


[DATAGO-145097]: https://sol-jira.atlassian.net/browse/DATAGO-145097?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ