### PR TITLE
fix(DATAGO-130675): bump pypdf to 6.15.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -80,7 +80,7 @@ dependencies = [
     "cryptography==48.0.1",  # [CVE-2026-39892, GHSA-537c-gmf6-5ccf] Security fix: addresses vulnerabilities in older versions (transitive dependency from multiple packages)
     "pillow==12.3.0",  # [CVE-2026-54058, CVE-2026-54059, CVE-2026-54060, CVE-2026-55379, CVE-2026-55380, CVE-2026-55798, CVE-2026-59198, CVE-2026-59203, CVE-2026-59204] Security fix: addresses vulnerabilities in older versions (transitive dependency from python-pptx)
     "bm25s==0.2.14",
-    "pypdf==6.10.2",  # [CVE-2026-40260, GHSA-jj6c-8h6c-hppx] Security fix: multiple vulnerabilities resolved in 6.10.2
+    "pypdf==6.15.0",  # Security fix: multiple vulnerabilities resolved in 6.15.0
     "lxml==6.1.0",
     "python-pptx==1.0.2",
     "python-docx==1.2.0",
@@ -140,7 +140,7 @@ dependencies = [
     "asyncpg",
     "bm25s==0.2.14",
     "pymysql>=1.1.0",  # Required for MySQL testcontainers
-    "pypdf==6.10.2",
+    "pypdf==6.15.0",
     "python-pptx==1.0.2",
     "python-docx==1.2.0",
     "sam-test-infrastructure @ {root:uri}/tests/sam-test-infrastructure"

--- a/uv.lock
+++ b/uv.lock
@@ -3908,14 +3908,14 @@ wheels = [
 
 [[package]]
 name = "pypdf"
-version = "6.10.2"
+version = "6.15.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "typing-extensions", marker = "python_full_version < '3.11'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/7b/3f/9f2167401c2e94833ca3b69535bad89e533b5de75fefe4197a2c224baec2/pypdf-6.10.2.tar.gz", hash = "sha256:7d09ce108eff6bf67465d461b6ef352dcb8d84f7a91befc02f904455c6eea11d", size = 5315679, upload-time = "2026-04-15T16:37:36.978Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/17/17/ee75a92718ec7212de831e71454d702225aa5e474a805cce169806044453/pypdf-6.15.0.tar.gz", hash = "sha256:d39c4d955a76409284a905e2d65b40076d77ab76129e0faaeeb6612403ecfc79", size = 6993794, upload-time = "2026-08-06T13:06:49.929Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/0c/d6/1d5c60cc17bbdf37c1552d9c03862fc6d32c5836732a0415b2d637edc2d0/pypdf-6.10.2-py3-none-any.whl", hash = "sha256:aa53be9826655b51c96741e5d7983ca224d898ac0a77896e64636810517624aa", size = 336308, upload-time = "2026-04-15T16:37:34.851Z" },
+    { url = "https://files.pythonhosted.org/packages/af/72/ce3067ac31e214a66388159f8462ddb8c13dd00170f24d555a1f1ae8ee91/pypdf-6.15.0-py3-none-any.whl", hash = "sha256:14e001d6504822cb1ca9c7ed9a69bccb320f59b320730f55af804361abe4d5ee", size = 378123, upload-time = "2026-08-06T13:06:47.709Z" },
 ]
 
 [[package]]
@@ -4849,7 +4849,7 @@ requires-dist = [
     { name = "pydub", specifier = "==0.25.1" },
     { name = "pyjwt", specifier = ">=2.13.0" },
     { name = "pymysql", marker = "extra == 'test'", specifier = ">=1.1.0" },
-    { name = "pypdf", specifier = "==6.10.2" },
+    { name = "pypdf", specifier = "==6.15.0" },
     { name = "pystache", specifier = "==0.6.8" },
     { name = "pytest", marker = "extra == 'test'", specifier = ">=8.0.0" },
     { name = "pytest-asyncio", marker = "extra == 'test'" },


### PR DESCRIPTION
### What is the purpose of this change?

    Fixes DATAGO-130675: 14 open High/Medium CVEs against pypdf 6.10.2 (CVE-2026-54531, CVE-2026-49461, CVE-2026-54530, GHSA-jm82-fx9c-mx94, CVE-2026-49460, CVE-2026-48735, CVE-2026-48155, CVE-2026-48156, CVE-2026-54651, CVE-2026-59935, CVE-2026-59936, CVE-2026-59937, CVE-2026-59938, CVE-2026-71852, CVE-2026-71870), flagged by FOSSA/Prisma. The two newest (CVE-2026-71852/CVE-2026-71870, font width/ToUnicode DoS) are confirmed fixed exactly at pypdf 6.15.0 per the upstream advisories.

### How was this change implemented?

    pypdf is a direct, exact-pinned dependency in `pyproject.toml` (main `[project.dependencies]` and the `[tool.hatch.envs.hatch-test]` mirror). Bumped both from `6.10.2` to `6.15.0` — the current latest release on PyPI with no open advisories — and refreshed `uv.lock` via `uv lock`. No other dependencies were affected.

### How was this change tested?

- [x] Manual testing: `uv lock` resolved cleanly (`Updated pypdf v6.10.2 -> v6.15.0`).
- [x] Unit tests: ran all suites covering the only in-repo pypdf usage (`PdfReader` in `src/solace_agent_mesh/gateway/http_sse/services/file_converter_service.py`) — `test_file_converter_service.py`, `test_file_converter_comprehensive.py`, `test_indexing_task_service.py`, `test_indexing_task_comprehensive.py`, 83/83 passed.
- [ ] Integration tests: not applicable.
- [x] Known limitations: none identified — pypdf's public `PdfReader` API used here is unaffected by these fixes.

### Is there anything the reviewers should focus on/be aware of?

    5 minor versions in one jump, but each intermediate release was a normal pypdf release (not security-only, unlike the recent GitPython bump) — 6.15.0 is simply the current latest, chosen because it's the first version confirmed to close every advisory in the ticket. Diff is limited to `pyproject.toml` (two pins) and `uv.lock`.