### PR TITLE
fix: show the agent's real model in the context usage indicator

### DIFF
--- a/client/webui/frontend/src/lib/components/chat/ContextUsageIndicator.tsx
+++ b/client/webui/frontend/src/lib/components/chat/ContextUsageIndicator.tsx
@@ -241,7 +241,7 @@ export function ContextUsageIndicator({ sessionId, onCompacted, messageCount = 0
                                 <span className="text-muted-foreground shrink-0">Model:</span>
                                 <Tooltip>
                                     <TooltipTrigger asChild>
-                                        <span className="min-w-0 truncate font-mono font-semibold">{formatModelName(usage.model)}</span>
+                                        <span className="min-w-0 truncate font-mono font-semibold">{formatModelName(usage.model ?? "")}</span>
                                     </TooltipTrigger>
                                     <TooltipContent className="max-w-xs break-all">{usage.model}</TooltipContent>
                                 </Tooltip>

--- a/client/webui/frontend/src/lib/types/context-usage.ts
+++ b/client/webui/frontend/src/lib/types/context-usage.ts
@@ -11,7 +11,8 @@ export interface ContextUsage {
     /** null when the model's context limit is unknown (e.g. LiteLLM has no info) */
     maxInputTokens: number | null;
     usagePercentage: number;
-    model: string;
+    /** null when the model could not be attributed to the selected agent (no completed task yet) */
+    model: string | null;
     totalEvents: number;
     totalMessages: number;
     totalTasks: number;

--- a/docs/docs/documentation/installing-and-configuring/model_configurations.md
+++ b/docs/docs/documentation/installing-and-configuring/model_configurations.md
@@ -239,6 +239,8 @@ The indicator is only rendered when the model's context window is known. The pla
 
 If none of these resolve, the indicator is hidden rather than displayed against a guessed limit. Set `Max Input Tokens` explicitly in the Models UI whenever you connect a Custom provider or a model the registry does not recognize, and check the provider's documentation for the current value — providers publish this per model and can change it over time.
 
+The model itself is identified from the selected agent's most recent completed task in the session, which is the point at which the agent reports the model it used. The indicator is therefore hidden until that agent completes its first task in a session, and stays hidden for providers that do not return token usage metadata. In the latter case the gateway logs a warning naming the session and agent.
+
 ## Next Steps
 
 - For details on LLM provider configuration options and prompt caching, see [Configuring LLMs](./large_language_models.md)

--- a/src/solace_agent_mesh/gateway/http_sse/routers/sessions.py
+++ b/src/solace_agent_mesh/gateway/http_sse/routers/sessions.py
@@ -1173,11 +1173,6 @@ async def trigger_title_generation(
 # Context Usage & Manual Compaction Endpoints
 # =============================================================================
 
-# Fallback model used for token counting when neither the request nor the
-# component config specifies a model.  Callers should prefer the component's
-# configured model (component.model_config) over this constant.
-DEFAULT_MODEL = "claude-sonnet-4-5"
-
 
 class ContextUsageResponse(BaseModel):
     """Response model for session context window usage."""
@@ -1188,7 +1183,10 @@ class ContextUsageResponse(BaseModel):
     cached_tokens: int = Field(default=0, alias="cachedTokens")
     max_input_tokens: Optional[int] = Field(default=None, alias="maxInputTokens")
     usage_percentage: float = Field(alias="usagePercentage")
-    model: str
+    # None when the model could not be attributed to the selected agent (no
+    # completed task yet, or the provider never reported usage metadata). The
+    # client hides the indicator rather than showing an invented model.
+    model: Optional[str] = None
     total_events: int = Field(alias="totalEvents")
     total_messages: int = Field(default=0, alias="totalMessages")
     total_tasks: int = Field(default=0, alias="totalTasks")
@@ -1356,14 +1354,13 @@ async def get_session_context_usage(
             raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Session not found")
 
         # Resolve the model to use for context limit lookup:
-        # 1. Explicit model from request query param
-        # 2. Model configured on the gateway component
-        # 3. Hardcoded fallback constant
-        component_model = None
-        if hasattr(component, "model_config") and isinstance(component.model_config, dict):
-            component_model = component.model_config.get("model")
-        resolved_default_model = component_model or DEFAULT_MODEL
-        effective_model = model or resolved_default_model
+        # 1. Explicit model from the request query param (caller override)
+        # 2. The model the selected agent actually used, read from its latest
+        #    completed task's token_usage_details.by_model further below
+        # 3. None — unknown. Never fall back to the gateway component's own
+        #    `model:` config: that is the gateway's model, not the agent's, and
+        #    inventing a name here produces a confidently wrong context limit.
+        effective_model: Optional[str] = model
 
         prompt_tokens = 0
         completion_tokens = 0
@@ -1434,16 +1431,22 @@ async def get_session_context_usage(
                 except AttributeError:
                     return None
 
-            # Find the most recent real (non-compaction) task's agent — that's the
-            # ADK session currently active for this gateway session.
-            current_agent: Optional[str] = None
-            for t in completed_tasks:
-                if (t.id or "").startswith("compaction-cost-"):
-                    continue
-                current_agent = _task_agent(t.id)
-                if current_agent:
-                    break
-            if current_agent is None:
+            # The agent the caller says the user is talking to wins — the UI
+            # passes ?agent_name= for exactly this, and it is authoritative in a
+            # way history is not: right after an agent switch the most recent
+            # task still belongs to the *previous* agent. Fall back to the
+            # historical inference for callers that omit the parameter.
+            current_agent: Optional[str] = agent_name
+            if not current_agent:
+                # Find the most recent real (non-compaction) task's agent — that's the
+                # ADK session currently active for this gateway session.
+                for t in completed_tasks:
+                    if (t.id or "").startswith("compaction-cost-"):
+                        continue
+                    current_agent = _task_agent(t.id)
+                    if current_agent:
+                        break
+            if not current_agent:
                 current_agent = gateway_session.agent_id
 
             if current_agent:
@@ -1455,6 +1458,15 @@ async def get_session_context_usage(
                     for t in completed_tasks
                     if t.id.startswith("compaction-cost-") or _task_agent(t.id) == current_agent
                 ]
+
+                # Compaction-cost rows are kept unconditionally above because they
+                # belong to the session rather than to any one agent. On their own,
+                # though, they are not an agent's context: if no real task survived
+                # the filter, this agent has no history in this session yet, and
+                # reporting the previous agent's post-compaction remaining tokens
+                # as this agent's context would be wrong.
+                if all((t.id or "").startswith("compaction-cost-") for t in completed_tasks):
+                    completed_tasks = []
 
         current_tokens = 0
 
@@ -1502,6 +1514,19 @@ async def get_session_context_usage(
                     dominant = max(valid_entries, key=lambda kv: kv[1].get("input_tokens", 0))
                     effective_model = dominant[0]
 
+            if not effective_model:
+                # The agent has completed work in this session but never reported
+                # which model it used — typically a provider that omits usage
+                # metadata. Surface it: the indicator will be hidden, and without
+                # this the failure is silent.
+                log.warning(
+                    "Context usage for session %s: completed tasks exist for agent %s "
+                    "but no model could be attributed (token_usage_details.by_model "
+                    "is empty) — hiding the context indicator.",
+                    session_id,
+                    current_agent,
+                )
+
         stamped_limit: Optional[int] = None
         if completed_tasks:
             real_latest_for_limit = next(
@@ -1517,7 +1542,11 @@ async def get_session_context_usage(
                 except (TypeError, ValueError):
                     stamped_limit = None
 
-        max_input_tokens = _get_model_context_limit(effective_model, db=db, stamped=stamped_limit)
+        max_input_tokens = (
+            _get_model_context_limit(effective_model, db=db, stamped=stamped_limit)
+            if effective_model
+            else None
+        )
         usage_pct = (
             min(100.0, round((current_tokens / max_input_tokens) * 100, 1))
             if max_input_tokens and current_tokens > 0

--- a/tests/unit/gateway/http_sse/routers/test_sessions_context_usage.py
+++ b/tests/unit/gateway/http_sse/routers/test_sessions_context_usage.py
@@ -1,6 +1,8 @@
 """Unit tests for context usage and manual compaction endpoints."""
 
 import asyncio
+import logging
+
 import pytest
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -86,6 +88,93 @@ def _make_mock_db():
     query_mock.first.return_value = None
     db.query.return_value = query_mock
     return db
+
+
+def _make_query_chain(all_rows=None, count=0):
+    """A stubbed SQLAlchemy query chain.
+
+    `first()` must return None: `_lookup_configured_context_limit` calls it, and
+    a bare MagicMock would be truthy, making `row[0]` a MagicMock that Pydantic
+    then rejects as `max_input_tokens: int`.
+    """
+    q = MagicMock()
+    q.filter.return_value = q
+    q.order_by.return_value = q
+    q.count.return_value = count
+    q.all.return_value = all_rows or []
+    q.first.return_value = None
+    return q
+
+
+def _make_mock_db_with_agents(tasks, events, chat_task_count=0):
+    """Like _make_mock_db, but routes TaskEventModel queries separately from
+    TaskModel ones, so tests can attribute tasks to different agents."""
+    from solace_agent_mesh.gateway.http_sse.repository.models import (
+        ChatTaskModel,
+        TaskEventModel,
+        TaskModel,
+    )
+
+    def _dispatch(entity, *_args):
+        if entity is ChatTaskModel:
+            return _make_query_chain(count=chat_task_count)
+        if entity is TaskModel:
+            return _make_query_chain(all_rows=tasks)
+        if entity is TaskEventModel:
+            return _make_query_chain(all_rows=events)
+        # ModelConfiguration column lookups fall through to a first() of None.
+        return _make_query_chain()
+
+    db = MagicMock()
+    db.query.side_effect = _dispatch
+    return db
+
+
+def _make_task(
+    task_id, input_tokens=0, output_tokens=0, cached_tokens=0, details=None
+):
+    task = MagicMock()
+    task.id = task_id
+    task.total_input_tokens = input_tokens
+    task.total_output_tokens = output_tokens
+    task.total_cached_input_tokens = cached_tokens
+    task.token_usage_details = details
+    return task
+
+
+def _make_request_event(task_id, agent_name):
+    event = MagicMock()
+    event.task_id = task_id
+    event.direction = "request"
+    event.payload = {"params": {"message": {"metadata": {"agent_name": agent_name}}}}
+    return event
+
+
+async def _call_context_usage(
+    db, session_service, model=None, agent_name=None, component=None
+):
+    """Invoke the endpoint the way the rest of this module does."""
+    if component is None:
+        component = MagicMock()
+        component.model_config = None
+
+    with patch(
+        "solace_agent_mesh.gateway.http_sse.dependencies.get_sac_component",
+        return_value=component,
+    ):
+        from solace_agent_mesh.gateway.http_sse.routers.sessions import (
+            get_session_context_usage,
+        )
+
+        return await get_session_context_usage(
+            session_id="test-session-id",
+            model=model,
+            agent_name=agent_name,
+            db=db,
+            user={"id": "user-1"},
+            session_service=session_service,
+            component=component,
+        )
 
 
 class TestGetSessionContextUsage:
@@ -662,16 +751,20 @@ class TestContextUsageModelResolution:
         return MagicMock()
 
     @pytest.mark.asyncio
-    async def test_uses_component_model_config_as_default(
+    async def test_ignores_component_model_config(
         self, mock_db, mock_session_service
     ):
-        """When no model param given, should use component.model_config['model']."""
+        """The gateway's own `model:` config must never leak into the response.
+
+        `component` here is the WebUI gateway, not the agent, so its model bears
+        no relationship to the model the agent runs.
+        """
         mock_session = MagicMock()
         mock_session.agent_id = "test-agent"
         mock_session_service.get_session_details.return_value = mock_session
 
         mock_component = MagicMock()
-        mock_component.model_config = {"model": "my-custom-model"}
+        mock_component.model_config = {"model": "gateway-model"}
 
         with patch(
             "solace_agent_mesh.gateway.http_sse.dependencies.get_sac_component",
@@ -691,19 +784,18 @@ class TestContextUsageModelResolution:
                 component=mock_component,
             )
 
-        assert result.model == "my-custom-model"
+        assert result.model is None
+        assert result.max_input_tokens is None
 
     @pytest.mark.asyncio
-    async def test_explicit_model_param_overrides_component_config(
-        self, mock_db, mock_session_service
-    ):
-        """Explicit model query param should take priority over component.model_config."""
+    async def test_explicit_model_param_wins(self, mock_db, mock_session_service):
+        """An explicit ?model= query param overrides everything else."""
         mock_session = MagicMock()
         mock_session.agent_id = "test-agent"
         mock_session_service.get_session_details.return_value = mock_session
 
         mock_component = MagicMock()
-        mock_component.model_config = {"model": "component-model"}
+        mock_component.model_config = {"model": "gateway-model"}
 
         with patch(
             "solace_agent_mesh.gateway.http_sse.dependencies.get_sac_component",
@@ -726,16 +818,20 @@ class TestContextUsageModelResolution:
         assert result.model == "explicit-model"
 
     @pytest.mark.asyncio
-    async def test_falls_back_to_default_model_when_no_config(
+    async def test_returns_null_model_when_no_completed_tasks(
         self, mock_db, mock_session_service
     ):
-        """Falls back to DEFAULT_MODEL when component has no model_config."""
+        """With nothing to attribute a model to, report null rather than inventing one.
+
+        The client hides the indicator on a null limit, which beats showing a
+        real denominator for a model the agent never ran.
+        """
         mock_session = MagicMock()
         mock_session.agent_id = "test-agent"
         mock_session_service.get_session_details.return_value = mock_session
 
         mock_component = MagicMock()
-        mock_component.model_config = None  # No model configured
+        mock_component.model_config = None
 
         with patch(
             "solace_agent_mesh.gateway.http_sse.dependencies.get_sac_component",
@@ -743,7 +839,6 @@ class TestContextUsageModelResolution:
         ):
             from solace_agent_mesh.gateway.http_sse.routers.sessions import (
                 get_session_context_usage,
-                DEFAULT_MODEL,
             )
 
             result = await get_session_context_usage(
@@ -756,7 +851,251 @@ class TestContextUsageModelResolution:
                 component=mock_component,
             )
 
-        assert result.model == DEFAULT_MODEL
+        assert result.model is None
+        assert result.max_input_tokens is None
+        assert result.usage_percentage == 0.0
+
+    @pytest.mark.asyncio
+    async def test_model_from_latest_task_by_model(self, mock_session_service):
+        """The model comes from the agent's latest completed task."""
+        mock_session = MagicMock()
+        mock_session.agent_id = None
+        mock_session_service.get_session_details.return_value = mock_session
+
+        task = _make_task(
+            "task-1",
+            input_tokens=1000,
+            details={
+                "by_model": {
+                    "openai/gpt-4o": {"input_tokens": 1000, "max_input_tokens": 128_000}
+                }
+            },
+        )
+        db = _make_mock_db_with_agents(tasks=[task], events=[])
+
+        result = await _call_context_usage(db, mock_session_service)
+
+        assert result.model == "openai/gpt-4o"
+        # Resolved via the agent-stamped max_input_tokens, not the LiteLLM registry.
+        assert result.max_input_tokens == 128_000
+
+    @pytest.mark.asyncio
+    async def test_dominant_model_wins_when_multiple(self, mock_session_service):
+        """When a task used several models, the one with most input tokens wins."""
+        mock_session = MagicMock()
+        mock_session.agent_id = None
+        mock_session_service.get_session_details.return_value = mock_session
+
+        task = _make_task(
+            "task-1",
+            input_tokens=1000,
+            details={
+                "by_model": {
+                    "minor-model": {"input_tokens": 100},
+                    "dominant-model": {"input_tokens": 900, "max_input_tokens": 64_000},
+                }
+            },
+        )
+        db = _make_mock_db_with_agents(tasks=[task], events=[])
+
+        result = await _call_context_usage(db, mock_session_service)
+
+        assert result.model == "dominant-model"
+
+    @pytest.mark.asyncio
+    async def test_null_model_when_by_model_empty(self, mock_session_service, caplog):
+        """A provider that omits usage metadata leaves by_model empty.
+
+        The token totals still come through; only the model is unknown. This is
+        the case the issue reports as failing silently, so it must also warn.
+        """
+        mock_session = MagicMock()
+        mock_session.agent_id = None
+        mock_session_service.get_session_details.return_value = mock_session
+
+        task = _make_task("task-1", input_tokens=5000, output_tokens=700, details={})
+        db = _make_mock_db_with_agents(tasks=[task], events=[])
+
+        with caplog.at_level(
+            logging.WARNING,
+            logger="solace_agent_mesh.gateway.http_sse.routers.sessions",
+        ):
+            result = await _call_context_usage(db, mock_session_service)
+
+        assert result.model is None
+        assert result.max_input_tokens is None
+        assert result.usage_percentage == 0.0
+        # Token math must survive an unresolvable model.
+        assert result.prompt_tokens == 5000
+        assert result.completion_tokens == 700
+        assert "no model could be attributed" in caplog.text
+
+    @pytest.mark.asyncio
+    async def test_by_model_ignores_non_dict_entries(self, mock_session_service):
+        """Malformed by_model entries are skipped rather than crashing."""
+        mock_session = MagicMock()
+        mock_session.agent_id = None
+        mock_session_service.get_session_details.return_value = mock_session
+
+        task = _make_task(
+            "task-1",
+            input_tokens=1000,
+            details={
+                "by_model": {
+                    "good-model": {"input_tokens": 10, "max_input_tokens": 50_000},
+                    "bad-model": "oops",
+                }
+            },
+        )
+        db = _make_mock_db_with_agents(tasks=[task], events=[])
+
+        result = await _call_context_usage(db, mock_session_service)
+
+        assert result.model == "good-model"
+
+
+class TestContextUsageAgentScoping:
+    """Tests for scoping context usage to the caller-supplied agent_name."""
+
+    @pytest.fixture
+    def mock_session_service(self):
+        service = MagicMock()
+        session = MagicMock()
+        session.agent_id = None
+        service.get_session_details.return_value = session
+        return service
+
+    @staticmethod
+    def _two_agent_db(chat_task_count=0):
+        """Newest-first: agent-a ran most recently, agent-b before it."""
+        task_a = _make_task(
+            "task-a",
+            input_tokens=5000,
+            details={
+                "by_model": {
+                    "openai/gpt-4o": {"input_tokens": 5000, "max_input_tokens": 128_000}
+                }
+            },
+        )
+        task_b = _make_task(
+            "task-b",
+            input_tokens=300,
+            details={
+                "by_model": {
+                    "anthropic/claude-x": {
+                        "input_tokens": 300,
+                        "max_input_tokens": 100_000,
+                    }
+                }
+            },
+        )
+        events = [
+            _make_request_event("task-a", "agent-a"),
+            _make_request_event("task-b", "agent-b"),
+        ]
+        return _make_mock_db_with_agents(
+            tasks=[task_a, task_b], events=events, chat_task_count=chat_task_count
+        )
+
+    @pytest.mark.asyncio
+    async def test_agent_name_scopes_model_and_tokens(self, mock_session_service):
+        """agent_name selects the agent, and model and tokens agree with each other.
+
+        Reporting agent A's tokens beside agent B's model would be worse than
+        either being wrong on its own.
+        """
+        db = self._two_agent_db()
+
+        result = await _call_context_usage(
+            db, mock_session_service, agent_name="agent-b"
+        )
+
+        assert result.model == "anthropic/claude-x"
+        assert result.max_input_tokens == 100_000
+        assert result.prompt_tokens == 300
+        assert result.current_context_tokens == 300
+
+    @pytest.mark.asyncio
+    async def test_agent_name_with_no_matching_tasks_returns_empty(
+        self, mock_session_service
+    ):
+        """A newly-selected agent has no context in this session yet."""
+        task_a = _make_task(
+            "task-a",
+            input_tokens=5000,
+            details={"by_model": {"openai/gpt-4o": {"input_tokens": 5000}}},
+        )
+        db = _make_mock_db_with_agents(
+            tasks=[task_a], events=[_make_request_event("task-a", "agent-a")]
+        )
+
+        result = await _call_context_usage(
+            db, mock_session_service, agent_name="agent-b"
+        )
+
+        assert result.model is None
+        assert result.max_input_tokens is None
+        assert result.current_context_tokens == 0
+        assert result.prompt_tokens == 0
+
+    @pytest.mark.asyncio
+    async def test_compaction_cost_row_alone_does_not_leak_into_other_agent(
+        self, mock_session_service
+    ):
+        """Compaction-cost rows survive agent filtering but are not an agent's context.
+
+        Regression test: a session compacted under agent A must not report A's
+        post-compaction remaining tokens as newly-selected agent B's context.
+        """
+        compaction_row = _make_task(
+            "compaction-cost-1",
+            input_tokens=1000,
+            details={"post_compaction_remaining_tokens": 42_000},
+        )
+        task_a = _make_task(
+            "task-a",
+            input_tokens=5000,
+            details={"by_model": {"openai/gpt-4o": {"input_tokens": 5000}}},
+        )
+        db = _make_mock_db_with_agents(
+            tasks=[compaction_row, task_a],
+            events=[_make_request_event("task-a", "agent-a")],
+        )
+
+        result = await _call_context_usage(
+            db, mock_session_service, agent_name="agent-b"
+        )
+
+        assert result.current_context_tokens == 0
+        assert result.model is None
+
+    @pytest.mark.asyncio
+    async def test_omitting_agent_name_falls_back_to_latest_task_agent(
+        self, mock_session_service
+    ):
+        """Callers that don't send agent_name keep the previous behaviour."""
+        db = self._two_agent_db()
+
+        result = await _call_context_usage(db, mock_session_service, agent_name=None)
+
+        assert result.model == "openai/gpt-4o"
+        assert result.prompt_tokens == 5000
+
+    @pytest.mark.asyncio
+    async def test_totals_remain_session_wide(self, mock_session_service):
+        """totalTasks/totalMessages stay session-wide, deliberately.
+
+        The client polls after each response until totalTasks increases; making
+        these agent-scoped would stall that loop on an agent's first message.
+        """
+        db = self._two_agent_db(chat_task_count=4)
+
+        result = await _call_context_usage(
+            db, mock_session_service, agent_name="agent-unknown"
+        )
+
+        assert result.total_tasks == 4
+        assert result.total_messages == 8
 
 
 class TestCreateSessionServiceFromConfig:


### PR DESCRIPTION
### What is the purpose of this change?

Fixes #1627.

The Context Window Usage panel always showed `claude-sonnet-4-5` with a 200K limit, whatever model the agent was actually running. The limit is the denominator of the usage percentage, so users got a wrong idea of how close they were to compaction.

Four causes, all in `get_session_context_usage`:

1. It read `component.model_config`, but the injected component is the gateway. `gateway/http_sse/component.py:171` sets that from the gateway's own `model:` block, which has nothing to do with the agent.
2. `DEFAULT_MODEL = "claude-sonnet-4-5"` was the last resort. That is worse than no value, because the limit lookup then finds a real 200K window for a model the agent never ran.
3. The real model was only recovered from a completed task's `token_usage_details.by_model`, so the made up name stayed until the first task finished, and stayed forever for providers that do not report usage metadata.
4. The `agent_name` query param was accepted but never read. It has been unused since the feature landed in `d2c25fc8`, and the UI has always sent it.

### How was this change implemented?

Backend, `src/solace_agent_mesh/gateway/http_sse/routers/sessions.py`:

* Removed `DEFAULT_MODEL` and the `component.model_config` read.
* Model resolution is now: explicit `?model=` param, then the model recorded against the selected agent, then `null`.
* `agent_name` now picks the agent instead of guessing from history. History is wrong right after an agent switch, when the newest task still belongs to the previous agent. Callers that do not send it keep the old behaviour.
* Added a guard so a lone compaction cost row is not treated as an agent's context (see design notes).
* Skipped the context limit lookup when the model is unknown. Calling it with `None` hits `"/" in model_name` and raises `TypeError`, which the outer handler would turn into a 500.
* `ContextUsageResponse.model` is now `Optional[str]`, which is a response schema change.

Frontend, two one line changes:

* `types/context-usage.ts`: `model` is now `string | null`.
* `ContextUsageIndicator.tsx`: `formatModelName(usage.model ?? "")`. Without this `tsc` fails under `strict`.

No frontend behaviour change was needed. The client already sends `agent_name`, and already hides the indicator when `maxInputTokens` is null, with the comment "showing a progress bar against a made-up 200K limit would be misleading". Returning null lands on that existing path.

Docs: two lines in `model_configurations.md`. The Context Usage Indicator section explained how the limit resolves but never how the model itself is identified.

### Key Design Decisions

**Why not publish the model on the agent card?** That would be the cleaner architecture, but there is no existing way for the gateway to learn a named agent's model. Agent cards carry six extensions and none of them has a model. The dynamic model provider topics are keyed by model id, not agent name. The platform `/models` list has no agent association. Adding a model field to the card is a cross-cutting protocol change, and it would go stale whenever the dynamic model provider swaps a model at runtime. The only source available today is `token_usage_details.by_model`, which is already in the gateway's own database.

**Why hide instead of guessing?** Showing a real 200K denominator for a model the agent never ran is worse than showing nothing. It also matches what the docs already promise at `model_configurations.md:240`.

**The compaction cost guard.** Scoping by agent exposed a latent bug. Compaction cost rows survive the agent filter on purpose, since they belong to the session rather than to one agent. On their own they are not an agent's context, so a session compacted under agent A would report A's post-compaction remaining tokens as newly selected agent B's context. Without the guard the regression test returns 42000 instead of 0.

**`totalTasks` and `totalMessages` stay session wide.** `ContextUsageIndicator.tsx` polls after each response until `totalTasks` increases. Making those agent scoped would stall that loop on an agent's first message.

### How was this change tested?

- [x] Manual testing: ran a dev mode project (`SOLACE_DEV_MODE`, no broker needed) with a session holding completed tasks for two agents on different models, and queried the endpoint:

  | Request | model | maxInputTokens | currentContextTokens |
  | --- | --- | --- | --- |
  | no `agent_name` | `openai/gpt-4o` | 128000 | 5000 |
  | `agent_name=AgentA` | `openai/gpt-4o` | 128000 | 5000 |
  | `agent_name=AgentB` | `anthropic/claude-x` | 100000 | 300 |
  | `agent_name=AgentC` (unknown) | `null` | `null` | 0 |
  | fresh session, no tasks | `null` | `null` | 0 |

  Before the fix the last three rows all returned `claude-sonnet-4-5` with 200000. Note that the model and the token counts move together, so you never see agent A's tokens under agent B's model.

- [x] Unit tests: `tests/unit/gateway/http_sse/routers/test_sessions_context_usage.py`. Rewrote three tests in `TestContextUsageModelResolution` that asserted the old behaviour, added four more, and added a new `TestContextUsageAgentScoping` class with five tests. 32 pass. I also reran the new tests against the old code and six of them fail, so they are not passing by accident. Full `tests/unit/gateway` package: 1514 passed, 24 skipped.

- [ ] Integration tests: none added. This endpoint has no integration coverage today, and the unit tests exercise the changed paths directly.

- [x] Known limitations: no automated frontend test, since there is no existing test for `ContextUsageIndicator`. `tsc -b` and `eslint` are clean, and I confirmed the type change fails `tsc` without the `?? ""`, so that second frontend line is required rather than cosmetic.

### Is there anything the reviewers should focus on/be aware of?

**Behaviour change worth agreeing on.** Sessions that used to show a wrong indicator will now show none until the selected agent completes a task. I think little is lost: when a provider omits usage metadata, `total_input_tokens` is NULL and those tasks are already filtered out by the `isnot(None)` check, so the bar was permanently empty under a wrong model name. Happy to revisit if you would rather keep something on screen.

**Response schema change.** `model` can now be null. The only consumer is the hand written client type, updated here. There is no generated client or OpenAPI snapshot in the repo.

**Log volume.** The new warning fires whenever tasks exist but no model can be attributed, which is up to about five per turn per open tab in a degraded deployment. It is bounded by user interaction, since there is no refetch interval. If that is too noisy I can switch it to the `_warn_missing_model_configurations_once` pattern already in this file.

**Overlap with #1472.** That PR touches the same function. This change adds no `await` and does not touch the signature, so it works whether the handler is sync or async. The thing to watch on rebase is the DB query projection rework, since this code reads `.id` and `.token_usage_details` off the task rows. The agent scoping tests are in their own class to keep any conflict in one place.

**Left out on purpose:** agent scoping the totals, validating `agent_name` against the agent registry (session ownership is already checked and every query filters on session and user, so the param can only narrow an already authorised set), excluding `wf_*` workflow node subtasks from token sums, and adding a model field to the agent card.
