### PR TITLE
fix(DATAGO-146160): bump pyasn1 to 0.6.4 for CVE-2026-59884, CVE-2026-59885, CVE-2026-59886

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -88,7 +88,7 @@ dependencies = [
     "azure-identity>=1.17.0",
     "azure-storage-blob==12.28.0",
     "authlib>=1.6.12",  # [CVE-2026-27962, CVE-2026-41425, CVE-2026-44681] Security fixes
-    "pyasn1>=0.6.3",  # [CVE-2026-30922] Security fix: Prevents DoS via unbounded recursion in ASN.1 decoder
+    "pyasn1>=0.6.4",  # [CVE-2026-30922, CVE-2026-59884, CVE-2026-59885, CVE-2026-59886] Security fix: Prevents DoS via unbounded recursion/quadratic-time decoding in ASN.1 decoder
     "cachetools==7.0.1",
     "openfeature-sdk==0.8.4",
     "filelock==3.20.3",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -88,7 +88,7 @@ dependencies = [
     "azure-identity>=1.17.0",
     "azure-storage-blob==12.28.0",
     "authlib>=1.6.12",  # [CVE-2026-27962, CVE-2026-41425, CVE-2026-44681] Security fixes
-    "pyasn1>=0.6.4",  # [CVE-2026-30922, CVE-2026-59884, CVE-2026-59885, CVE-2026-59886] Security fix: Prevents DoS via unbounded recursion/quadratic-time decoding in ASN.1 decoder
+    "pyasn1>=0.6.4",  # [CVE-2026-30922, CVE-2026-59884, CVE-2026-59885, CVE-2026-59886] Security fixes
     "cachetools==7.0.1",
     "openfeature-sdk==0.8.4",
     "filelock==3.20.3",

--- a/uv.lock
+++ b/uv.lock
@@ -3684,11 +3684,11 @@ memory = [
 
 [[package]]
 name = "pyasn1"
-version = "0.6.3"
+version = "0.6.4"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/5c/5f/6583902b6f79b399c9c40674ac384fd9cd77805f9e6205075f828ef11fb2/pyasn1-0.6.3.tar.gz", hash = "sha256:697a8ecd6d98891189184ca1fa05d1bb00e2f84b5977c481452050549c8a72cf", size = 148685, upload-time = "2026-03-17T01:06:53.382Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/a4/9a/23310166d960def5897e91fe20e5b724601b02a22e84ba1f94232c0b7f67/pyasn1-0.6.4.tar.gz", hash = "sha256:9c447d8431c947fe4c8febc4ed9e760bc29011a5b01e5c74b67025bd9fb8ce81", size = 151262, upload-time = "2026-07-09T01:12:33.988Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/5d/a0/7d793dce3fa811fe047d6ae2431c672364b462850c6235ae306c0efd025f/pyasn1-0.6.3-py3-none-any.whl", hash = "sha256:a80184d120f0864a52a073acc6fc642847d0be408e7c7252f31390c0f4eadcde", size = 83997, upload-time = "2026-03-17T01:06:52.036Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/3b/6163796d69c3977d1e4287bea4a6979161cbbdd170ebb430511e8e1999ce/pyasn1-0.6.4-py3-none-any.whl", hash = "sha256:deda9277cfd454080ec40b207fb6df82206a3a2688735233cdcd8d3d565f088b", size = 84410, upload-time = "2026-07-09T01:12:32.92Z" },
 ]
 
 [[package]]
@@ -4844,7 +4844,7 @@ requires-dist = [
     { name = "protobuf", specifier = "==6.33.6" },
     { name = "psycopg2-binary", specifier = "==2.9.10" },
     { name = "psycopg2-binary", marker = "extra == 'test'" },
-    { name = "pyasn1", specifier = ">=0.6.3" },
+    { name = "pyasn1", specifier = ">=0.6.4" },
     { name = "pydantic", specifier = "==2.12.5" },
     { name = "pydub", specifier = "==0.25.1" },
     { name = "pyjwt", specifier = ">=2.13.0" },


### PR DESCRIPTION
### What is the purpose of this change?

    Fixes DATAGO-146160: three High-severity pyasn1 CVEs (CVE-2026-59884, CVE-2026-59885, CVE-2026-59886) flagged by FOSSA/Prisma against solace-agent-mesh:main. All are DoS vectors in pyasn1's BER/CER/DER decode/encode paths (unbounded tag-size accumulation, quadratic-time OID parsing, unbounded REAL-to-float conversion) that can be triggered by untrusted ASN.1 input. Fixed upstream in pyasn1 0.6.4.

### How was this change implemented?

    pyasn1 was already a direct dependency pin (`pyasn1>=0.6.3`) added for an earlier CVE (CVE-2026-30922). Raised the floor to `>=0.6.4` in `pyproject.toml` and refreshed `uv.lock` via `uv lock`, which resolves pyasn1 to 0.6.4. No other dependencies were affected.

### How was this change tested?

- [x] Manual testing: `uv lock` resolved cleanly (`Updated pyasn1 v0.6.3 -> v0.6.4`); `uv run python -c "import pyasn1; print(pyasn1.__version__)"` confirms 0.6.4 installs and imports.
- [ ] Unit tests: none added — version bump only, no code changes.
- [ ] Integration tests: not applicable.
- [x] Known limitations: `solace-agent-mesh-enterprise` pins `solace-agent-mesh==1.28.6` and will keep resolving pyasn1 0.6.3 transitively until its community pin is bumped to a release that includes this fix — tracked as a follow-up.

### Is there anything the reviewers should focus on/be aware of?

    Straightforward floor bump on an existing security pin; diff is limited to `pyproject.toml` and `uv.lock`.