### PR TITLE
fix: import-time crash risk from direct sys.modules lookup

### DIFF
--- a/config_portal/backend/server.py
+++ b/config_portal/backend/server.py
@@ -20,8 +20,11 @@ import logging
 
 log = logging.getLogger("werkzeug")
 log.disabled = True
-cli_flask = sys.modules["flask.cli"]
-cli_flask.show_server_banner = lambda *x: None
+try:
+    import flask.cli
+    flask.cli.show_server_banner = lambda *x: None
+except ImportError:
+    pass
 litellm.suppress_debug_info = True
 
 config_portal_host = "CONFIG_PORTAL_HOST"


### PR DESCRIPTION
Fixes #1271 by safely importing flask.cli and catching ImportError, removing the brittle sys.modules dict lookup that caused KeyErrors.