### PR TITLE
fix(DATAGO-145096): bump joserfc to 1.7.4 for CVE-2026-49852

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -2303,14 +2303,14 @@ wheels = [
 
 [[package]]
 name = "joserfc"
-version = "1.6.7"
+version = "1.7.4"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "cryptography" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/1b/cb/52e479f20804904f5df20ac4539d292dcecd1287aaa33cba1d1def1d9d8e/joserfc-1.6.7.tar.gz", hash = "sha256:6999fe89457069ecacd8cc797c88a805f83054dd883333fa0409f74b46479fd7", size = 232158, upload-time = "2026-05-23T01:46:44.069Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/c7/e0/27a6a081ae25420eda6768ceae05d7022a7f2447f420588843f2a44e4298/joserfc-1.7.4.tar.gz", hash = "sha256:b3bc561672ae541b17a9237053b48a03dacddd92d68047b3ecdfb4b5714a88ed", size = 234027, upload-time = "2026-07-19T15:43:02.739Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/c5/e4/bcf6718b5662894c6831f46296b73cd4b1a2e90c20b6d437e20c4997388c/joserfc-1.6.7-py3-none-any.whl", hash = "sha256:9e51e4a64840aa1734a058258e80a4480e2ff2d5686e480e7c92c954a92fbe05", size = 70603, upload-time = "2026-05-23T01:46:42.129Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/bf/249dcd99b3376375910b7fa922383b57792975c8758f50d44612e749226c/joserfc-1.7.4-py3-none-any.whl", hash = "sha256:32d46c2cd5e3203c13e87a6c61333cab310b1ba80cd54b4c4f386a848a122463", size = 71000, upload-time = "2026-07-19T15:43:01.299Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## What

Bumps the transitive dependency **`joserfc` 1.6.7 → 1.7.4** via a lock refresh (`uv lock --upgrade-package joserfc`). Only `uv.lock` changes.

## Why

[DATAGO-145096](https://sol-jira.atlassian.net/browse/DATAGO-145096) — **CVE-2026-49852** (High, CVSS 8.7), flagged by FOSSA + Prisma.

`joserfc` < 1.6.8 lets `joserfc.jwt.decode` accept attacker-forged HMAC-signed tokens when the caller-supplied verification key is the empty string or `None` (`HMACAlgorithm.sign`/`verify` pass a zero-length key straight to `hmac.new`, and `OctKey.import_key` only warns on short keys instead of rejecting them). Fixed in 1.6.8.

## Approach

`joserfc` is pulled in transitively through `authlib`, which only requires `joserfc>=1.6.0` and does **not** cap it — the lock had simply frozen 1.6.7. So a lock refresh re-resolves it upward to 1.7.4 (past the 1.6.8 fix floor) with **no `pyproject.toml` pin required** and no other package drift. Bumping `authlib` was not an option/effective: it's already at the latest (1.7.2) and doesn't gate `joserfc`.

## Verification

- `uv lock --upgrade-package joserfc` → `Updated joserfc v1.6.7 -> v1.7.4`
- `git diff` touches only the `joserfc` block in `uv.lock` (version + sdist/wheel hashes); 279 packages re-resolved, nothing else moved.

Enterprise inherits this transitive pin from community, so no separate enterprise change is needed.

[DATAGO-145096]: https://sol-jira.atlassian.net/browse/DATAGO-145096?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ