### PR TITLE
fix(DATAGO-145006): bump httplib2 to 0.32.0 for CVE-2026-59939

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -2013,14 +2013,14 @@ wheels = [
 
 [[package]]
 name = "httplib2"
-version = "0.31.2"
+version = "0.32.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pyparsing" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/c1/1f/e86365613582c027dda5ddb64e1010e57a3d53e99ab8a72093fa13d565ec/httplib2-0.31.2.tar.gz", hash = "sha256:385e0869d7397484f4eab426197a4c020b606edd43372492337c0b4010ae5d24", size = 250800, upload-time = "2026-01-23T11:04:44.165Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/84/f5/ccf58de92d61e3ad921119668f54ed36ca1d0cf5dcc5c1657dfb164fd78b/httplib2-0.32.0.tar.gz", hash = "sha256:48a0ef30a42db65d8f3399045e1d09ab0ba66e3b9efc360d07f80ea55d286025", size = 254283, upload-time = "2026-06-26T10:13:56.265Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/2f/90/fd509079dfcab01102c0fdd87f3a9506894bc70afcf9e9785ef6b2b3aff6/httplib2-0.31.2-py3-none-any.whl", hash = "sha256:dbf0c2fa3862acf3c55c078ea9c0bc4481d7dc5117cae71be9514912cf9f8349", size = 91099, upload-time = "2026-01-23T11:04:42.78Z" },
+    { url = "https://files.pythonhosted.org/packages/33/a0/550eec327e5f5c7b732531c489f5307efec41f047b0d703bd4ca1e5ad2db/httplib2-0.32.0-py3-none-any.whl", hash = "sha256:dc6705cacdf3fb0a2aba7629fa33c90fd93e30035db0c157325826be177e4816", size = 93148, upload-time = "2026-06-26T10:13:54.985Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
### What is the purpose of this change?

Resolves **DATAGO-145006** / **CVE-2026-59939** (High, CVSS 7.5). `httplib2` < 0.32.0 performs unbounded decompression of gzip/deflate HTTP response bodies, so a malicious or compromised server can return a small compressed payload that expands to an arbitrarily large size and exhausts client memory (MemoryError / OOM-kill). Flagged by FOSSA + Prisma on `solace-agent-mesh:main` (was resolving to `httplib2 0.31.2`).

### How was this change implemented?

`httplib2` is a **transitive** dependency (via `google-api-python-client` and `google-auth-httplib2`). Both parents already declare `httplib2 >=0.19.0,<1.0.0`, which permits the fixed `0.32.0` — the lock was simply stale (resolved before 0.32.0 was published). So this is a **lock-only refresh**:

```
uv lock --upgrade-package httplib2   # httplib2 0.31.2 -> 0.32.0
```

Only `uv.lock` changes (the `httplib2` version + sdist/wheel hashes). No `pyproject.toml` pin and no parent bump were required, so the fix is deliberately minimal.

### Key Design Decisions

A direct pin in `pyproject.toml` was considered but rejected: since the parents already allow `0.32.0`, refreshing the lock is the least invasive fix and avoids adding a pin we'd later have to prune.

### How was this change tested?

- [x] Dependency resolution: `uv lock --upgrade-package httplib2` resolves cleanly (279 packages), diff limited to the `httplib2` block only.
- [ ] Manual testing: n/a — no source/behavior change, transitive lock bump only.
- [ ] Unit tests: n/a
- [ ] Known limitations: relies on CI (FOSSA/Prisma) rescan to confirm the finding clears.

### Is there anything the reviewers should focus on/be aware of?

`httplib2` still depends on `pyparsing` in 0.32.0 (unchanged). No API-facing changes. `google-api-python-client` (2.198.0) and `google-auth-httplib2` (0.4.0) have newer releases available but bumping them is unnecessary for this CVE and intentionally left out of scope.