### PR TITLE
feat(evaluation): Export results to the EvalPort open format

### DIFF
--- a/cli/commands/eval_cmd.py
+++ b/cli/commands/eval_cmd.py
@@ -17,7 +17,22 @@ from cli.utils import error_exit
     is_flag=True,
     help="Enable verbose output.",
 )
-def eval_cmd(test_suite_config_path, verbose):
+@click.option(
+    "--export-evalport",
+    is_flag=True,
+    help="After the run, export the test cases and results to the EvalPort "
+    "open format (https://github.com/adhabnr-ux/evalport) under "
+    "<results dir>/evalport.",
+)
+@click.option(
+    "--pass-threshold",
+    type=click.FloatRange(0.0, 1.0),
+    default=0.5,
+    show_default=True,
+    help="Score at or above which an exported grader result counts as "
+    "passed (only used with --export-evalport).",
+)
+def eval_cmd(test_suite_config_path, verbose, export_evalport, pass_threshold):
     """
     Run an evaluation suite using a specified configuration file. Such as path/to/file.yaml.
 
@@ -43,3 +58,15 @@ def eval_cmd(test_suite_config_path, verbose):
         click.echo(click.style("Evaluation completed successfully.", fg="green"))
     except Exception as e:
         error_exit(f"An error occurred during evaluation: {e}")
+
+    if export_evalport:
+        from evaluation.evalport_bridge import export_results
+
+        try:
+            written = export_results(
+                test_suite_config_path, pass_threshold=pass_threshold
+            )
+            for path in written:
+                click.echo(click.style(f"Wrote {path}", fg="green"))
+        except Exception as e:
+            error_exit(f"An error occurred during the EvalPort export: {e}")

--- a/evaluation/README.md
+++ b/evaluation/README.md
@@ -64,3 +64,34 @@ For evaluations that use an LLM to judge the response, the following variables a
 export LLM_SERVICE_ENDPOINT=<enter the endpoint for the LLM service>
 export LLM_SERVICE_API_KEY=<enter the API key for the LLM service>
 ```
+
+## Exporting to EvalPort
+
+The evaluation results can be exported to [EvalPort](https://github.com/adhabnr-ux/evalport),
+an open JSON-Schema specification for portable LLM evaluation documents, so
+suites and results can be consumed by other evaluation tools without bespoke
+glue code.
+
+Export as part of a run:
+
+```bash
+sam eval <test_suite_config.json> --export-evalport
+```
+
+Or convert the results of a previous run without re-executing anything:
+
+```bash
+python -m evaluation.evalport_bridge <test_suite_config.json>
+```
+
+This writes one `<suite>.suite.json` (the test cases plus grader
+definitions) and one `<model>.resultset.json` per evaluated model into
+`results/<results_dir_name>/evalport/`. Each SAM run maps to an EvalPort
+result with the run number as its `attempt`, and the three evaluators map to
+the framework-specific grader types `tool_match`, `response_match` and
+`llm_eval`.
+
+SAM scores are continuous values in [0, 1] with no pass/fail notion, while
+EvalPort requires a boolean per grader result. The export derives it as
+`score >= threshold` with a configurable `--pass-threshold` (default `0.5`),
+and records the threshold in the ResultSet metadata.

--- a/evaluation/evalport_bridge.py
+++ b/evaluation/evalport_bridge.py
@@ -303,8 +303,15 @@ def export_results(
     ``<model>.resultset.json`` per model into ``output_dir`` (defaults to
     ``<results_dir>/evalport``). Returns the written paths.
     """
+    if not 0.0 <= pass_threshold <= 1.0:
+        raise ValueError(
+            f"pass_threshold must be within [0, 1], got {pass_threshold}"
+        )
+
     config = EvaluationConfigLoader(config_path).load_configuration()
-    suite_id = config.results_directory
+    suite_id = _safe_filename_component(
+        config.results_directory, what="results_dir_name"
+    )
     grader_ids = enabled_grader_ids(config.evaluation_options)
     if not grader_ids:
         raise ValueError(
@@ -343,8 +350,10 @@ def export_results(
             started_at=started_at,
             pass_threshold=pass_threshold,
         )
+        # The filename comes from the model directory on disk, not from the
+        # JSON content: a crafted results.json must not choose where we write.
         result_set_path = (
-            output_dir / f"{model_results['model_name']}.resultset.json"
+            output_dir / f"{results_file.parent.name}.resultset.json"
         )
         _write_json(result_set, result_set_path)
         written.append(result_set_path)
@@ -357,6 +366,25 @@ def export_results(
         )
 
     return written
+
+
+def _safe_filename_component(name: str, *, what: str) -> str:
+    """``name`` verified to be a single, safe path component.
+
+    The suite id names output files and the default results directory; a
+    value carrying separators or traversal must fail loudly rather than
+    write outside the output directory.
+    """
+    candidate = str(name)
+    if (
+        not candidate
+        or candidate in (".", "..")
+        or "/" in candidate
+        or "\\" in candidate
+        or candidate != Path(candidate).name
+    ):
+        raise ValueError(f"{what} {name!r} is not a safe filename component")
+    return candidate
 
 
 def _write_json(data: dict, filepath: Path) -> None:

--- a/evaluation/evalport_bridge.py
+++ b/evaluation/evalport_bridge.py
@@ -1,0 +1,412 @@
+"""Bridge SAM evaluation test cases and results to the EvalPort open format.
+
+EvalPort (https://github.com/adhabnr-ux/evalport) is an open JSON-Schema
+specification for portable LLM evaluation documents, so eval data is not
+locked to one framework's format. This module exports:
+
+- the suite's test cases as an EvalPort ``EvalSuite`` document
+  (``spec/schemas/suite.json`` / ``testcase.json``), and
+- each model's ``results.json`` as an EvalPort ``ResultSet`` document
+  (``spec/schemas/resultset.json``), one result per run with the run number
+  carried as the spec's ``attempt`` field.
+
+SAM's evaluators map to framework-specific grader types (``tool_match``,
+``response_match``, ``llm_eval``). Per the EvalPort spec, unknown grader
+types declare ``params.handler`` so consumers that cannot execute them skip
+gracefully instead of guessing.
+
+SAM scores are continuous values in [0, 1] with no pass/fail notion, while
+EvalPort requires a boolean ``passed`` per grader result. The bridge applies
+a configurable threshold (``--pass-threshold``, default 0.5) and records it
+in the ResultSet metadata so consumers know how the booleans were derived.
+
+Usage:
+    sam eval <config.json> --export-evalport
+    python -m evaluation.evalport_bridge <config.json> [--results-dir DIR]
+        [--output-dir DIR] [--pass-threshold 0.5]
+"""
+
+import argparse
+import json
+import logging
+from datetime import datetime, timezone
+from importlib import metadata as importlib_metadata
+from pathlib import Path
+
+from .shared import EvaluationConfigLoader, load_test_case
+
+log = logging.getLogger(__name__)
+
+EVALPORT_VERSION = "1.0.0-rc.5"
+DEFAULT_PASS_THRESHOLD = 0.5
+
+GRADER_DEFINITIONS = {
+    "tool_match": {
+        "id": "tool_match",
+        "type": "tool_match",
+        "params": {"handler": "evaluation.evaluator.ToolMatchEvaluator"},
+        "description": (
+            "Recall of the expected tools over the tools the agent "
+            "actually called (1.0 when no tools are expected)."
+        ),
+    },
+    "response_match": {
+        "id": "response_match",
+        "type": "response_match",
+        "params": {"handler": "evaluation.evaluator.ResponseMatchEvaluator"},
+        "description": (
+            "Weighted ROUGE F-score (0.2 rouge-1 + 0.3 rouge-2 + "
+            "0.5 rouge-l) between the final response and the expected "
+            "response."
+        ),
+    },
+    "llm_eval": {
+        "id": "llm_eval",
+        "type": "llm_eval",
+        "params": {"handler": "evaluation.evaluator.LLMEvaluator"},
+        "description": (
+            "LLM judge scoring the response against the test case "
+            "criterion on a 0.0-1.0 rubric, with reasoning."
+        ),
+    },
+}
+
+
+def enabled_grader_ids(evaluation_options) -> list[str]:
+    """The grader ids enabled by the suite's evaluation settings."""
+    graders = []
+    if evaluation_options.tool_matching_enabled:
+        graders.append("tool_match")
+    if evaluation_options.response_matching_enabled:
+        graders.append("response_match")
+    if evaluation_options.llm_evaluation_enabled:
+        graders.append("llm_eval")
+    return graders
+
+
+def to_evalport_test_case(test_case: dict, grader_ids: list[str]) -> dict:
+    """Map one SAM test case dict to an EvalPort TestCase document."""
+    evaluation = test_case.get("evaluation", {})
+
+    evalport_case = {
+        "id": test_case["test_case_id"],
+        "input": test_case["query"],
+        "graders": list(grader_ids),
+    }
+
+    if evaluation.get("expected_response"):
+        evalport_case["expected_output"] = evaluation["expected_response"]
+    if evaluation.get("expected_tools"):
+        evalport_case["expected_tools"] = list(evaluation["expected_tools"])
+    if test_case.get("wait_time"):
+        evalport_case["timeout_ms"] = int(test_case["wait_time"] * 1000)
+    if test_case.get("category"):
+        evalport_case["tags"] = [test_case["category"]]
+
+    metadata = {"sam.target_agent": test_case["target_agent"]}
+    if test_case.get("description"):
+        metadata["sam.description"] = test_case["description"]
+    if evaluation.get("criterion"):
+        metadata["sam.criterion"] = evaluation["criterion"]
+    if test_case.get("artifacts"):
+        metadata["sam.artifacts"] = test_case["artifacts"]
+    evalport_case["metadata"] = metadata
+
+    return evalport_case
+
+
+def build_suite(
+    *,
+    suite_id: str,
+    config_name: str,
+    test_cases: list[dict],
+    grader_ids: list[str],
+    run_count: int,
+) -> dict:
+    """Build the EvalPort EvalSuite document for the SAM test suite."""
+    return {
+        "version": EVALPORT_VERSION,
+        "id": suite_id,
+        "name": suite_id,
+        "description": (
+            f"Exported from the Solace Agent Mesh test suite '{config_name}'."
+        ),
+        "graders": [GRADER_DEFINITIONS[grader_id] for grader_id in grader_ids],
+        "test_cases": [
+            to_evalport_test_case(test_case, grader_ids)
+            for test_case in test_cases
+        ],
+        "metadata": {
+            "sam.source_config": config_name,
+            "sam.run_count": run_count,
+        },
+    }
+
+
+def _grader_results(run: dict, pass_threshold: float) -> list[dict]:
+    """The EvalPort grader results present in one SAM run record."""
+    graders = []
+
+    for grader_id in ("tool_match", "response_match"):
+        if grader_id in run:
+            score = float(run[grader_id])
+            graders.append(
+                {
+                    "grader_id": grader_id,
+                    "type": grader_id,
+                    "score": score,
+                    "passed": score >= pass_threshold,
+                }
+            )
+
+    llm_eval = run.get("llm_eval")
+    if llm_eval is not None:
+        score = float(llm_eval["score"])
+        grader = {
+            "grader_id": "llm_eval",
+            "type": "llm_eval",
+            "score": score,
+            "passed": score >= pass_threshold,
+        }
+        if llm_eval.get("reasoning"):
+            grader["reason"] = llm_eval["reasoning"]
+        graders.append(grader)
+
+    return graders
+
+
+def _run_to_result(run: dict, pass_threshold: float) -> dict:
+    """Map one SAM run record to an EvalPort result item."""
+    grader_results = _grader_results(run, pass_threshold)
+    errors = run.get("errors") or []
+
+    result = {
+        "test_case_id": run["test_case_id"],
+        "attempt": int(run["run"]),
+        "grader_results": grader_results,
+        "passed": (
+            bool(grader_results)
+            and not errors
+            and all(grader["passed"] for grader in grader_results)
+        ),
+    }
+
+    if run.get("duration_seconds") is not None:
+        result["duration_ms"] = max(0, round(run["duration_seconds"] * 1000))
+    if errors:
+        result["error"] = {
+            "type": "runner_error",
+            "message": "; ".join(str(error) for error in errors),
+        }
+
+    return result
+
+
+def _summary(results: list[dict], total_execution_time: float | None) -> dict:
+    """Aggregate statistics over the mapped results."""
+    passed = sum(1 for result in results if result["passed"])
+    scores = [
+        grader["score"]
+        for result in results
+        for grader in result["grader_results"]
+        if grader["score"] is not None
+    ]
+
+    by_grader: dict[str, dict] = {}
+    for result in results:
+        for grader in result["grader_results"]:
+            stats = by_grader.setdefault(
+                grader["grader_id"], {"passed": 0, "failed": 0, "scores": []}
+            )
+            stats["passed" if grader["passed"] else "failed"] += 1
+            if grader["score"] is not None:
+                stats["scores"].append(grader["score"])
+
+    summary = {
+        "total": len(results),
+        "passed": passed,
+        "failed": len(results) - passed,
+        "pass_rate": (passed / len(results)) if results else 0.0,
+        "avg_score": (sum(scores) / len(scores)) if scores else 0.0,
+        "by_grader": {
+            grader_id: {
+                "passed": stats["passed"],
+                "failed": stats["failed"],
+                "avg_score": (
+                    sum(stats["scores"]) / len(stats["scores"])
+                    if stats["scores"]
+                    else 0.0
+                ),
+            }
+            for grader_id, stats in by_grader.items()
+        },
+    }
+    if total_execution_time is not None:
+        summary["duration_ms"] = max(0, round(total_execution_time * 1000))
+    return summary
+
+
+def _runner_info() -> dict:
+    runner = {"name": "solace-agent-mesh"}
+    try:
+        runner["version"] = importlib_metadata.version("solace-agent-mesh")
+    except importlib_metadata.PackageNotFoundError:
+        log.debug("solace-agent-mesh is not installed; omitting runner version")
+    return runner
+
+
+def build_result_set(
+    model_results: dict,
+    *,
+    suite_id: str,
+    started_at: str,
+    pass_threshold: float,
+) -> dict:
+    """Map one model's results.json content to an EvalPort ResultSet."""
+    model_name = model_results["model_name"]
+    results = [
+        _run_to_result(run, pass_threshold)
+        for test_case in model_results.get("test_cases", [])
+        for run in test_case.get("runs", [])
+    ]
+    if not results:
+        raise ValueError(
+            f"results for model '{model_name}' contain no runs to export"
+        )
+
+    return {
+        "version": EVALPORT_VERSION,
+        "suite_id": suite_id,
+        "run_id": f"{suite_id}-{model_name}",
+        "started_at": started_at,
+        "provider": {"model": model_name},
+        "runner": _runner_info(),
+        "results": results,
+        "summary": _summary(results, model_results.get("total_execution_time")),
+        "metadata": {
+            "sam.pass_threshold": pass_threshold,
+            "sam.started_at_source": "results.json modification time",
+        },
+    }
+
+
+def export_results(
+    config_path: str,
+    results_dir: Path | None = None,
+    output_dir: Path | None = None,
+    pass_threshold: float = DEFAULT_PASS_THRESHOLD,
+) -> list[Path]:
+    """Export a suite's test cases and per-model results to EvalPort files.
+
+    Reads the suite configuration and the results directory a previous
+    ``sam eval`` run produced, and writes one ``<suite>.suite.json`` plus one
+    ``<model>.resultset.json`` per model into ``output_dir`` (defaults to
+    ``<results_dir>/evalport``). Returns the written paths.
+    """
+    config = EvaluationConfigLoader(config_path).load_configuration()
+    suite_id = config.results_directory
+    grader_ids = enabled_grader_ids(config.evaluation_options)
+    if not grader_ids:
+        raise ValueError(
+            "no evaluators are enabled in evaluation_settings; "
+            "there are no graders to export"
+        )
+
+    if results_dir is None:
+        results_dir = Path.cwd() / "results" / suite_id
+    if output_dir is None:
+        output_dir = results_dir / "evalport"
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    written: list[Path] = []
+
+    test_cases = [load_test_case(path) for path in config.test_case_files]
+    suite_doc = build_suite(
+        suite_id=suite_id,
+        config_name=Path(config_path).name,
+        test_cases=test_cases,
+        grader_ids=grader_ids,
+        run_count=config.run_count,
+    )
+    suite_path = output_dir / f"{suite_id}.suite.json"
+    _write_json(suite_doc, suite_path)
+    written.append(suite_path)
+
+    for results_file in sorted(results_dir.glob("*/results.json")):
+        model_results = json.loads(results_file.read_text())
+        started_at = datetime.fromtimestamp(
+            results_file.stat().st_mtime, tz=timezone.utc
+        ).isoformat()
+        result_set = build_result_set(
+            model_results,
+            suite_id=suite_id,
+            started_at=started_at,
+            pass_threshold=pass_threshold,
+        )
+        result_set_path = (
+            output_dir / f"{model_results['model_name']}.resultset.json"
+        )
+        _write_json(result_set, result_set_path)
+        written.append(result_set_path)
+
+    if len(written) == 1:
+        log.warning(
+            "No <model>/results.json files found under %s; only the suite "
+            "document was exported. Run `sam eval` first.",
+            results_dir,
+        )
+
+    return written
+
+
+def _write_json(data: dict, filepath: Path) -> None:
+    filepath.parent.mkdir(parents=True, exist_ok=True)
+    with filepath.open("w") as f:
+        json.dump(data, f, indent=4)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Export SAM evaluation test cases and results to the EvalPort "
+            "open format."
+        )
+    )
+    parser.add_argument(
+        "config_path", help="Path to the evaluation test suite config file."
+    )
+    parser.add_argument(
+        "--results-dir",
+        type=Path,
+        default=None,
+        help="Results directory of a previous run "
+        "(default: ./results/<results_dir_name>).",
+    )
+    parser.add_argument(
+        "--output-dir",
+        type=Path,
+        default=None,
+        help="Where to write the EvalPort documents "
+        "(default: <results-dir>/evalport).",
+    )
+    parser.add_argument(
+        "--pass-threshold",
+        type=float,
+        default=DEFAULT_PASS_THRESHOLD,
+        help="Score at or above which a grader result counts as passed "
+        f"(default: {DEFAULT_PASS_THRESHOLD}).",
+    )
+    args = parser.parse_args()
+
+    written = export_results(
+        args.config_path,
+        results_dir=args.results_dir,
+        output_dir=args.output_dir,
+        pass_threshold=args.pass_threshold,
+    )
+    for path in written:
+        print(f"Wrote {path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/evaluation/evalport_bridge.py
+++ b/evaluation/evalport_bridge.py
@@ -328,7 +328,7 @@ def export_results(
         grader_ids=grader_ids,
         run_count=config.run_count,
     )
-    suite_path = output_dir / f"{suite_id}.suite.json"
+    suite_path = output_dir / f"{results_dir.name}.suite.json"
     _write_json(suite_doc, suite_path)
     written.append(suite_path)
 

--- a/tests/unit/cli/commands/test_eval_cmd.py
+++ b/tests/unit/cli/commands/test_eval_cmd.py
@@ -290,3 +290,75 @@ class TestEvalCommand:
         assert result.exit_code == 0
         # Starting message should be present
         assert "Starting evaluation" in result.output
+
+
+class TestEvalCommandEvalPortExport:
+    """Tests for the --export-evalport flag"""
+
+    def test_export_flag_runs_the_export(self, runner, test_config_file, mocker):
+        """Test --export-evalport exports after a successful run"""
+        mocker.patch("evaluation.run.main")
+        mock_export = mocker.patch(
+            "evaluation.evalport_bridge.export_results",
+            return_value=[Path("/results/evalport/suite.suite.json")],
+        )
+
+        result = runner.invoke(eval_cmd, [str(test_config_file), "--export-evalport"])
+
+        assert result.exit_code == 0
+        mock_export.assert_called_once_with(str(test_config_file), pass_threshold=0.5)
+        assert "Wrote" in result.output
+
+    def test_no_export_without_the_flag(self, runner, test_config_file, mocker):
+        """Test the export does not run unless requested"""
+        mocker.patch("evaluation.run.main")
+        mock_export = mocker.patch("evaluation.evalport_bridge.export_results")
+
+        result = runner.invoke(eval_cmd, [str(test_config_file)])
+
+        assert result.exit_code == 0
+        mock_export.assert_not_called()
+
+    def test_custom_pass_threshold_is_forwarded(self, runner, test_config_file, mocker):
+        """Test --pass-threshold reaches the exporter"""
+        mocker.patch("evaluation.run.main")
+        mock_export = mocker.patch(
+            "evaluation.evalport_bridge.export_results", return_value=[]
+        )
+
+        result = runner.invoke(
+            eval_cmd,
+            [str(test_config_file), "--export-evalport", "--pass-threshold", "0.8"],
+        )
+
+        assert result.exit_code == 0
+        mock_export.assert_called_once_with(str(test_config_file), pass_threshold=0.8)
+
+    def test_export_errors_are_reported(self, runner, test_config_file, mocker):
+        """Test export failures exit with a clear message"""
+        mocker.patch("evaluation.run.main")
+        mocker.patch(
+            "evaluation.evalport_bridge.export_results",
+            side_effect=ValueError("no evaluators are enabled"),
+        )
+        mock_error_exit = mocker.patch(
+            "cli.commands.eval_cmd.error_exit", side_effect=SystemExit(1)
+        )
+
+        result = runner.invoke(eval_cmd, [str(test_config_file), "--export-evalport"])
+
+        assert result.exit_code == 1
+        mock_error_exit.assert_called_once()
+        assert "EvalPort export" in mock_error_exit.call_args[0][0]
+        assert "no evaluators are enabled" in mock_error_exit.call_args[0][0]
+
+    def test_export_skipped_when_evaluation_fails(self, runner, test_config_file, mocker):
+        """Test a failed evaluation never reaches the export"""
+        mocker.patch("evaluation.run.main", side_effect=Exception("boom"))
+        mock_export = mocker.patch("evaluation.evalport_bridge.export_results")
+        mocker.patch("cli.commands.eval_cmd.error_exit", side_effect=SystemExit(1))
+
+        result = runner.invoke(eval_cmd, [str(test_config_file), "--export-evalport"])
+
+        assert result.exit_code == 1
+        mock_export.assert_not_called()

--- a/tests/unit/evaluation/test_evalport_bridge.py
+++ b/tests/unit/evaluation/test_evalport_bridge.py
@@ -1,0 +1,325 @@
+"""
+Unit tests for evaluation/evalport_bridge.py
+
+Tests the EvalPort export bridge including:
+- Test case mapping to the EvalPort TestCase document
+- Grader selection from evaluation settings
+- ResultSet mapping (attempts, grader results, pass threshold, errors)
+- Summary aggregation
+- End-to-end export of a results directory
+"""
+
+import json
+from types import SimpleNamespace
+
+import pytest
+
+from evaluation.evalport_bridge import (
+    EVALPORT_VERSION,
+    build_result_set,
+    build_suite,
+    enabled_grader_ids,
+    export_results,
+    to_evalport_test_case,
+)
+
+FULL_TEST_CASE = {
+    "test_case_id": "hello_world",
+    "category": "Content Generation",
+    "description": "A simple greeting test.",
+    "query": "Hello, world!",
+    "target_agent": "OrchestratorAgent",
+    "wait_time": 30,
+    "artifacts": [{"type": "url", "path": "https://example.com/doc"}],
+    "evaluation": {
+        "expected_tools": ["web_request"],
+        "expected_response": "Hello! How can I help you today?",
+        "criterion": "Evaluate if the agent greets the user.",
+    },
+}
+
+MODEL_RESULTS = {
+    "model_name": "test-model",
+    "total_execution_time": 12.5,
+    "test_cases": [
+        {
+            "test_case_id": "case_a",
+            "category": "Content Generation",
+            "runs": [
+                {
+                    "run": 1,
+                    "test_case_id": "case_a",
+                    "test_case_path": "/tmp/a.test.json",
+                    "duration_seconds": 2.0,
+                    "tool_match": 1.0,
+                    "response_match": 0.8,
+                    "llm_eval": {"score": 0.9, "reasoning": "Good answer."},
+                },
+                {
+                    "run": 2,
+                    "test_case_id": "case_a",
+                    "test_case_path": "/tmp/a.test.json",
+                    "duration_seconds": 1.5,
+                    "tool_match": 1.0,
+                    "response_match": 0.4,
+                },
+            ],
+        },
+        {
+            "test_case_id": "case_b",
+            "category": "Other",
+            "runs": [
+                {
+                    "run": 1,
+                    "test_case_id": "case_b",
+                    "test_case_path": "/tmp/b.test.json",
+                    "duration_seconds": None,
+                    "errors": ["agent timed out"],
+                },
+            ],
+        },
+    ],
+}
+
+
+def options(tool=True, response=True, llm=False):
+    return SimpleNamespace(
+        tool_matching_enabled=tool,
+        response_matching_enabled=response,
+        llm_evaluation_enabled=llm,
+    )
+
+
+class TestGraderSelection:
+    def test_reflects_the_enabled_evaluators(self):
+        assert enabled_grader_ids(options(llm=True)) == [
+            "tool_match",
+            "response_match",
+            "llm_eval",
+        ]
+        assert enabled_grader_ids(options(tool=False)) == ["response_match"]
+
+    def test_no_evaluators_means_no_graders(self):
+        assert enabled_grader_ids(options(False, False, False)) == []
+
+
+class TestTestCaseMapping:
+    def test_maps_every_field_of_a_full_test_case(self):
+        doc = to_evalport_test_case(FULL_TEST_CASE, ["tool_match", "llm_eval"])
+
+        assert doc == {
+            "id": "hello_world",
+            "input": "Hello, world!",
+            "graders": ["tool_match", "llm_eval"],
+            "expected_output": "Hello! How can I help you today?",
+            "expected_tools": ["web_request"],
+            "timeout_ms": 30000,
+            "tags": ["Content Generation"],
+            "metadata": {
+                "sam.target_agent": "OrchestratorAgent",
+                "sam.description": "A simple greeting test.",
+                "sam.criterion": "Evaluate if the agent greets the user.",
+                "sam.artifacts": [
+                    {"type": "url", "path": "https://example.com/doc"}
+                ],
+            },
+        }
+
+    def test_omits_empty_optional_fields(self):
+        doc = to_evalport_test_case(
+            {
+                "test_case_id": "minimal",
+                "query": "Hi",
+                "target_agent": "Agent",
+                "evaluation": {"expected_tools": [], "expected_response": ""},
+            },
+            ["response_match"],
+        )
+
+        assert doc["id"] == "minimal"
+        assert doc["graders"] == ["response_match"]
+        assert "expected_output" not in doc
+        assert "expected_tools" not in doc
+        assert "timeout_ms" not in doc
+        assert "tags" not in doc
+
+
+class TestSuiteDocument:
+    def test_builds_a_suite_with_grader_definitions(self):
+        suite = build_suite(
+            suite_id="my-suite",
+            config_name="config.json",
+            test_cases=[FULL_TEST_CASE],
+            grader_ids=["tool_match", "response_match"],
+            run_count=3,
+        )
+
+        assert suite["version"] == EVALPORT_VERSION
+        assert suite["id"] == "my-suite"
+        assert [grader["id"] for grader in suite["graders"]] == [
+            "tool_match",
+            "response_match",
+        ]
+        # Framework-specific grader types must declare params.handler so
+        # consumers that cannot execute them can skip gracefully.
+        assert all("handler" in grader["params"] for grader in suite["graders"])
+        assert suite["test_cases"][0]["id"] == "hello_world"
+        assert suite["metadata"]["sam.run_count"] == 3
+
+
+class TestResultSetMapping:
+    def build(self, pass_threshold=0.5):
+        return build_result_set(
+            MODEL_RESULTS,
+            suite_id="my-suite",
+            started_at="2026-08-31T00:00:00+00:00",
+            pass_threshold=pass_threshold,
+        )
+
+    def test_maps_runs_to_attempts(self):
+        result_set = self.build()
+
+        assert result_set["version"] == EVALPORT_VERSION
+        assert result_set["suite_id"] == "my-suite"
+        assert result_set["run_id"] == "my-suite-test-model"
+        assert result_set["provider"] == {"model": "test-model"}
+        assert [
+            (result["test_case_id"], result["attempt"])
+            for result in result_set["results"]
+        ] == [("case_a", 1), ("case_a", 2), ("case_b", 1)]
+
+    def test_applies_the_pass_threshold_per_grader(self):
+        first, second, _ = self.build()["results"]
+
+        assert first["passed"] is True
+        assert {g["grader_id"]: g["passed"] for g in first["grader_results"]} == {
+            "tool_match": True,
+            "response_match": True,
+            "llm_eval": True,
+        }
+        llm = next(
+            g for g in first["grader_results"] if g["grader_id"] == "llm_eval"
+        )
+        assert llm["reason"] == "Good answer."
+        assert first["duration_ms"] == 2000
+
+        assert second["passed"] is False, "response_match 0.4 is below 0.5"
+
+    def test_a_stricter_threshold_flips_results(self):
+        first = self.build(pass_threshold=0.85)["results"][0]
+
+        assert first["passed"] is False, "response_match 0.8 is below 0.85"
+
+    def test_errors_become_a_runner_error(self):
+        errored = self.build()["results"][2]
+
+        assert errored["passed"] is False
+        assert errored["grader_results"] == []
+        assert errored["error"] == {
+            "type": "runner_error",
+            "message": "agent timed out",
+        }
+        assert "duration_ms" not in errored
+
+    def test_summary_aggregates_results_and_graders(self):
+        summary = self.build()["summary"]
+
+        assert summary["total"] == 3
+        assert summary["passed"] == 1
+        assert summary["failed"] == 2
+        assert summary["pass_rate"] == pytest.approx(1 / 3)
+        assert summary["avg_score"] == pytest.approx(0.82)
+        assert summary["duration_ms"] == 12500
+        assert summary["by_grader"]["response_match"] == {
+            "passed": 1,
+            "failed": 1,
+            "avg_score": pytest.approx(0.6),
+        }
+
+    def test_rejects_results_without_runs(self):
+        with pytest.raises(ValueError, match="no runs to export"):
+            build_result_set(
+                {"model_name": "empty", "test_cases": []},
+                suite_id="s",
+                started_at="2026-08-31T00:00:00+00:00",
+                pass_threshold=0.5,
+            )
+
+
+class TestExportResults:
+    @pytest.fixture
+    def suite_tree(self, tmp_path, mocker):
+        """A fake config loader plus test case files and a results tree."""
+        cases_dir = tmp_path / "cases"
+        cases_dir.mkdir()
+        case_paths = []
+        for case_id in ("case_a", "case_b"):
+            path = cases_dir / f"{case_id}.test.json"
+            path.write_text(
+                json.dumps(
+                    {
+                        "test_case_id": case_id,
+                        "query": f"Query for {case_id}",
+                        "target_agent": "OrchestratorAgent",
+                    }
+                )
+            )
+            case_paths.append(str(path))
+
+        results_dir = tmp_path / "results" / "my-suite"
+        model_dir = results_dir / "test-model"
+        model_dir.mkdir(parents=True)
+        (model_dir / "results.json").write_text(json.dumps(MODEL_RESULTS))
+
+        loader = mocker.patch(
+            "evaluation.evalport_bridge.EvaluationConfigLoader"
+        )
+        loader.return_value.load_configuration.return_value = SimpleNamespace(
+            results_directory="my-suite",
+            test_case_files=case_paths,
+            run_count=2,
+            evaluation_options=options(llm=True),
+        )
+        return results_dir
+
+    def test_writes_the_suite_and_one_result_set_per_model(
+        self, suite_tree, tmp_path
+    ):
+        written = export_results(
+            str(tmp_path / "config.json"), results_dir=suite_tree
+        )
+
+        assert [path.name for path in written] == [
+            "my-suite.suite.json",
+            "test-model.resultset.json",
+        ]
+        assert all(path.parent == suite_tree / "evalport" for path in written)
+
+        suite_doc = json.loads(written[0].read_text())
+        assert [case["id"] for case in suite_doc["test_cases"]] == [
+            "case_a",
+            "case_b",
+        ]
+
+        result_set = json.loads(written[1].read_text())
+        assert result_set["suite_id"] == "my-suite"
+        assert result_set["metadata"]["sam.pass_threshold"] == 0.5
+        assert result_set["started_at"].endswith("+00:00")
+
+    def test_refuses_to_export_without_enabled_graders(
+        self, suite_tree, tmp_path, mocker
+    ):
+        loader = mocker.patch(
+            "evaluation.evalport_bridge.EvaluationConfigLoader"
+        )
+        loader.return_value.load_configuration.return_value = SimpleNamespace(
+            results_directory="my-suite",
+            test_case_files=[],
+            run_count=1,
+            evaluation_options=options(False, False, False),
+        )
+
+        with pytest.raises(ValueError, match="no evaluators are enabled"):
+            export_results(
+                str(tmp_path / "config.json"), results_dir=suite_tree
+            )

--- a/tests/unit/evaluation/test_evalport_bridge.py
+++ b/tests/unit/evaluation/test_evalport_bridge.py
@@ -323,3 +323,47 @@ class TestExportResults:
             export_results(
                 str(tmp_path / "config.json"), results_dir=suite_tree
             )
+
+    def test_rejects_a_suite_id_that_escapes_the_output_dir(
+        self, suite_tree, tmp_path, mocker
+    ):
+        loader = mocker.patch(
+            "evaluation.evalport_bridge.EvaluationConfigLoader"
+        )
+        loader.return_value.load_configuration.return_value = SimpleNamespace(
+            results_directory="../evil",
+            test_case_files=[],
+            run_count=1,
+            evaluation_options=options(llm=True),
+        )
+
+        with pytest.raises(ValueError, match="not a safe filename component"):
+            export_results(
+                str(tmp_path / "config.json"), results_dir=suite_tree
+            )
+
+    def test_model_filename_comes_from_the_directory_not_the_json(
+        self, suite_tree, tmp_path
+    ):
+        crafted = dict(MODEL_RESULTS, model_name="../../escape")
+        results_file = suite_tree / "test-model" / "results.json"
+        results_file.write_text(json.dumps(crafted))
+
+        written = export_results(
+            str(tmp_path / "config.json"), results_dir=suite_tree
+        )
+
+        result_set_path = written[1]
+        assert result_set_path.name == "test-model.resultset.json"
+        assert result_set_path.parent == suite_tree / "evalport"
+
+    @pytest.mark.parametrize("threshold", [-0.1, 1.5])
+    def test_rejects_an_out_of_range_pass_threshold(
+        self, suite_tree, tmp_path, threshold
+    ):
+        with pytest.raises(ValueError, match="pass_threshold"):
+            export_results(
+                str(tmp_path / "config.json"),
+                results_dir=suite_tree,
+                pass_threshold=threshold,
+            )

--- a/tests/unit/evaluation/test_evalport_schema_validation.py
+++ b/tests/unit/evaluation/test_evalport_schema_validation.py
@@ -1,0 +1,48 @@
+"""
+Schema validation of the EvalPort export against the official validators.
+
+Runs only when the ``evalport-sdk`` package is installed (it is not a
+project dependency), so the spec conformance claim is reproducible:
+
+    pip install evalport-sdk && pytest tests/unit/evaluation/test_evalport_schema_validation.py
+"""
+
+import pytest
+
+validate = pytest.importorskip(
+    "openeval.validate", reason="evalport-sdk is not installed"
+)
+
+from evaluation.evalport_bridge import (  # noqa: E402
+    build_result_set,
+    build_suite,
+)
+
+from .test_evalport_bridge import FULL_TEST_CASE, MODEL_RESULTS  # noqa: E402
+
+
+def test_suite_document_conforms_to_the_evalport_schema():
+    suite = build_suite(
+        suite_id="sam-suite",
+        config_name="config.json",
+        test_cases=[FULL_TEST_CASE],
+        grader_ids=["tool_match", "response_match", "llm_eval"],
+        run_count=2,
+    )
+
+    result = validate.validate_suite(suite)
+
+    assert result.valid, [str(error) for error in result.errors]
+
+
+def test_result_set_document_conforms_to_the_evalport_schema():
+    result_set = build_result_set(
+        MODEL_RESULTS,
+        suite_id="sam-suite",
+        started_at="2026-09-10T00:00:00+00:00",
+        pass_threshold=0.5,
+    )
+
+    result = validate.validate_result_set(result_set)
+
+    assert result.valid, [str(error) for error in result.errors]


### PR DESCRIPTION
## What

Bridges the `evaluation/` framework to [EvalPort](https://github.com/adhabnr-ux/evalport), an open JSON-Schema specification for portable LLM evaluation documents, so SAM suites and results can be consumed by other evaluation tools without bespoke glue code.

Closes #1635

## How

- New `evaluation/evalport_bridge.py`:
  - Maps each test case to an EvalPort TestCase document (query -> `input`, expected_response -> `expected_output`, expected_tools, wait_time -> `timeout_ms`, category -> `tags`, SAM-specific fields under `sam.*` metadata keys).
  - Maps each model's `results.json` to an EvalPort ResultSet — one result per run, with the run number carried as the spec's `attempt` field.
  - The three evaluators map to framework-specific grader types (`tool_match`, `response_match`, `llm_eval`) declaring `params.handler`, so consumers that cannot execute them skip gracefully per the spec.
  - SAM scores are continuous with no pass/fail notion, while EvalPort requires a boolean per grader result: the bridge derives it from a configurable `--pass-threshold` (default 0.5) and records the threshold in ResultSet metadata.
- CLI: `sam eval <config> --export-evalport [--pass-threshold 0.5]` exports after a run; `python -m evaluation.evalport_bridge <config>` converts an existing results directory without re-running anything.
- Docs: "Exporting to EvalPort" section in `evaluation/README.md`.

## Testing

- `tests/unit/evaluation/test_evalport_bridge.py` (new) + extended `tests/unit/cli/commands/test_eval_cmd.py`: 36 tests, all passing.
- Both generated document types validate `True` against the official `evalport-sdk` validators (`validate_suite`, `validate_result_set`).
- New files are ruff-clean.