### PR TITLE
fix(artifacts): scope metadata semaphore to event loop

### DIFF
--- a/src/solace_agent_mesh/agent/utils/artifact_helpers.py
+++ b/src/solace_agent_mesh/agent/utils/artifact_helpers.py
@@ -10,6 +10,7 @@ import csv
 import io
 import inspect
 import os
+import threading
 import yaml
 import traceback
 from datetime import datetime, timezone
@@ -38,13 +39,35 @@ BM25_INDEX_FILENAME = "project_bm25_index.zip"
 DEFAULT_SCHEMA_MAX_KEYS = 20
 DEFAULT_SCHEMA_INFERENCE_DEPTH = 4
 
-# Caps concurrent artifact-metadata S3 loads across the whole process. Without
-# this, get_artifact_info_list_fast does an unbounded asyncio.gather over every
+# Caps concurrent artifact-metadata S3 loads on each event loop. Without this,
+# get_artifact_info_list_fast does an unbounded asyncio.gather over every
 # artifact in a session, and the /api/v1/artifacts/all router fans out across
-# many sessions in parallel. Under multi-user load the combined fan-out
-# exhausts the botocore connection pool (default 200), discards connections,
-# and stalls the FastAPI event loop on TLS handshakes for unrelated requests.
-_METADATA_LOAD_SEMAPHORE = asyncio.Semaphore(50)
+# many sessions in parallel. A separate semaphore is required per loop because
+# asyncio synchronization primitives cannot safely serve waiters from another
+# loop once bound under contention.
+_METADATA_LOAD_LIMIT = 50
+_METADATA_LOAD_SEMAPHORES: dict[asyncio.AbstractEventLoop, asyncio.Semaphore] = {}
+_METADATA_LOAD_SEMAPHORES_LOCK = threading.Lock()
+
+
+def _get_metadata_load_semaphore() -> asyncio.Semaphore:
+    """Return the metadata-load semaphore for the current event loop."""
+    loop = asyncio.get_running_loop()
+
+    with _METADATA_LOAD_SEMAPHORES_LOCK:
+        closed_loops = [
+            cached_loop
+            for cached_loop in _METADATA_LOAD_SEMAPHORES
+            if cached_loop.is_closed()
+        ]
+        for closed_loop in closed_loops:
+            del _METADATA_LOAD_SEMAPHORES[closed_loop]
+
+        semaphore = _METADATA_LOAD_SEMAPHORES.get(loop)
+        if semaphore is None:
+            semaphore = asyncio.Semaphore(_METADATA_LOAD_LIMIT)
+            _METADATA_LOAD_SEMAPHORES[loop] = semaphore
+        return semaphore
 
 
 def is_internal_artifact(filename: str) -> bool:
@@ -1141,16 +1164,17 @@ async def get_artifact_info_list(
                             list_ver_err,
                         )
 
-                data = await load_artifact_content_or_metadata(
-                    artifact_service=artifact_service,
-                    app_name=app_name,
-                    user_id=user_id,
-                    session_id=session_id,
-                    filename=filename,
-                    version="latest",
-                    load_metadata_only=True,
-                    log_identifier_prefix=log_identifier_item,
-                )
+                async with _get_metadata_load_semaphore():
+                    data = await load_artifact_content_or_metadata(
+                        artifact_service=artifact_service,
+                        app_name=app_name,
+                        user_id=user_id,
+                        session_id=session_id,
+                        filename=filename,
+                        version="latest",
+                        load_metadata_only=True,
+                        log_identifier_prefix=log_identifier_item,
+                    )
 
                 metadata = data.get("metadata", {})
                 mime_type = metadata.get("mime_type", "application/data")
@@ -1344,7 +1368,7 @@ async def get_artifact_info_list_fast(
                 version_to_load: int | str = latest_metadata_version_by_filename.get(
                     filename, "latest"
                 )
-                async with _METADATA_LOAD_SEMAPHORE:
+                async with _get_metadata_load_semaphore():
                     data = await load_artifact_content_or_metadata(
                         artifact_service=artifact_service,
                         app_name=app_name,

--- a/tests/unit/agent/utils/test_artifact_helpers_concurrency.py
+++ b/tests/unit/agent/utils/test_artifact_helpers_concurrency.py
@@ -1,0 +1,123 @@
+"""Concurrency regression tests for artifact metadata listing."""
+
+import asyncio
+import threading
+from concurrent.futures import ThreadPoolExecutor
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from google.adk.artifacts import BaseArtifactService
+
+from solace_agent_mesh.agent.utils.artifact_helpers import (
+    _METADATA_LOAD_LIMIT,
+    get_artifact_info_list,
+    get_artifact_info_list_fast,
+)
+
+
+@pytest.mark.parametrize(
+    "list_function", [get_artifact_info_list, get_artifact_info_list_fast]
+)
+def test_metadata_load_limit_is_loop_local_under_contention(list_function):
+    """Both listing paths enforce an independent limit on each event loop."""
+    release_loads = threading.Event()
+    loops_ready = [threading.Event(), threading.Event()]
+    loop_state = threading.local()
+    states = [
+        {"entered": 0, "active": 0, "max_active": 0},
+        {"entered": 0, "active": 0, "max_active": 0},
+    ]
+
+    async def blocked_load(**_kwargs):
+        state = loop_state.current
+        state["entered"] += 1
+        state["active"] += 1
+        state["max_active"] = max(state["max_active"], state["active"])
+        try:
+            await state["gate"].wait()
+        finally:
+            state["active"] -= 1
+        return {
+            "metadata": {"mime_type": "text/plain", "size_bytes": 1},
+            "version": 1,
+        }
+
+    async def run_on_loop(index):
+        state = states[index]
+        loop_state.current = state
+        state["gate"] = asyncio.Event()
+
+        service = AsyncMock(spec=BaseArtifactService)
+        service.list_versions = AsyncMock(return_value=[1])
+        if list_function is get_artifact_info_list_fast:
+            service.list_artifact_keys = AsyncMock(
+                return_value=[
+                    f"artifact-{number}.txt"
+                    for number in range(_METADATA_LOAD_LIMIT + 1)
+                ]
+            )
+            listing = asyncio.create_task(
+                list_function(
+                    artifact_service=service,
+                    app_name="app",
+                    user_id="user",
+                    session_id=f"session-{index}",
+                )
+            )
+        else:
+            service.list_artifact_keys = AsyncMock(return_value=["artifact.txt"])
+
+            async def list_all_sessions():
+                nested_results = await asyncio.gather(
+                    *(
+                        list_function(
+                            artifact_service=service,
+                            app_name="app",
+                            user_id="user",
+                            session_id=f"session-{index}-{number}",
+                        )
+                        for number in range(_METADATA_LOAD_LIMIT + 1)
+                    )
+                )
+                return [item for result in nested_results for item in result]
+
+            listing = asyncio.create_task(list_all_sessions())
+
+        async def wait_for_contention():
+            while state["entered"] < _METADATA_LOAD_LIMIT and not listing.done():
+                await asyncio.sleep(0)
+
+        await asyncio.wait_for(wait_for_contention(), timeout=5)
+        await asyncio.sleep(0)
+        loops_ready[index].set()
+
+        await asyncio.to_thread(release_loads.wait)
+        state["gate"].set()
+        return await listing
+
+    with (
+        patch(
+            "solace_agent_mesh.agent.utils.artifact_helpers.load_artifact_content_or_metadata",
+            new=blocked_load,
+        ),
+        ThreadPoolExecutor(max_workers=2) as executor,
+    ):
+        futures = []
+        try:
+            futures.append(executor.submit(asyncio.run, run_on_loop(0)))
+            assert loops_ready[0].wait(10)
+
+            futures.append(executor.submit(asyncio.run, run_on_loop(1)))
+            assert loops_ready[1].wait(10)
+        finally:
+            release_loads.set()
+
+        results = [future.result(timeout=10) for future in futures]
+
+    for state, result in zip(states, results, strict=True):
+        assert state["entered"] == _METADATA_LOAD_LIMIT + 1
+        assert state["max_active"] == _METADATA_LOAD_LIMIT
+        assert len(result) == _METADATA_LOAD_LIMIT + 1
+        assert all(
+            not info.description.startswith("Error loading details") for info in result
+        )


### PR DESCRIPTION
### What is the purpose of this change?

Fixes #1591.

Artifact metadata can be loaded from both the FastAPI and SAC event loops. The module-level `asyncio.Semaphore` can bind to one loop under contention, causing metadata loads from the other loop to fail with a cross-loop `RuntimeError`.

This change keeps the metadata concurrency limit while making it safe for multiple event loops in the same process.

### How was this change implemented?

- Replace the shared semaphore with a registry keyed by the running event loop.
- Guard registry access with a `threading.Lock` because the loops run in different threads.
- Remove entries for closed loops opportunistically when the registry is accessed.
- Use the loop-local semaphore in both artifact-info loading paths.
- Add a regression test that drives two event loops concurrently and verifies an independent limit of 50 metadata loads per loop without cross-loop errors.

### Key Design Decisions

The registry uses event-loop objects rather than loop IDs, avoiding ID-reuse hazards. Closed-loop cleanup also avoids retaining stale entries during long-running processes that recreate loops.

### How was this change tested?

- [x] Unit tests: artifact helper suite (`117 passed`, `3 warnings`)
- [x] Ruff lint and format checks for the new concurrency test
- [x] `git diff --check`

### Is there anything the reviewers should focus on/be aware of?

PR #1590 currently changes the same area. When rebasing it on this change, its wider critical section around version listing and metadata loading should be retained while switching to `_get_metadata_load_semaphore()`.
