### PR TITLE
feat(webui): expose fastapi_root_path for reverse proxy sub-paths

### DIFF
--- a/examples/gateways/webui_gateway_example.yaml
+++ b/examples/gateways/webui_gateway_example.yaml
@@ -57,7 +57,7 @@ apps:
       gateway_id: ${WEBUI_GATEWAY_ID} # Optional: Unique ID for this instance. If omitted, one will be generated.
       fastapi_host: ${FASTAPI_HOST, localhost} # Host for the FastAPI server
       fastapi_port: ${FASTAPI_PORT, 8000} # Port for the FastAPI server
-      fastapi_root_path: ${FASTAPI_ROOT_PATH} # URL prefix behind a reverse proxy sub-path, e.g. "/agent-mesh"
+      fastapi_root_path: ${FASTAPI_ROOT_PATH, ""} # URL prefix behind a reverse proxy sub-path, e.g. "/agent-mesh"
       cors_allowed_origins: # List of allowed origins for CORS
         - "http://localhost:3000" # Example: Allow local React dev server
         - "http://127.0.0.1:3000"

--- a/examples/gateways/webui_gateway_example.yaml
+++ b/examples/gateways/webui_gateway_example.yaml
@@ -57,6 +57,7 @@ apps:
       gateway_id: ${WEBUI_GATEWAY_ID} # Optional: Unique ID for this instance. If omitted, one will be generated.
       fastapi_host: ${FASTAPI_HOST, localhost} # Host for the FastAPI server
       fastapi_port: ${FASTAPI_PORT, 8000} # Port for the FastAPI server
+      fastapi_root_path: ${FASTAPI_ROOT_PATH} # URL prefix behind a reverse proxy sub-path, e.g. "/agent-mesh"
       cors_allowed_origins: # List of allowed origins for CORS
         - "http://localhost:3000" # Example: Allow local React dev server
         - "http://127.0.0.1:3000"

--- a/preset/env-template
+++ b/preset/env-template
@@ -16,6 +16,7 @@ SESSION_SECRET_KEY="replace_with_your_secret_key"
 FASTAPI_HOST="127.0.0.1" # Must be 0.0.0.0 for containerized environments
 FASTAPI_PORT="8000"
 FASTAPI_HTTPS_PORT="8443"
+FASTAPI_ROOT_PATH="" # URL prefix behind a reverse proxy sub-path, e.g. "/agent-mesh"
 
 # OAuth 2.0 Client Credentials configuration
 LLM_SERVICE_OAUTH_TOKEN_URL=""

--- a/src/solace_agent_mesh/gateway/http_sse/app.py
+++ b/src/solace_agent_mesh/gateway/http_sse/app.py
@@ -55,6 +55,16 @@ class WebUIBackendApp(BaseGatewayApp):
             "description": "Port for the embedded FastAPI server when SSL is enabled.",
         },
         {
+            "name": "fastapi_root_path",
+            "required": False,
+            "type": "string",
+            "default": "",
+            "description": "URL path prefix when the gateway is mounted behind a "
+            "reverse proxy sub-path (e.g. '/agent-mesh'). Passed to uvicorn as "
+            "root_path so FastAPI generates correct redirect, docs and "
+            "absolute URLs.",
+        },
+        {
             "name": "cors_allowed_origins",
             "required": False,
             "type": "list",

--- a/src/solace_agent_mesh/gateway/http_sse/component.py
+++ b/src/solace_agent_mesh/gateway/http_sse/component.py
@@ -162,6 +162,7 @@ class WebUIBackendComponent(BaseGatewayComponent):
             self.fastapi_host = self.get_config("fastapi_host", "127.0.0.1")
             self.fastapi_port = self.get_config("fastapi_port", 8000)
             self.fastapi_https_port = self.get_config("fastapi_https_port", 8443)
+            self.fastapi_root_path = self.get_config("fastapi_root_path", "")
             self.session_secret_key = self.get_config("session_secret_key")
             self.cors_allowed_origins = self.get_config("cors_allowed_origins", ["*"])
             self.cors_allowed_origin_regex = self.get_config("cors_allowed_origin_regex", "")
@@ -1753,6 +1754,7 @@ class WebUIBackendComponent(BaseGatewayComponent):
                 app=self.fastapi_app,
                 host=self.fastapi_host,
                 port=port,
+                root_path=self.fastapi_root_path,
                 log_level="warning",
                 lifespan="on",
                 ssl_keyfile=self.ssl_keyfile,

--- a/src/solace_agent_mesh/gateway/http_sse/component.py
+++ b/src/solace_agent_mesh/gateway/http_sse/component.py
@@ -162,7 +162,10 @@ class WebUIBackendComponent(BaseGatewayComponent):
             self.fastapi_host = self.get_config("fastapi_host", "127.0.0.1")
             self.fastapi_port = self.get_config("fastapi_port", 8000)
             self.fastapi_https_port = self.get_config("fastapi_https_port", 8443)
-            self.fastapi_root_path = self.get_config("fastapi_root_path", "")
+            # `or ""` guards a config that carries the key with a None value
+            # (e.g. an unset env var leaving `fastapi_root_path:` blank in
+            # YAML), so uvicorn always receives a string.
+            self.fastapi_root_path = self.get_config("fastapi_root_path", "") or ""
             self.session_secret_key = self.get_config("session_secret_key")
             self.cors_allowed_origins = self.get_config("cors_allowed_origins", ["*"])
             self.cors_allowed_origin_regex = self.get_config("cors_allowed_origin_regex", "")

--- a/templates/webui.yaml
+++ b/templates/webui.yaml
@@ -30,7 +30,7 @@ apps:
       fastapi_host: ${FASTAPI_HOST}
       fastapi_port: ${FASTAPI_PORT, 8000}
       # URL prefix when served behind a reverse proxy sub-path, e.g. "/agent-mesh"
-      fastapi_root_path: ${FASTAPI_ROOT_PATH}
+      fastapi_root_path: ${FASTAPI_ROOT_PATH, ""}
       cors_allowed_origins:
         - "http://localhost:3000"
         - "http://127.0.0.1:3000"

--- a/templates/webui.yaml
+++ b/templates/webui.yaml
@@ -29,6 +29,8 @@ apps:
       gateway_id: ${WEBUI_GATEWAY_ID}
       fastapi_host: ${FASTAPI_HOST}
       fastapi_port: ${FASTAPI_PORT, 8000}
+      # URL prefix when served behind a reverse proxy sub-path, e.g. "/agent-mesh"
+      fastapi_root_path: ${FASTAPI_ROOT_PATH}
       cors_allowed_origins:
         - "http://localhost:3000"
         - "http://127.0.0.1:3000"

--- a/tests/unit/gateway/http_sse/test_fastapi_root_path.py
+++ b/tests/unit/gateway/http_sse/test_fastapi_root_path.py
@@ -33,7 +33,10 @@ class TestRootPathSchema:
     def test_component_runtime_fallback_matches_schema_default(self):
         source = inspect.getsource(WebUIBackendComponent.__init__)
 
-        assert 'self.get_config("fastapi_root_path", "")' in source
+        # The `or ""` also covers a config that carries the key with a None
+        # value (an unset env var leaves `fastapi_root_path:` blank in YAML),
+        # so uvicorn always receives a string.
+        assert 'self.get_config("fastapi_root_path", "") or ""' in source
 
 
 class TestRootPathReachesUvicorn:

--- a/tests/unit/gateway/http_sse/test_fastapi_root_path.py
+++ b/tests/unit/gateway/http_sse/test_fastapi_root_path.py
@@ -1,0 +1,95 @@
+"""
+Unit tests for the fastapi_root_path configuration (issue #1486).
+
+The Web UI gateway can be mounted behind a reverse proxy at a sub-path
+(e.g. https://host/agent-mesh/). uvicorn must receive that prefix as
+root_path so FastAPI generates correct redirect, docs and absolute URLs.
+
+Covers:
+- App schema declares fastapi_root_path with an empty-string default
+- Component runtime fallback matches the schema default
+- The uvicorn.Config call receives root_path from the component
+"""
+
+import inspect
+from unittest.mock import MagicMock, patch
+
+from solace_agent_mesh.gateway.http_sse.app import WebUIBackendApp
+from solace_agent_mesh.gateway.http_sse.component import WebUIBackendComponent
+
+
+class TestRootPathSchema:
+    def test_app_schema_declares_empty_default(self):
+        params = {
+            param["name"]: param
+            for param in WebUIBackendApp.SPECIFIC_APP_SCHEMA_PARAMS
+        }
+
+        assert "fastapi_root_path" in params
+        assert params["fastapi_root_path"]["required"] is False
+        assert params["fastapi_root_path"]["type"] == "string"
+        assert params["fastapi_root_path"]["default"] == ""
+
+    def test_component_runtime_fallback_matches_schema_default(self):
+        source = inspect.getsource(WebUIBackendComponent.__init__)
+
+        assert 'self.get_config("fastapi_root_path", "")' in source
+
+
+class TestRootPathReachesUvicorn:
+    def _start_server(self, component):
+        with (
+            patch(
+                "solace_agent_mesh.gateway.http_sse.component.uvicorn.Config"
+            ) as mock_config,
+            patch("solace_agent_mesh.gateway.http_sse.component.uvicorn.Server"),
+            patch("solace_agent_mesh.gateway.http_sse.component.threading.Thread"),
+            patch("solace_agent_mesh.gateway.http_sse.component.TaskLoggerService"),
+            patch(
+                "solace_agent_mesh.gateway.http_sse.component.dependencies"
+            ) as mock_deps,
+            patch("solace_agent_mesh.gateway.http_sse.component.log"),
+            patch(
+                "solace_agent_mesh.gateway.http_sse.component.feature_flags"
+            ) as mock_ff,
+            patch.dict(
+                "sys.modules",
+                {"solace_agent_mesh.gateway.http_sse.main": MagicMock()},
+            ),
+        ):
+            mock_ff.get_registry.return_value.keys.return_value = []
+            mock_deps.SessionLocal = None
+            WebUIBackendComponent._start_fastapi_server(component)
+        return mock_config
+
+    def _component(self) -> MagicMock:
+        component = MagicMock()
+        component.fastapi_app = None
+        component.fastapi_thread = None
+        component.fastapi_host = "127.0.0.1"
+        component.fastapi_port = 8000
+        component.fastapi_https_port = 8443
+        component.ssl_keyfile = ""
+        component.ssl_certfile = ""
+        component.ssl_keyfile_password = ""
+        component.log_identifier = "[test]"
+        component.database_url = None
+        component.platform_database_url = None
+        component.get_config = MagicMock(return_value={})
+        return component
+
+    def test_configured_prefix_is_passed_as_root_path(self):
+        component = self._component()
+        component.fastapi_root_path = "/agent-mesh"
+
+        mock_config = self._start_server(component)
+
+        assert mock_config.call_args.kwargs["root_path"] == "/agent-mesh"
+
+    def test_default_is_an_empty_prefix(self):
+        component = self._component()
+        component.fastapi_root_path = ""
+
+        mock_config = self._start_server(component)
+
+        assert mock_config.call_args.kwargs["root_path"] == ""


### PR DESCRIPTION
## What

Lets an operator mount the Web UI gateway behind a reverse proxy at a sub-path (e.g. `https://myhost/agent-mesh/`) by exposing a `fastapi_root_path` app config, passed to uvicorn as `root_path`.

Addresses the backend half of #1486 (items 1 and 2 of the proposal there).

## How

- `gateway/http_sse/app.py`: new `fastapi_root_path` schema entry (optional, default `""`)
- `gateway/http_sse/component.py`: read the config and pass `root_path=self.fastapi_root_path` into `uvicorn.Config` — Starlette propagates the ASGI `root_path`, so redirects, `/docs`, `/openapi.json`, `request.base_url` and share-link URLs honor the prefix
- Config surfaces: `templates/webui.yaml`, `examples/gateways/webui_gateway_example.yaml` and `preset/env-template` gain `FASTAPI_ROOT_PATH` (unset resolves to `""`, so existing deployments are unaffected)

## Scope note

Item 3 of the issue (the SPA's hardcoded `/assets/...` base path) needs a frontend build change (`VITE` base or an injected `<base href>`), so it's deliberately left for a follow-up. With `root_path` in place the API and docs are fully functional behind the proxy, which also unblocks API-only deployments.

## Testing

- New `tests/unit/gateway/http_sse/test_fastapi_root_path.py`: schema default, component runtime fallback, and uvicorn kwargs for both a configured prefix and the default — mirrors the existing `test_uvicorn_config.py` / `test_sse_max_queue_size_defaults.py` patterns
- Full `tests/unit/gateway/http_sse` suite: 1353 passed, 23 skipped
- Ruff: zero new findings on touched files