### PR TITLE
fix(DATAGO-145440): bump GitPython to 3.1.59

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,7 +57,7 @@ dependencies = [
     "jsonpath-ng==1.7.0",
     "pydub==0.25.1",
     "toml==0.10.2",
-    "GitPython==3.1.50",
+    "GitPython==3.1.59",  # Security fixes (see DATAGO-145440 for the full GHSA list)
     "Flask==3.1.3",
     "flask-cors==6.0.1",
     "werkzeug==3.1.6",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,7 +57,7 @@ dependencies = [
     "jsonpath-ng==1.7.0",
     "pydub==0.25.1",
     "toml==0.10.2",
-    "GitPython==3.1.59",  # Security fixes (see DATAGO-145440 for the full GHSA list)
+    "GitPython==3.1.59",  # [GHSA-2f96-g7mh-g2hx, GHSA-956x-8gvw-wg5v, GHSA-rwj8-pgh3-r573, GHSA-v396-v7q4-x2qj, GHSA-3rp5-jjmw-4wv2, GHSA-6p8h-3wgx-97gf, GHSA-fjr4-x663-mwxc, GHSA-r9mr-m37c-5fr3, GHSA-94p4-4cq8-9g67, GHSA-3f7w-8rr8-f37f, GHSA-539m-9xh6-q6rr, GHSA-p538-c434-8v24, GHSA-4gmw-gg2m-w46p, GHSA-9rj7-rf2p-w77r, GHSA-hh9p-6wh2-4mfc, GHSA-hmq2-w58f-27jc, GHSA-jm78-9fvv-mhgr, GHSA-wvpp-8hx9-p66j] Security fixes
     "Flask==3.1.3",
     "flask-cors==6.0.1",
     "werkzeug==3.1.6",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,7 +57,7 @@ dependencies = [
     "jsonpath-ng==1.7.0",
     "pydub==0.25.1",
     "toml==0.10.2",
-    "GitPython==3.1.59",  # [GHSA-2f96-g7mh-g2hx, GHSA-956x-8gvw-wg5v, GHSA-rwj8-pgh3-r573, GHSA-v396-v7q4-x2qj, GHSA-3rp5-jjmw-4wv2, GHSA-6p8h-3wgx-97gf, GHSA-fjr4-x663-mwxc, GHSA-r9mr-m37c-5fr3, GHSA-94p4-4cq8-9g67, GHSA-3f7w-8rr8-f37f, GHSA-539m-9xh6-q6rr, GHSA-p538-c434-8v24, GHSA-4gmw-gg2m-w46p, GHSA-9rj7-rf2p-w77r, GHSA-hh9p-6wh2-4mfc, GHSA-hmq2-w58f-27jc, GHSA-jm78-9fvv-mhgr, GHSA-wvpp-8hx9-p66j] Security fixes
+    "GitPython==3.1.59",
     "Flask==3.1.3",
     "flask-cors==6.0.1",
     "werkzeug==3.1.6",

--- a/uv.lock
+++ b/uv.lock
@@ -1337,14 +1337,14 @@ wheels = [
 
 [[package]]
 name = "gitpython"
-version = "3.1.50"
+version = "3.1.59"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "gitdb" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/33/f6/354ae6491228b5eb40e10d89c4d13c651fe1cf7556e35ebdded50cff57ce/gitpython-3.1.50.tar.gz", hash = "sha256:80da2d12504d52e1f998772dc5baf6e553f8d2fcfe1fcc226c9d9a2ee3372dcc", size = 219798, upload-time = "2026-05-06T04:01:26.571Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/ca/dc/126b28e76b24a9268ba931ad3e012f71ebdadf62fd9f17758f7074bb0b20/gitpython-3.1.59.tar.gz", hash = "sha256:0a1475cfdc38a5bfba1a3e9a4a9da52a39749ecec322b772915c019f94e5b7e4", size = 230445, upload-time = "2026-08-10T12:03:20.271Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/20/7a/1c6e3562dfd8950adbb11ffbc65d21e7c89d01a6e4f137fa981056de25c5/gitpython-3.1.50-py3-none-any.whl", hash = "sha256:d352abe2908d07355014abdd21ddf798c2a961469239afec4962e9da884858f9", size = 212507, upload-time = "2026-05-06T04:01:23.799Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/ed/ae57eb7d344f43f87b74b3a281ead6ec7d6394eef72a7b1dcb28dd089550/gitpython-3.1.59-py3-none-any.whl", hash = "sha256:67a82f537384578643624c8b2c531938a9b82be431663e575dcf638526631d4c", size = 220996, upload-time = "2026-08-10T12:03:18.804Z" },
 ]
 
 [[package]]
@@ -4810,7 +4810,7 @@ requires-dist = [
     { name = "filelock", specifier = "==3.20.3" },
     { name = "flask", specifier = "==3.1.3" },
     { name = "flask-cors", specifier = "==6.0.1" },
-    { name = "gitpython", specifier = "==3.1.50" },
+    { name = "gitpython", specifier = "==3.1.59" },
     { name = "google-adk", specifier = "==1.18.0" },
     { name = "google-cloud-aiplatform", marker = "extra == 'vertex'", specifier = "==1.133.0" },
     { name = "google-cloud-storage", specifier = "==3.9.0" },


### PR DESCRIPTION
### What is the purpose of this change?

    Fixes DATAGO-145440: 18 High/Medium GitHub advisories (mostly GHSA-only, no assigned CVEs) against GitPython 3.1.50, flagged by Prisma. All are variations of the same underlying issue — git command/option injection via subprocess calls — where each patch release closed one bypass and a subsequent advisory found the next one. Full GHSA list is in the Jira ticket's attached CSV.

### How was this change implemented?

    GitPython is a direct, exact-pinned dependency (`GitPython==3.1.50`) in `pyproject.toml`. Bumped the pin to `3.1.59`, the current latest release on PyPI with no open advisories, and refreshed `uv.lock` via `uv lock`. No other dependencies were affected.

### How was this change tested?

- [x] Manual testing: `uv lock` resolved cleanly (`Updated gitpython v3.1.50 -> v3.1.59`); confirmed `import git` works at the new version.
- [x] Unit tests: ran the existing suites covering the only in-repo GitPython usage (`config_portal/backend/plugin_catalog/scraper.py`) — `tests/unit/config_portal/backend/plugin_catalog/test_registry_readd.py` and `tests/unit/cli/commands/plugin_cmd/test_catalog_cmd.py`, 25/25 passed.
- [ ] Integration tests: not applicable.
- [x] Known limitations: none — the in-repo usage (`git.Repo`, `clone_from`, `GitCommandError`) is a stable, long-standing API untouched by these security patches.

### Is there anything the reviewers should focus on/be aware of?

    9 patch versions in one jump looks large, but every intermediate release (3.1.51-3.1.59) was a security-only patch closing a specific injection bypass, not a feature release. Diff is limited to `pyproject.toml` and `uv.lock`.