### PR TITLE
fix(DATAGO-147141): bump undici override to 7.29.0

### DIFF
--- a/config_portal/frontend/package-lock.json
+++ b/config_portal/frontend/package-lock.json
@@ -1574,15 +1574,6 @@
         }
       }
     },
-    "node_modules/@remix-run/node/node_modules/undici": {
-      "version": "7.28.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-7.28.0.tgz",
-      "integrity": "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=20.18.1"
-      }
-    },
     "node_modules/@remix-run/react": {
       "version": "2.17.5",
       "resolved": "https://registry.npmjs.org/@remix-run/react/-/react-2.17.5.tgz",
@@ -14571,6 +14562,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/undici": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.29.0.tgz",
+      "integrity": "sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.1"
       }
     },
     "node_modules/undici-types": {

--- a/config_portal/frontend/package.json
+++ b/config_portal/frontend/package.json
@@ -47,7 +47,7 @@
     "@rollup/rollup-linux-x64-gnu": "4.36.0"
   },
   "overrides": {
-    "undici": "^7.28.0",
+    "undici": "^7.29.0",
     "turbo-stream": "3.0.0"
   },
   "engines": {


### PR DESCRIPTION
### What is the purpose of this change?

    Fixes DATAGO-147141: undici Critical/High/Medium CVEs (CVE-2026-13697, CVE-2026-14643, CVE-2026-15157, CVE-2026-16728, CVE-2026-16729) flagged by FOSSA/Prisma against solace-agent-mesh:main. undici is a transitive dependency of `@remix-run/node` in the config-portal frontend; all affected versions are fixed in 7.29.0.

### How was this change implemented?

    undici is not a direct dependency — it's pulled in transitively via `@remix-run/node` and has been forced to a fixed version through an `overrides` entry in `config_portal/frontend/package.json` across several prior CVE rounds (see #1217, #1583, #1597). Raised that override from `^7.28.0` to `^7.29.0` and refreshed `config_portal/frontend/package-lock.json` via `npm install`, which resolves undici to 7.29.0 (now hoisted to top-level `node_modules/undici`). No other dependencies were affected.

### How was this change tested?

- [x] Manual testing: `npm install` resolved cleanly; `package-lock.json` confirms `undici@7.29.0`.
- [x] Unit tests: not applicable — version bump only, no code changes.
- [ ] Integration tests: not applicable.
- [x] Known limitations: `npm run typecheck` in this package shows 2 pre-existing type errors (`AddAgentFlow.tsx`, `AddGatewayFlow.tsx`) unrelated to this change — confirmed identical on unmodified `main` before this bump.

### Is there anything the reviewers should focus on/be aware of?

    Straightforward override bump, following the same pattern used for prior undici CVE fixes in this package. Diff is limited to `config_portal/frontend/package.json` and `package-lock.json`. The Jira ticket also lists stale `undici:6.27.0` findings from before the earlier override existed — only `7.28.0` is actually resolved in the current lockfile, so this bump covers everything currently installed.