### PR TITLE
fix(agent): use per-event-loop metadata-load semaphores

### DIFF
--- a/.github/workflows/release-post-process.yml
+++ b/.github/workflows/release-post-process.yml
@@ -92,7 +92,8 @@ jobs:
 
       - name: Install Hatch
         if: steps.resolve-commit.outputs.is_release_please_tag == 'true'
-        run: uv tool install --with virtualenv==20.26.6 hatch
+        # hatchling>=1.32 defaults core metadata to 2.5, which current PyPI upload tooling rejects
+        run: uv tool install --with virtualenv==20.26.6 --with "hatchling<1.32" hatch
 
       - name: Build package artifacts
         if: steps.resolve-commit.outputs.is_release_please_tag == 'true'

--- a/.github/workflows/test-and-coverage.yml
+++ b/.github/workflows/test-and-coverage.yml
@@ -260,8 +260,9 @@ jobs:
         uses: astral-sh/setup-uv@38f3f104447c67c051c4a08e39b64a148898af3a # v4.2.0
 
       - name: Install Hatch and Twine
+        # hatchling>=1.32 defaults core metadata to 2.5, which current twine/PyPI upload tooling rejects
         run: |
-          uv tool install hatch
+          uv tool install --with "hatchling<1.32" hatch
           uv tool install twine
 
       - name: Run Lint

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["hatchling"]
+requires = ["hatchling<1.32"]  # 1.32 defaults core metadata to 2.5, which current PyPI upload tooling rejects
 build-backend = "hatchling.build"
 
 [project]

--- a/src/solace_agent_mesh/agent/utils/artifact_helpers.py
+++ b/src/solace_agent_mesh/agent/utils/artifact_helpers.py
@@ -3,6 +3,7 @@ Helper functions for artifact management, including metadata handling and schema
 """
 
 import asyncio
+import weakref as weak
 import logging
 import base64
 import json
@@ -44,7 +45,26 @@ DEFAULT_SCHEMA_INFERENCE_DEPTH = 4
 # many sessions in parallel. Under multi-user load the combined fan-out
 # exhausts the botocore connection pool (default 200), discards connections,
 # and stalls the FastAPI event loop on TLS handshakes for unrelated requests.
-_METADATA_LOAD_SEMAPHORE = asyncio.Semaphore(50)
+_METADATA_LOAD_SEMAPHORE_CAP = 50
+_metadata_load_semaphores: weak.WeakKeyDictionary = weak.WeakKeyDictionary()
+
+
+def _get_metadata_load_semaphore() -> asyncio.Semaphore:
+    """Return this event loop's metadata-load semaphore, creating one on first use.
+
+    A single ``asyncio.Semaphore`` created at import time binds its internal
+    waiter futures to whichever event loop first acquires it. When multiple
+    long-lived loops coexist in one process (e.g. uvicorn's loop and a SAC
+    component's ``async_loop``), acquiring from a second loop raises
+    ``RuntimeError: ... bound to a different event loop`` under contention.
+    Keying on the running loop keeps each loop's waiters inside that loop.
+    """
+    loop = asyncio.get_running_loop()
+    sem = _metadata_load_semaphores.get(loop)
+    if sem is None:
+        sem = asyncio.Semaphore(_METADATA_LOAD_SEMAPHORE_CAP)
+        _metadata_load_semaphores[loop] = sem
+    return sem
 
 
 def is_internal_artifact(filename: str) -> bool:
@@ -1344,7 +1364,7 @@ async def get_artifact_info_list_fast(
                 version_to_load: int | str = latest_metadata_version_by_filename.get(
                     filename, "latest"
                 )
-                async with _METADATA_LOAD_SEMAPHORE:
+                async with _get_metadata_load_semaphore():
                     data = await load_artifact_content_or_metadata(
                         artifact_service=artifact_service,
                         app_name=app_name,

--- a/tests/unit/agent/utils/test_artifact_helpers_semaphore.py
+++ b/tests/unit/agent/utils/test_artifact_helpers_semaphore.py
@@ -1,0 +1,67 @@
+"""Tests for per-event-loop metadata-load semaphore (issue #1591)."""
+
+import asyncio
+import gc
+
+import pytest
+
+from solace_agent_mesh.agent.utils.artifact_helpers import (
+    _get_metadata_load_semaphore,
+    _metadata_load_semaphores,
+)
+
+
+@pytest.mark.asyncio
+async def test_returns_semaphore_for_current_loop():
+    sem = _get_metadata_load_semaphore()
+    assert isinstance(sem, asyncio.Semaphore)
+
+
+@pytest.mark.asyncio
+async def test_same_loop_gets_same_semaphore():
+    s1 = _get_metadata_load_semaphore()
+    s2 = _get_metadata_load_semaphore()
+    assert s1 is s2
+
+
+def test_different_loops_get_different_semaphores():
+    """Two sequential event loops must receive distinct Semaphore instances."""
+
+    async def _acquire():
+        return _get_metadata_load_semaphore()
+
+    loop_a = asyncio.new_event_loop()
+    try:
+        sem_a = loop_a.run_until_complete(_acquire())
+    finally:
+        loop_a.close()
+
+    loop_b = asyncio.new_event_loop()
+    try:
+        sem_b = loop_b.run_until_complete(_acquire())
+    finally:
+        loop_b.close()
+
+    assert sem_a is not sem_b
+
+
+def test_weak_key_dictionary_cleans_up_after_gc():
+    """Entries whose loop has been garbage-collected disappear from the map."""
+    gc.collect()
+    before = len(_metadata_load_semaphores)
+
+    loop = asyncio.new_event_loop()
+    try:
+        asyncio.set_event_loop(loop)
+
+        async def _acquire():
+            return _get_metadata_load_semaphore()
+
+        loop.run_until_complete(_acquire())
+        assert len(_metadata_load_semaphores) > before
+    finally:
+        asyncio.set_event_loop(None)
+        del loop
+        gc.collect()
+
+    assert len(_metadata_load_semaphores) == before


### PR DESCRIPTION
## Description

Fixes #1591

A single module-level `asyncio.Semaphore(50)` binds its internal waiter futures to whichever event loop first acquires it. When the WebUI gateway runs multiple long-lived loops in one process (uvicorn's `FastAPI_Thread` loop for HTTP routes and a SAC component's `async_loop` reached via `run_coroutine_threadsafe`), acquiring from a second loop under contention raises `RuntimeError: ... bound to a different event loop`.

This replaces the shared semaphore with a per-loop semaphore stored in a `WeakKeyDictionary` keyed by the running loop, so each loop gets its own `Semaphore(50)` and no future crosses loops.

## Type of Change
- [x] Bug fix (non-blocking change which fixes an issue)

## Testing

- New tests in `tests/unit/agent/utils/test_artifact_helpers_semaphore.py`:
  - Same-loop calls return the same semaphore instance
  - Two sequential event loops receive distinct semaphores
  - WeakKeyDictionary cleans up after GC removes closed loops
- All 4 pass locally with `pytest --asyncio-mode auto`.

