### PR TITLE
fix(DATAGO-145095): bump npm to 11.19.1 to fix node-tar CVE-2026-73566

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -213,8 +213,9 @@ RUN echo "deb http://deb.debian.org/debian unstable main" > /etc/apt/sources.lis
 
 # Node 25.5.0 ships with npm 11.8.0; upgrade to pick up security fixes in bundled dependencies
 # Upgrade npm to fix CVE-2026-42338 (ip-address XSS vulnerability) and
-# CVE-2026-48815 (sigstore ignores certificateOIDs; needs bundled sigstore >= 4.1.1, first in npm 11.16.0)
-RUN node /usr/local/lib/node_modules/npm/bin/npm-cli.js install -g npm@11.18.0
+# CVE-2026-48815 (sigstore ignores certificateOIDs; needs bundled sigstore >= 4.1.1, first in npm 11.16.0) and
+# CVE-2026-73566 (node-tar stack-overflow DoS; needs bundled tar >= 7.5.21, first in npm 11.19.1 which bundles tar 7.5.22)
+RUN node /usr/local/lib/node_modules/npm/bin/npm-cli.js install -g npm@11.19.1
 
 # Install playwright temporarily just for browser installation (cached layer)
 # This is separate from the full venv to keep this layer cached


### PR DESCRIPTION
## What

Bumps the bundled npm upgrade in the runtime stage from `npm@11.18.0` to `npm@11.19.1`.

## Why

npm `11.18.0` bundles `tar@7.5.19`, which is vulnerable to **CVE-2026-73566** (uncatchable stack-overflow DoS in node-tar's `filesFilter`/`mapHas` via a crafted long-path tar with member selection). Flagged by Prisma at `/usr/local/lib/node_modules/npm/node_modules/tar`.

npm `11.19.1` bundles `tar@7.5.22` (≥ the `7.5.21` fix — npm skipped 7.5.20/7.5.21).

Verified concrete bundled versions from the npm registry tarballs:

| npm | bundled tar | status |
|---|---|---|
| 11.18.0 (before) | 7.5.19 | ❌ vulnerable |
| 11.19.1 (after) | 7.5.22 | ✅ fixed |

`brace-expansion` (DATAGO-145093) was already patched (`5.0.7`), so no change needed there.

## Tickets

- Fixes DATAGO-145095 (tar : solace-agent-mesh)
- Unblocks DATAGO-144739 (tar : solace-agent-mesh-enterprise) once the enterprise base-image pin is bumped to a release containing this fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)